### PR TITLE
Bug with runnig of SpiceOpus has been fixed

### DIFF
--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -61,7 +61,8 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
     bool found = findMathFuncInc(mathf_inc);
     stream<<QString("* Qucs %1 %2\n").arg(PACKAGE_VERSION).arg(Sch->DocName);
     // Let to simulate schematic without mathfunc.inc file
-    if (found) stream<<QString(".INCLUDE \"%1\"\n").arg(mathf_inc);
+    if (found && QucsSettings.DefaultSimulator != spicecompat::simSpiceOpus)
+        stream<<QString(".INCLUDE \"%1\"\n").arg(mathf_inc);
 
     QString s;
     if(!prepareSpiceNetlist(stream)) return; // Unable to perform spice simulation


### PR DESCRIPTION
There was a problem which stops Qucs-s from running SpiceOpus simulator. The reason was that SpiceOpus doesn't support .func directive, which uses in  ngspice_mathfunc.inc file. It's not possible to use that file with SpiceOpus, so ngspice_mathfunc.inc doesn't include in netlist if we use SpiceOpus as a default simulator. 