### PR TITLE
Added Field to Pass Parameters to Simulator

### DIFF
--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -1285,12 +1285,22 @@ QString AbstractSpiceKernel::getOutput()
 }
 
 /*!
- * \brief AbstractSpiceKernel::setSimulatorCmd Set simualtor executable location
+ * \brief AbstractSpiceKernel::setSimulatorCmd Set simulator executable location
  * \param cmd Simulator executable absolute path. For example /usr/bin/ngspice
  */
 void AbstractSpiceKernel::setSimulatorCmd(QString cmd)
 {
     simulator_cmd = cmd;
+}
+
+
+/*!
+ * \brief AbstractSpiceKernel::setSimulatorParameters Set simulator parameters
+ * \param cmd Simulator executable absolute path. For example -plugin lib/Xyce_ADMS_Plugin.so
+ */
+void AbstractSpiceKernel::setSimulatorParameters(QString parameters)
+{
+    simulator_parameters = parameters;
 }
 
 /*!

--- a/qucs/extsimkernels/abstractspicekernel.h
+++ b/qucs/extsimkernels/abstractspicekernel.h
@@ -100,6 +100,7 @@ public:
     QString getOutput();
 
     virtual void setSimulatorCmd(QString cmd);
+    virtual void setSimulatorParameters(QString parameters);
     void setWorkdir(QString path);
     virtual void SaveNetlist(QString filename);
     virtual bool waitEndOfSimulation();

--- a/qucs/extsimkernels/externsimdialog.cpp
+++ b/qucs/extsimkernels/externsimdialog.cpp
@@ -123,6 +123,7 @@ void ExternSimDialog::slotSetSimulator()
         connect(ngspice,SIGNAL(errors(QProcess::ProcessError)),this,SLOT(slotNgspiceStartError(QProcess::ProcessError)));
         connect(buttonSimulate,SIGNAL(clicked()),ngspice,SLOT(slotSimulate()));
         ngspice->setSimulatorCmd(QucsSettings.NgspiceExecutable);
+        ngspice->setSimulatorParameters(QucsSettings.SimParameters);
     }
         break;
     case spicecompat::simXyceSer: {
@@ -131,6 +132,7 @@ void ExternSimDialog::slotSetSimulator()
         connect(xyce,SIGNAL(finished()),this,SLOT(slotProcessOutput()));
         connect(xyce,SIGNAL(errors(QProcess::ProcessError)),this,SLOT(slotNgspiceStartError(QProcess::ProcessError)));
         connect(buttonSimulate,SIGNAL(clicked()),xyce,SLOT(slotSimulate()));
+        xyce->setSimulatorParameters(QucsSettings.SimParameters);
     }
         break;
     case spicecompat::simXycePar: {
@@ -143,6 +145,7 @@ void ExternSimDialog::slotSetSimulator()
         connect(xyce,SIGNAL(finished()),this,SLOT(slotProcessOutput()));
         connect(xyce,SIGNAL(errors(QProcess::ProcessError)),this,SLOT(slotNgspiceStartError(QProcess::ProcessError)));
         connect(buttonSimulate,SIGNAL(clicked()),xyce,SLOT(slotSimulate()));
+        xyce->setSimulatorParameters(QucsSettings.SimParameters);
     }
         break;
     case spicecompat::simSpiceOpus: {
@@ -152,6 +155,7 @@ void ExternSimDialog::slotSetSimulator()
         connect(ngspice,SIGNAL(errors(QProcess::ProcessError)),this,SLOT(slotNgspiceStartError(QProcess::ProcessError)),Qt::UniqueConnection);
         connect(buttonSimulate,SIGNAL(clicked()),ngspice,SLOT(slotSimulate()),Qt::UniqueConnection);
         ngspice->setSimulatorCmd(QucsSettings.SpiceOpusExecutable);
+        ngspice->setSimulatorParameters(QucsSettings.SimParameters);
     }
         break;
     default: break;

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -564,12 +564,16 @@ void Ngspice::setSimulatorCmd(QString cmd)
         env.remove("LANG");
         env.insert("LANG","en_US");
         SimProcess->setProcessEnvironment(env);
-        simulator_parameters="-c";
+        simulator_parameters = simulator_parameters + "-c";
     } else { // restore system environment
         QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
         SimProcess->setProcessEnvironment(env);
-        simulator_parameters="";
     }
 
     simulator_cmd = cmd;
+}
+
+void Ngspice::setSimulatorParameters(QString parameters)
+{
+    simulator_parameters = parameters;
 }

--- a/qucs/extsimkernels/ngspice.h
+++ b/qucs/extsimkernels/ngspice.h
@@ -46,6 +46,7 @@ public:
     explicit Ngspice(Schematic *sch_, QObject *parent = 0);
     void SaveNetlist(QString filename);
     void setSimulatorCmd(QString cmd);
+    void setSimulatorParameters(QString parameters);
     
 protected:
     void createNetlist(QTextStream &stream, int NumPorts, QStringList &simulations,

--- a/qucs/extsimkernels/simsettingsdialog.cpp
+++ b/qucs/extsimkernels/simsettingsdialog.cpp
@@ -34,6 +34,7 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     lblQucsator = new QLabel(tr("Qucsator executable location"));
     lblNprocs = new QLabel(tr("Number of processors in a system:"));
     lblWorkdir = new QLabel(tr("Directory to store netlist and simulator output"));
+    lblSimParam = new QLabel(tr("Extra simulator parameters"));
 
     cbxSimulator = new QComboBox(this);
     QStringList items;
@@ -52,6 +53,7 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     spbNprocs = new QSpinBox(1,256,1,this);
     spbNprocs->setValue(QucsSettings.NProcs);
     edtWorkdir = new QLineEdit(QucsSettings.S4Qworkdir);
+    edtSimParam = new QLineEdit(QucsSettings.SimParameters);
 
     btnOK = new QPushButton(tr("Apply changes"));
     connect(btnOK,SIGNAL(clicked()),this,SLOT(slotApply()));
@@ -117,6 +119,11 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     h6->addWidget(btnSetWorkdir,1);
     top2->addLayout(h6);
 
+    top2->addWidget(lblSimParam);
+    QHBoxLayout *h10 = new QHBoxLayout;
+    h10->addWidget(edtSimParam,4);
+    top2->addLayout(h10);
+
     gbp1->setLayout(top2);
     top->addWidget(gbp1);
 
@@ -162,6 +169,7 @@ void SimSettingsDialog::slotApply()
     QucsSettings.Qucsator = edtQucsator->text();
     QucsSettings.NProcs = spbNprocs->value();
     QucsSettings.S4Qworkdir = edtWorkdir->text();
+    QucsSettings.SimParameters = edtSimParam->text();
     if ((QucsSettings.DefaultSimulator != cbxSimulator->currentIndex())&&
         (QucsSettings.DefaultSimulator != spicecompat::simNotSpecified)) {
         QMessageBox::warning(this,tr("Simulator settings"),tr("Default simulator engine was changed!\n"

--- a/qucs/extsimkernels/simsettingsdialog.h
+++ b/qucs/extsimkernels/simsettingsdialog.h
@@ -34,6 +34,7 @@ private:
     QLabel *lblQucsator;
     QLabel *lblWorkdir;
     QLabel *lblSimulator;
+    QLabel *lblSimParam;
 
     QComboBox *cbxSimulator;
 
@@ -44,6 +45,7 @@ private:
     QLineEdit *edtQucsator;
     QSpinBox  *spbNprocs;
     QLineEdit *edtWorkdir;
+    QLineEdit *edtSimParam;
 
     QPushButton *btnOK;
     QPushButton *btnCancel;

--- a/qucs/extsimkernels/xyce.cpp
+++ b/qucs/extsimkernels/xyce.cpp
@@ -20,6 +20,7 @@
 #include "components/equation.h"
 #include "main.h"
 
+
 /*!
   \file xyce.cpp
   \brief Implementation of the Xyce class
@@ -392,9 +393,9 @@ void Xyce::setParallel(bool par)
         QString xyce_par = QucsSettings.XyceParExecutable;
         xyce_par.replace("%p",QString::number(QucsSettings.NProcs));
         simulator_cmd = xyce_par;
-        simulator_parameters = QString(" -a ");
+        simulator_parameters = simulator_parameters + QString(" -a ");
     } else {
         simulator_cmd = "\"" + QucsSettings.XyceExecutable + "\"";
-        simulator_parameters = "-a";
+        simulator_parameters = simulator_parameters + " -a ";
     }
 }

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -139,6 +139,8 @@ bool loadSettings()
     else QucsSettings.NProcs = 4;
     if(settings.contains("S4Q_workdir")) QucsSettings.S4Qworkdir = settings.value("S4Q_workdir").toString();
     else QucsSettings.S4Qworkdir = QDir::convertSeparators(QDir::homePath()+"/.qucs/spice4qucs");
+    if(settings.contains("SimParameters")) QucsSettings.SimParameters = settings.value("SimParameters").toString();
+    else QucsSettings.SimParameters = "";
     if(settings.contains("OctaveExecutable")) {
         QucsSettings.OctaveExecutable = settings.value("OctaveExecutable").toString();
     } else {
@@ -232,6 +234,7 @@ bool saveApplSettings()
     settings.setValue("Qucsator",QucsSettings.Qucsator);
     settings.setValue("Nprocs",QucsSettings.NProcs);
     settings.setValue("S4Q_workdir",QucsSettings.S4Qworkdir);
+    settings.setValue("SimParameters",QucsSettings.SimParameters);
     // settings.setValue("OctaveBinDir", QucsSettings.OctaveBinDir.canonicalPath());
     settings.setValue("OctaveExecutable",QucsSettings.OctaveExecutable);
     settings.setValue("QucsHomeDir", QucsSettings.QucsHomeDir.canonicalPath());

--- a/qucs/main.h
+++ b/qucs/main.h
@@ -74,6 +74,7 @@ struct tQucsSettings {
   QString XyceParExecutable;
   QString SpiceOpusExecutable;
   QString S4Qworkdir;
+  QString SimParameters;
   unsigned int NProcs; // Number of processors for Xyce
   QString OctaveExecutable; // OctaveExecutable location
   QString QucsOctave; // OUCS_OCTAVE variable

--- a/qucs/spicecomponents/symbols/CMakeLists.txt
+++ b/qucs/spicecomponents/symbols/CMakeLists.txt
@@ -2,6 +2,8 @@
 SET(SYMBOLS
 opamp5t.sym
 opamp3t.sym
+nmos4.sym
+pmos4.sym
 )
 
 # installation of transmission lines


### PR DESCRIPTION
1. I have added a field in the simulator setup dialog which allows a user to add extra arguments that will be passed to the simulator executable when the simulation is run.

    This is motivated by the need to add a link to a shared object when using custom verilog-a/ADMS blocks with Xyce. ie. `Xyce -plugin lib/Xyce_ADMS_Plugin.so circuit.cir`



2. Also, when I added the NMOS and PMOS symbols to the file component in a previous commit (#29) I forgot to add these to the CMakelist so they aren't installed correctly.  This is now fixed.
