### PR TITLE
guaranteed newlines

### DIFF
--- a/qucs/spicecomponents/C_SPICE.cpp
+++ b/qucs/spicecomponents/C_SPICE.cpp
@@ -93,11 +93,11 @@ QString C_SPICE::spice_netlist(bool)
     QString C_Line_4= Props.at(3)->Value;
     QString C_Line_5= Props.at(4)->Value;
 
-    if(  C.length()  > 0)          s += QString("%1\n").arg(C);
-    if(  C_Line_2.length() > 0 )   s += QString("%1\n").arg(C_Line_2);
-    if(  C_Line_3.length() > 0 )   s += QString("%1\n").arg(C_Line_3);
-    if(  C_Line_4.length() > 0 )   s += QString("%1\n").arg(C_Line_4);
-    if(  C_Line_5.length() > 0 )   s += QString("%1\n").arg(C_Line_5);
- 
+    if(  C.length()  > 0)          s += QString("%1").arg(C);
+    if(  C_Line_2.length() > 0 )   s += QString("\n%1").arg(C_Line_2);
+    if(  C_Line_3.length() > 0 )   s += QString("\n%1").arg(C_Line_3);
+    if(  C_Line_4.length() > 0 )   s += QString("\n%1").arg(C_Line_4);
+    if(  C_Line_5.length() > 0 )   s += QString("\n%1").arg(C_Line_5);
+    s += "\n";
     return s;
 }

--- a/qucs/spicecomponents/DIODE_SPICE.cpp
+++ b/qucs/spicecomponents/DIODE_SPICE.cpp
@@ -99,11 +99,11 @@ QString DIODE_SPICE::spice_netlist(bool)
     QString D_Line_4= Props.at(3)->Value;
     QString D_Line_5= Props.at(4)->Value;
 
-    if(  D.length()  > 0)          s += QString("%1\n").arg(D);
-    if(  D_Line_2.length() > 0 )   s += QString("%1\n").arg(D_Line_2);
-    if(  D_Line_3.length() > 0 )   s += QString("%1\n").arg(D_Line_3);
-    if(  D_Line_4.length() > 0 )   s += QString("%1\n").arg(D_Line_4);
-    if(  D_Line_5.length() > 0 )   s += QString("%1\n").arg(D_Line_5);
- 
+    if(  D.length()  > 0)          s += QString("%1").arg(D);
+    if(  D_Line_2.length() > 0 )   s += QString("\n%1").arg(D_Line_2);
+    if(  D_Line_3.length() > 0 )   s += QString("\n%1").arg(D_Line_3);
+    if(  D_Line_4.length() > 0 )   s += QString("\n%1").arg(D_Line_4);
+    if(  D_Line_5.length() > 0 )   s += QString("\n%1").arg(D_Line_5);
+    s += "\n";
     return s;
 }

--- a/qucs/spicecomponents/Icouple.cpp
+++ b/qucs/spicecomponents/Icouple.cpp
@@ -113,8 +113,9 @@ QString Icouple::spice_netlist(bool)
     
     QString A= Props.at(0)->Value;
     QString A_Line_2= Props.at(1)->Value;
-    if(  A.length()        > 0)    s += QString("%1\n").arg(A);
-    if(  A_Line_2.length() > 0 )   s += QString("%1\n").arg(A_Line_2);
-  
+    if(  A.length()        > 0)    s += QString("%1").arg(A);
+    if(  A_Line_2.length() > 0 )   s += QString("\n%1").arg(A_Line_2);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/LTRA_SPICE.cpp
+++ b/qucs/spicecomponents/LTRA_SPICE.cpp
@@ -109,11 +109,12 @@ QString LTRA_SPICE::spice_netlist(bool)
     QString O_Line_4= Props.at(3)->Value;
     QString O_Line_5= Props.at(4)->Value;
 
-    if(  O.length()  > 0)          s += QString("%1\n").arg(O);
-    if(  O_Line_2.length() > 0 )   s += QString("%1\n").arg(O_Line_2);
-    if(  O_Line_3.length() > 0 )   s += QString("%1\n").arg(O_Line_3);
-    if(  O_Line_4.length() > 0 )   s += QString("%1\n").arg(O_Line_4);
-    if(  O_Line_5.length() >  0 )  s += QString("%1\n").arg(O_Line_5);
- 
+    if(  O.length()  > 0)          s += QString("%1").arg(O);
+    if(  O_Line_2.length() > 0 )   s += QString("\n%1").arg(O_Line_2);
+    if(  O_Line_3.length() > 0 )   s += QString("\n%1").arg(O_Line_3);
+    if(  O_Line_4.length() > 0 )   s += QString("\n%1").arg(O_Line_4);
+    if(  O_Line_5.length() >  0 )  s += QString("\n%1").arg(O_Line_5);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/L_SPICE.cpp
+++ b/qucs/spicecomponents/L_SPICE.cpp
@@ -98,11 +98,12 @@ QString L_SPICE::spice_netlist(bool)
     QString L_Line_4= Props.at(3)->Value;
     QString L_Line_5= Props.at(4)->Value;
 
-    if(  L.length()  > 0)          s += QString("%1\n").arg(L);
-    if(  L_Line_2.length() > 0 )   s += QString("%1\n").arg(L_Line_2);
-    if(  L_Line_3.length() > 0 )   s += QString("%1\n").arg(L_Line_3);
-    if(  L_Line_4.length() > 0 )   s += QString("%1\n").arg(L_Line_4);
-    if( L_Line_5.length() >  0 )   s += QString("%1\n").arg(L_Line_5);
- 
+    if(  L.length()  > 0)          s += QString("%1").arg(L);
+    if(  L_Line_2.length() > 0 )   s += QString("\n%1").arg(L_Line_2);
+    if(  L_Line_3.length() > 0 )   s += QString("\n%1").arg(L_Line_3);
+    if(  L_Line_4.length() > 0 )   s += QString("\n%1").arg(L_Line_4);
+    if( L_Line_5.length() >  0 )   s += QString("\n%1").arg(L_Line_5);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/MESFET_SPICE.cpp
+++ b/qucs/spicecomponents/MESFET_SPICE.cpp
@@ -101,11 +101,12 @@ QString MESFET_SPICE::spice_netlist(bool)
     QString Z_Line_4= Props.at(3)->Value;
     QString Z_Line_5= Props.at(4)->Value;
 
-    if(  Z.length()  > 0)          s += QString("%1\n").arg(Z);
-    if(  Z_Line_2.length() > 0 )   s += QString("%1\n").arg(Z_Line_2);
-    if(  Z_Line_3.length() > 0 )   s += QString("%1\n").arg(Z_Line_3);
-    if(  Z_Line_4.length() > 0 )   s += QString("%1\n").arg(Z_Line_4);
-    if(  Z_Line_5.length() >  0 )  s += QString("%1\n").arg(Z_Line_5);
- 
+    if(  Z.length()  > 0)          s += QString("%1").arg(Z);
+    if(  Z_Line_2.length() > 0 )   s += QString("\n%1").arg(Z_Line_2);
+    if(  Z_Line_3.length() > 0 )   s += QString("\n%1").arg(Z_Line_3);
+    if(  Z_Line_4.length() > 0 )   s += QString("\n%1").arg(Z_Line_4);
+    if(  Z_Line_5.length() >  0 )  s += QString("\n%1").arg(Z_Line_5);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/NJF_SPICE.cpp
+++ b/qucs/spicecomponents/NJF_SPICE.cpp
@@ -105,11 +105,12 @@ QString NJF_SPICE::spice_netlist(bool)
     QString J_Line_4= Props.at(3)->Value;
     QString J_Line_5= Props.at(4)->Value;
 
-    if(  J.length()  > 0)          s += QString("%1\n").arg(J);
-    if(  J_Line_2.length() > 0 )   s += QString("%1\n").arg(J_Line_2);
-    if(  J_Line_3.length() > 0 )   s += QString("%1\n").arg(J_Line_3);
-    if(  J_Line_4.length() > 0 )   s += QString("%1\n").arg(J_Line_4);
-    if(  J_Line_5.length() > 0 )   s += QString("%1\n").arg(J_Line_5);
- 
+    if(  J.length()  > 0)          s += QString("%1").arg(J);
+    if(  J_Line_2.length() > 0 )   s += QString("\n%1").arg(J_Line_2);
+    if(  J_Line_3.length() > 0 )   s += QString("\n%1").arg(J_Line_3);
+    if(  J_Line_4.length() > 0 )   s += QString("\n%1").arg(J_Line_4);
+    if(  J_Line_5.length() > 0 )   s += QString("\n%1").arg(J_Line_5);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/NMOS_SPICE.cpp
+++ b/qucs/spicecomponents/NMOS_SPICE.cpp
@@ -116,11 +116,12 @@ QString NMOS_SPICE::spice_netlist(bool)
     QString M_Line_4= Props.at(3)->Value;
     QString M_Line_5= Props.at(4)->Value;
 
-    if(  M.length()  > 0)          s += QString("%1\n").arg(M);
-    if(  M_Line_2.length() > 0 )   s += QString("%1\n").arg(M_Line_2);
-    if(  M_Line_3.length() > 0 )   s += QString("%1\n").arg(M_Line_3);
-    if(  M_Line_4.length() > 0 )   s += QString("%1\n").arg(M_Line_4);
-    if(  M_Line_5.length() > 0 )   s += QString("%1\n").arg(M_Line_5);
- 
+    if(  M.length()  > 0)          s += QString("%1").arg(M);
+    if(  M_Line_2.length() > 0 )   s += QString("\n%1").arg(M_Line_2);
+    if(  M_Line_3.length() > 0 )   s += QString("\n%1").arg(M_Line_3);
+    if(  M_Line_4.length() > 0 )   s += QString("\n%1").arg(M_Line_4);
+    if(  M_Line_5.length() > 0 )   s += QString("\n%1").arg(M_Line_5);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/NPN_SPICE.cpp
+++ b/qucs/spicecomponents/NPN_SPICE.cpp
@@ -109,11 +109,12 @@ QString NPN_SPICE::spice_netlist(bool)
     QString Q_Line_4= Props.at(3)->Value;
     QString Q_Line_5= Props.at(4)->Value;
 
-    if(  Q.length()  > 0)          s += QString("%1\n").arg(Q);
-    if(  Q_Line_2.length() > 0 )   s += QString("%1\n").arg(Q_Line_2);
-    if(  Q_Line_3.length() > 0 )   s += QString("%1\n").arg(Q_Line_3);
-    if(  Q_Line_4.length() > 0 )   s += QString("%1\n").arg(Q_Line_4);
-    if(  Q_Line_5.length() > 0 )   s += QString("%1\n").arg(Q_Line_5);
- 
+    if(  Q.length()  > 0)          s += QString("%1").arg(Q);
+    if(  Q_Line_2.length() > 0 )   s += QString("\n%1").arg(Q_Line_2);
+    if(  Q_Line_3.length() > 0 )   s += QString("\n%1").arg(Q_Line_3);
+    if(  Q_Line_4.length() > 0 )   s += QString("\n%1").arg(Q_Line_4);
+    if(  Q_Line_5.length() > 0 )   s += QString("\n%1").arg(Q_Line_5);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/PJF_SPICE.cpp
+++ b/qucs/spicecomponents/PJF_SPICE.cpp
@@ -105,11 +105,12 @@ QString PJF_SPICE::spice_netlist(bool)
     QString J_Line_4= Props.at(3)->Value;
     QString J_Line_5= Props.at(4)->Value;
 
-    if(  J.length()  > 0)          s += QString("%1\n").arg(J);
-    if(  J_Line_2.length() > 0 )   s += QString("%1\n").arg(J_Line_2);
-    if(  J_Line_3.length() > 0 )   s += QString("%1\n").arg(J_Line_3);
-    if(  J_Line_4.length() > 0 )   s += QString("%1\n").arg(J_Line_4);
-    if(  J_Line_5.length() > 0 )   s += QString("%1\n").arg(J_Line_5);
- 
+    if(  J.length()  > 0)          s += QString("%1").arg(J);
+    if(  J_Line_2.length() > 0 )   s += QString("\n%1").arg(J_Line_2);
+    if(  J_Line_3.length() > 0 )   s += QString("\n%1").arg(J_Line_3);
+    if(  J_Line_4.length() > 0 )   s += QString("\n%1").arg(J_Line_4);
+    if(  J_Line_5.length() > 0 )   s += QString("\n%1").arg(J_Line_5);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/PMF_MESFET_SPICE.cpp
+++ b/qucs/spicecomponents/PMF_MESFET_SPICE.cpp
@@ -100,11 +100,12 @@ QString PMF_MESFET_SPICE::spice_netlist(bool)
     QString Z_Line_4= Props.at(3)->Value;
     QString Z_Line_5= Props.at(4)->Value;
 
-    if(  Z.length()  > 0)          s += QString("%1\n").arg(Z);
-    if(  Z_Line_2.length() > 0 )   s += QString("%1\n").arg(Z_Line_2);
-    if(  Z_Line_3.length() > 0 )   s += QString("%1\n").arg(Z_Line_3);
-    if(  Z_Line_4.length() > 0 )   s += QString("%1\n").arg(Z_Line_4);
-    if(  Z_Line_5.length() >  0 )  s += QString("%1\n").arg(Z_Line_5);
- 
+    if(  Z.length()  > 0)          s += QString("%1").arg(Z);
+    if(  Z_Line_2.length() > 0 )   s += QString("\n%1").arg(Z_Line_2);
+    if(  Z_Line_3.length() > 0 )   s += QString("\n%1").arg(Z_Line_3);
+    if(  Z_Line_4.length() > 0 )   s += QString("\n%1").arg(Z_Line_4);
+    if(  Z_Line_5.length() >  0 )  s += QString("\n%1").arg(Z_Line_5);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/PMOS_SPICE.cpp
+++ b/qucs/spicecomponents/PMOS_SPICE.cpp
@@ -116,11 +116,12 @@ QString PMOS_SPICE::spice_netlist(bool)
     QString M_Line_4= Props.at(3)->Value;
     QString M_Line_5= Props.at(4)->Value;
 
-    if(  M.length()  > 0)          s += QString("%1\n").arg(M);
-    if(  M_Line_2.length() > 0 )   s += QString("%1\n").arg(M_Line_2);
-    if(  M_Line_3.length() > 0 )   s += QString("%1\n").arg(M_Line_3);
-    if(  M_Line_4.length() > 0 )   s += QString("%1\n").arg(M_Line_4);
-    if(  M_Line_5.length() > 0 )   s += QString("%1\n").arg(M_Line_5);
- 
+    if(  M.length()  > 0)          s += QString("%1").arg(M);
+    if(  M_Line_2.length() > 0 )   s += QString("\n%1").arg(M_Line_2);
+    if(  M_Line_3.length() > 0 )   s += QString("\n%1").arg(M_Line_3);
+    if(  M_Line_4.length() > 0 )   s += QString("\n%1").arg(M_Line_4);
+    if(  M_Line_5.length() > 0 )   s += QString("\n%1").arg(M_Line_5);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/PNP_SPICE.cpp
+++ b/qucs/spicecomponents/PNP_SPICE.cpp
@@ -110,11 +110,12 @@ QString PNP_SPICE::spice_netlist(bool)
     QString Q_Line_4= Props.at(3)->Value;
     QString Q_Line_5= Props.at(4)->Value;
 
-    if(  Q.length()  > 0)          s += QString("%1\n").arg(Q);
-    if(  Q_Line_2.length() > 0 )   s += QString("%1\n").arg(Q_Line_2);
-    if(  Q_Line_3.length() > 0 )   s += QString("%1\n").arg(Q_Line_3);
-    if(  Q_Line_4.length() > 0 )   s += QString("%1\n").arg(Q_Line_4);
-    if(  Q_Line_5.length() > 0 )   s += QString("%1\n").arg(Q_Line_5);
- 
+    if(  Q.length()  > 0)          s += QString("%1").arg(Q);
+    if(  Q_Line_2.length() > 0 )   s += QString("/n%1").arg(Q_Line_2);
+    if(  Q_Line_3.length() > 0 )   s += QString("/n%1").arg(Q_Line_3);
+    if(  Q_Line_4.length() > 0 )   s += QString("/n%1").arg(Q_Line_4);
+    if(  Q_Line_5.length() > 0 )   s += QString("/n%1").arg(Q_Line_5);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/R_SPICE.cpp
+++ b/qucs/spicecomponents/R_SPICE.cpp
@@ -97,11 +97,12 @@ QString R_SPICE::spice_netlist(bool)
     QString R_Line_4= Props.at(3)->Value;
     QString R_Line_5= Props.at(4)->Value;
 
-    if(  R.length()  > 0)          s += QString("%1\n").arg(R);
-    if(  R_Line_2.length() > 0 )   s += QString("%1\n").arg(R_Line_2);
-    if(  R_Line_3.length() > 0 )   s += QString("%1\n").arg(R_Line_3);
-    if(  R_Line_4.length() > 0 )   s += QString("%1\n").arg(R_Line_4);
-    if(  R_Line_5.length() > 0)    s += QString("%1\n").arg(R_Line_5);
- 
+    if(  R.length()  > 0)          s += QString("%1").arg(R);
+    if(  R_Line_2.length() > 0 )   s += QString("/n%1").arg(R_Line_2);
+    if(  R_Line_3.length() > 0 )   s += QString("/n%1").arg(R_Line_3);
+    if(  R_Line_4.length() > 0 )   s += QString("/n%1").arg(R_Line_4);
+    if(  R_Line_5.length() > 0)    s += QString("/n%1").arg(R_Line_5);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/S4Q_I.cpp
+++ b/qucs/spicecomponents/S4Q_I.cpp
@@ -91,10 +91,12 @@ QString S4Q_I::spice_netlist(bool)
     QString l3= Props.at(3)->Value;
     QString l4= Props.at(4)->Value;
 
-    if(l0.length()> 0)   s += QString("%1\n").arg(l0);
-    if(l1.length()> 0)   s += QString("%1\n").arg(l1);
-    if(l2.length()> 0)   s += QString("%1\n").arg(l2);
-    if(l3.length()> 0)   s += QString("%1\n").arg(l3);
-    if(l4.length()> 0)   s += QString("%1\n").arg(l4);
+    if(l0.length()> 0)   s += QString("%1").arg(l0);
+    if(l1.length()> 0)   s += QString("\n%1").arg(l1);
+    if(l2.length()> 0)   s += QString("\n%1").arg(l2);
+    if(l3.length()> 0)   s += QString("\n%1").arg(l3);
+    if(l4.length()> 0)   s += QString("\n%1").arg(l4);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/S4Q_Ieqndef.cpp
+++ b/qucs/spicecomponents/S4Q_Ieqndef.cpp
@@ -103,11 +103,12 @@ QString S4Q_Ieqndef::spice_netlist(bool)
     QString Line_5 = Props.at(4)->Value;
 
     s += QString(" %1 = %2 \n").arg(VI).arg(VI2);
-    if(  Line_2.length() > 0 )   s += QString("%1\n").arg(Line_2);
-    if(  Line_3.length() > 0 )   s += QString("%1\n").arg(Line_3);
-    if(  Line_4.length() > 0 )   s += QString("%1\n").arg(Line_4);
-    if(  Line_5.length() > 0 )   s += QString("%1\n").arg(Line_5);
- 
+    if(  Line_2.length() > 0 )   s += QString("%1").arg(Line_2);
+    if(  Line_3.length() > 0 )   s += QString("\n%1").arg(Line_3);
+    if(  Line_4.length() > 0 )   s += QString("\n%1").arg(Line_4);
+    if(  Line_5.length() > 0 )   s += QString("\n%1").arg(Line_5);
+    s += "\n";
+
     return s;
 }
 

--- a/qucs/spicecomponents/S4Q_S.cpp
+++ b/qucs/spicecomponents/S4Q_S.cpp
@@ -108,11 +108,12 @@ QString S4Q_S::spice_netlist(bool)
     QString S_Line_4= Props.at(3)->Value;
     QString S_Line_5= Props.at(4)->Value;
 
-    if(  S.length()  > 0)          s += QString("%1\n").arg(S);
-    if(  S_Line_2.length() > 0 )   s += QString("%1\n").arg(S_Line_2);
-    if(  S_Line_3.length() > 0 )   s += QString("%1\n").arg(S_Line_3);
-    if(  S_Line_4.length() > 0 )   s += QString("%1\n").arg(S_Line_4);
-    if(  S_Line_5.length() > 0)    s += QString("%1\n").arg(S_Line_5);
- 
+    if(  S.length()  > 0)          s += QString("%1").arg(S);
+    if(  S_Line_2.length() > 0 )   s += QString("\n%1").arg(S_Line_2);
+    if(  S_Line_3.length() > 0 )   s += QString("\n%1").arg(S_Line_3);
+    if(  S_Line_4.length() > 0 )   s += QString("\n%1").arg(S_Line_4);
+    if(  S_Line_5.length() > 0)    s += QString("\n%1").arg(S_Line_5);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/S4Q_V.cpp
+++ b/qucs/spicecomponents/S4Q_V.cpp
@@ -92,10 +92,12 @@ QString S4Q_V::spice_netlist(bool)
     QString l3= Props.at(3)->Value;
     QString l4= Props.at(4)->Value;
 
-    if(l0.length()> 0)   s += QString("%1\n").arg(l0);
-    if(l1.length()> 0)   s += QString("%1\n").arg(l1);
-    if(l2.length()> 0)   s += QString("%1\n").arg(l2);
-    if(l3.length()> 0)   s += QString("%1\n").arg(l3);
-    if(l4.length()> 0)   s += QString("%1\n").arg(l4);
+    if(l0.length()> 0)   s += QString("%1").arg(l0);
+    if(l1.length()> 0)   s += QString("\n%1").arg(l1);
+    if(l2.length()> 0)   s += QString("\n%1").arg(l2);
+    if(l3.length()> 0)   s += QString("\n%1").arg(l3);
+    if(l4.length()> 0)   s += QString("\n%1").arg(l4);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/S4Q_W.cpp
+++ b/qucs/spicecomponents/S4Q_W.cpp
@@ -96,11 +96,12 @@ QString S4Q_W::spice_netlist(bool)
     QString W_Line_4= Props.at(3)->Value;
     QString W_Line_5= Props.at(4)->Value;
 
-    if(  W.length()  > 0)          s += QString("%1\n").arg(W);
-    if(  W_Line_2.length() > 0 )   s += QString("%1\n").arg(W_Line_2);
-    if(  W_Line_3.length() > 0 )   s += QString("%1\n").arg(W_Line_3);
-    if(  W_Line_4.length() > 0 )   s += QString("%1\n").arg(W_Line_4);
-    if(  W_Line_5.length() > 0)    s += QString("%1\n").arg(W_Line_5);
- 
+    if(  W.length()  > 0)          s += QString("%1").arg(W);
+    if(  W_Line_2.length() > 0 )   s += QString("\n%1").arg(W_Line_2);
+    if(  W_Line_3.length() > 0 )   s += QString("\n%1").arg(W_Line_3);
+    if(  W_Line_4.length() > 0 )   s += QString("\n%1").arg(W_Line_4);
+    if(  W_Line_5.length() > 0)    s += QString("\n%1").arg(W_Line_5);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/SDTF.cpp
+++ b/qucs/spicecomponents/SDTF.cpp
@@ -101,12 +101,13 @@ QString SDTF::spice_netlist(bool)
     QString A_Line_6 = Props.at(5)->Value;
     QString A_Line_7 = Props.at(6)->Value;   
      
-    if(  A.length()        > 0)    s += QString("%1\n").arg(A);
-    if(  A_Line_2.length() > 0 )   s += QString("%1\n").arg(A_Line_2);
-    if(  A_Line_3.length() > 0 )   s += QString("%1\n").arg(A_Line_3);   
-    if(  A_Line_4.length() > 0 )   s += QString("%1\n").arg(A_Line_4); 
-    if(  A_Line_5.length() > 0 )   s += QString("%1\n").arg(A_Line_5);
-    if(  A_Line_6.length() > 0 )   s += QString("%1\n").arg(A_Line_6);
-    if(  A_Line_7.length() > 0 )   s += QString("%1\n").arg(A_Line_7);   
+    if(  A.length()        > 0)    s += QString("%1").arg(A);
+    if(  A_Line_2.length() > 0 )   s += QString("\n%1").arg(A_Line_2);
+    if(  A_Line_3.length() > 0 )   s += QString("\n%1").arg(A_Line_3);
+    if(  A_Line_4.length() > 0 )   s += QString("\n%1").arg(A_Line_4);
+    if(  A_Line_5.length() > 0 )   s += QString("\n%1").arg(A_Line_5);
+    if(  A_Line_6.length() > 0 )   s += QString("\n%1").arg(A_Line_6);
+    if(  A_Line_7.length() > 0 )   s += QString("\n%1").arg(A_Line_7);
+    s += "\n";
     return s;
 }

--- a/qucs/spicecomponents/UDRCTL_SPICE.cpp
+++ b/qucs/spicecomponents/UDRCTL_SPICE.cpp
@@ -107,11 +107,12 @@ QString UDRCTL_SPICE::spice_netlist(bool)
     QString U_Line_4= Props.at(3)->Value;
     QString U_Line_5= Props.at(4)->Value;
 
-    if(  U.length()  > 0)          s += QString("%1\n").arg(U);
-    if(  U_Line_2.length() > 0 )   s += QString("%1\n").arg(U_Line_2);
-    if(  U_Line_3.length() > 0 )   s += QString("%1\n").arg(U_Line_3);
-    if(  U_Line_4.length() > 0 )   s += QString("%1\n").arg(U_Line_4);
-    if(  U_Line_5.length() > 0 )   s += QString("%1\n").arg(U_Line_5);
- 
+    if(  U.length()  > 0)          s += QString("%1").arg(U);
+    if(  U_Line_2.length() > 0 )   s += QString("\n%1").arg(U_Line_2);
+    if(  U_Line_3.length() > 0 )   s += QString("\n%1").arg(U_Line_3);
+    if(  U_Line_4.length() > 0 )   s += QString("\n%1").arg(U_Line_4);
+    if(  U_Line_5.length() > 0 )   s += QString("\n%1").arg(U_Line_5);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/XAPWL.cpp
+++ b/qucs/spicecomponents/XAPWL.cpp
@@ -101,12 +101,14 @@ QString XAPWL::spice_netlist(bool)
     QString A_Line_6 = Props.at(5)->Value;
     QString A_Line_7 = Props.at(6)->Value;   
      
-    if(  A.length()        > 0)    s += QString("%1\n").arg(A);
-    if(  A_Line_2.length() > 0 )   s += QString("%1\n").arg(A_Line_2);
-    if(  A_Line_3.length() > 0 )   s += QString("%1\n").arg(A_Line_3);   
-    if(  A_Line_4.length() > 0 )   s += QString("%1\n").arg(A_Line_4); 
-    if(  A_Line_5.length() > 0 )   s += QString("%1\n").arg(A_Line_5);
-    if(  A_Line_6.length() > 0 )   s += QString("%1\n").arg(A_Line_6);
-    if(  A_Line_7.length() > 0 )   s += QString("%1\n").arg(A_Line_7);   
+    if(  A.length()        > 0)    s += QString("%1").arg(A);
+    if(  A_Line_2.length() > 0 )   s += QString("\n%1").arg(A_Line_2);
+    if(  A_Line_3.length() > 0 )   s += QString("\n%1").arg(A_Line_3);
+    if(  A_Line_4.length() > 0 )   s += QString("\n%1").arg(A_Line_4);
+    if(  A_Line_5.length() > 0 )   s += QString("\n%1").arg(A_Line_5);
+    if(  A_Line_6.length() > 0 )   s += QString("\n%1").arg(A_Line_6);
+    if(  A_Line_7.length() > 0 )   s += QString("\n%1").arg(A_Line_7);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/eNL.cpp
+++ b/qucs/spicecomponents/eNL.cpp
@@ -94,11 +94,11 @@ QString eNL::spice_netlist(bool)
     QString Line_5 = Props.at(4)->Value;
  
     
-    if(  E.length()  > 0)        s += QString("%1\n").arg(E);
-    if(  Line_2.length() > 0 )   s += QString("%1\n").arg(Line_2);
-    if(  Line_3.length() > 0 )   s += QString("%1\n").arg(Line_3);
-    if(  Line_4.length() > 0 )   s += QString("%1\n").arg(Line_4);
-    if(  Line_5.length() > 0 )   s += QString("%1\n").arg(Line_5);
- 
+    if(  E.length()  > 0)        s += QString("%1").arg(E);
+    if(  Line_2.length() > 0 )   s += QString("\n%1").arg(Line_2);
+    if(  Line_3.length() > 0 )   s += QString("\n%1").arg(Line_3);
+    if(  Line_4.length() > 0 )   s += QString("\n%1").arg(Line_4);
+    if(  Line_5.length() > 0 )   s += QString("\n%1").arg(Line_5);
+    s += "\n";
     return s;
 }

--- a/qucs/spicecomponents/gNL.cpp
+++ b/qucs/spicecomponents/gNL.cpp
@@ -94,11 +94,12 @@ QString gNL::spice_netlist(bool)
     QString Line_5 = Props.at(4)->Value;
  
     
-    if(  G.length()      > 0 )   s += QString("%1\n").arg(G);
-    if(  Line_2.length() > 0 )   s += QString("%1\n").arg(Line_2);
-    if(  Line_3.length() > 0 )   s += QString("%1\n").arg(Line_3);
-    if(  Line_4.length() > 0 )   s += QString("%1\n").arg(Line_4);
-    if(  Line_5.length() > 0 )   s += QString("%1\n").arg(Line_5);
-    
+    if(  G.length()      > 0 )   s += QString("%1").arg(G);
+    if(  Line_2.length() > 0 )   s += QString("\n%1").arg(Line_2);
+    if(  Line_3.length() > 0 )   s += QString("\n%1").arg(Line_3);
+    if(  Line_4.length() > 0 )   s += QString("\n%1").arg(Line_4);
+    if(  Line_5.length() > 0 )   s += QString("\n%1").arg(Line_5);
+    s += "\n";
+
      return s;
 }

--- a/qucs/spicecomponents/iPWL.cpp
+++ b/qucs/spicecomponents/iPWL.cpp
@@ -111,16 +111,17 @@ QString Line_10= Props.at(9)->Value;
 
     s += QString("");
  
-    if(  PWL.length()    > 0)    s += QString("%1\n").arg(PWL);
-    if(  Line_2.length() > 0 )   s += QString("%1\n").arg(Line_2);
-    if(  Line_3.length() > 0 )   s += QString("%1\n").arg(Line_3);
-    if(  Line_4.length() > 0 )   s += QString("%1\n").arg(Line_4);
-    if(  Line_5.length() > 0 )   s += QString("%1\n").arg(Line_5);
-    if(  Line_6.length() > 0 )   s += QString("%1\n").arg(Line_6);
-    if(  Line_7.length() > 0 )   s += QString("%1\n").arg(Line_7);
-    if(  Line_8.length() > 0)    s += QString("%1\n").arg(Line_8);
-    if(  Line_9.length() > 0 )   s += QString("%1\n").arg(Line_9);
-    if(  Line_10.length() > 0 )  s += QString("%1\n").arg(Line_10);
-    
+    if(  PWL.length()    > 0)    s += QString("%1").arg(PWL);
+    if(  Line_2.length() > 0 )   s += QString("\n%1").arg(Line_2);
+    if(  Line_3.length() > 0 )   s += QString("\n%1").arg(Line_3);
+    if(  Line_4.length() > 0 )   s += QString("\n%1").arg(Line_4);
+    if(  Line_5.length() > 0 )   s += QString("\n%1").arg(Line_5);
+    if(  Line_6.length() > 0 )   s += QString("\n%1").arg(Line_6);
+    if(  Line_7.length() > 0 )   s += QString("\n%1").arg(Line_7);
+    if(  Line_8.length() > 0)    s += QString("\n%1").arg(Line_8);
+    if(  Line_9.length() > 0 )   s += QString("\n%1").arg(Line_9);
+    if(  Line_10.length() > 0 )  s += QString("\n%1").arg(Line_10);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/src_eqndef.cpp
+++ b/qucs/spicecomponents/src_eqndef.cpp
@@ -80,12 +80,13 @@ QString Src_eqndef::spice_netlist(bool)
     QString Line_4 = Props.at(3)->Value;
     QString Line_5 = Props.at(4)->Value;
 
-    s += QString(" %1 = %2 \n").arg(VI).arg(VI2);
-    if(  Line_2.length() > 0 )   s += QString("%1\n").arg(Line_2);
-    if(  Line_3.length() > 0 )   s += QString("%1\n").arg(Line_3);
-    if(  Line_4.length() > 0 )   s += QString("%1\n").arg(Line_4);
-    if(  Line_5.length() > 0 )   s += QString("%1\n").arg(Line_5);
- 
+    s += QString(" %1 = %2 ").arg(VI).arg(VI2);
+    if(  Line_2.length() > 0 )   s += QString("\n%1").arg(Line_2);
+    if(  Line_3.length() > 0 )   s += QString("\n%1").arg(Line_3);
+    if(  Line_4.length() > 0 )   s += QString("\n%1").arg(Line_4);
+    if(  Line_5.length() > 0 )   s += QString("\n%1").arg(Line_5);
+    s += "\n";
+
     return s;
 }
 

--- a/qucs/spicecomponents/vPWL.cpp
+++ b/qucs/spicecomponents/vPWL.cpp
@@ -109,15 +109,17 @@ QString Line_10= Props.at(9)->Value;
 
     s += QString("");
   
-    if(  PWL.length()  > 0)        s += QString("%1\n").arg(PWL);
-    if(  Line_2.length() > 0 )     s += QString("%1\n").arg(Line_2);
-    if(  Line_3.length() > 0 )     s += QString("%1\n").arg(Line_3);
-    if(  Line_4.length() > 0 )     s += QString("%1\n").arg(Line_4);
-    if(  Line_5.length() > 0 )     s += QString("%1\n").arg(Line_5);
-    if(  Line_6.length() > 0 )     s += QString("%1\n").arg(Line_6);
-    if(  Line_7.length() > 0 )     s += QString("%1\n").arg(Line_7);
-    if(  Line_8.length() > 0)      s += QString("%1\n").arg(Line_8);
-    if(  Line_9.length() > 0 )     s += QString("%1\n").arg(Line_9);
-    if(  Line_10.length() > 0 )    s += QString("%1\n").arg(Line_10);
+    if(  PWL.length()  > 0)        s += QString("%1").arg(PWL);
+    if(  Line_2.length() > 0 )     s += QString("\n%1").arg(Line_2);
+    if(  Line_3.length() > 0 )     s += QString("\n%1").arg(Line_3);
+    if(  Line_4.length() > 0 )     s += QString("\n%1").arg(Line_4);
+    if(  Line_5.length() > 0 )     s += QString("\n%1").arg(Line_5);
+    if(  Line_6.length() > 0 )     s += QString("\n%1").arg(Line_6);
+    if(  Line_7.length() > 0 )     s += QString("\n%1").arg(Line_7);
+    if(  Line_8.length() > 0)      s += QString("\n%1").arg(Line_8);
+    if(  Line_9.length() > 0 )     s += QString("\n%1").arg(Line_9);
+    if(  Line_10.length() > 0 )    s += QString("\n%1").arg(Line_10);
+    s += "\n";
+
     return s;
 }

--- a/qucs/spicecomponents/volt_ac_SPICE.cpp
+++ b/qucs/spicecomponents/volt_ac_SPICE.cpp
@@ -88,10 +88,12 @@ QString Vac_SPICE::spice_netlist(bool)
     QString l3= Props.at(3)->Value;
     QString l4= Props.at(4)->Value;
 
-    if(l0.length()> 0)   s += QString("%1\n").arg(l0);
-    if(l1.length()> 0)   s += QString("%1\n").arg(l1);
-    if(l2.length()> 0)   s += QString("%1\n").arg(l2);
-    if(l3.length()> 0)   s += QString("%1\n").arg(l3);
-    if(l4.length()> 0)   s += QString("%1\n").arg(l4);
+    if(l0.length()> 0)   s += QString("%1").arg(l0);
+    if(l1.length()> 0)   s += QString("\n%1").arg(l1);
+    if(l2.length()> 0)   s += QString("\n%1").arg(l2);
+    if(l3.length()> 0)   s += QString("\n%1").arg(l3);
+    if(l4.length()> 0)   s += QString("\n%1").arg(l4);
+    s += "\n";
+
     return s;
 }


### PR DESCRIPTION
guaranteeing newlines get printed per-component.  It would seem to me that the loop iterating over components would be a better place for the newline following each component, but I guess that's a design choice already made, so I kept to your convention.