### PR TITLE
Update ngspice.cpp because of rare error

### DIFF
--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -554,6 +554,12 @@ void Ngspice::SaveNetlist(QString filename)
         createNetlist(stream,num,sims,vars,output_files);
         spice_file.close();
     }
+    else
+    {
+        QString msg=QString("Tried to save netlist \nin %1\n(could not open for writing!)").arg(filename);
+        QString final_msg=QString("%1\n This could be an error in the QSettings settings file\n(usually in ~/.config/qucs/qucs_s.conf)\nThe value for S4Q_workdir (default:/spice4qucs) needs to be writeable!\nFor a Simulation Simulation will raise error! (most likely S4Q_workdir does not exists)").arg(msg);
+        QMessageBox::critical(nullptr,tr("Problem with SaveNetlist"),final_msg,QMessageBox::Ok);
+    }
 }
 
 void Ngspice::setSimulatorCmd(QString cmd)


### PR DESCRIPTION
On rare instances it can happen that the S4Q_workdir variable is not set correctly (set to the default as /spice4qucs) after compiling from source and this gives a cryptic error message when starting a ngspice simulation ("Error:Failed to Start")
The error is because qucs-s tries to open/write to the file /spice4qucs/spice4qucs.cir which is a) typically under the root domain and b) usually doesnt exists
This error can be solved by changing S4Q_workdir which is used to create the temporal netlist for simulations to a writeable folder (usually it is ~/.qucs/spice4qucs/)
So technically nothing needs to be changed in the code but there is no error message when saving the netlist so I added one with a small help message.
I havent seen a way to edit S4Q_workdir in the application itself so maybe it might be useful to add an option there.
I think this change is useful because the error is rare and hard to track, so a little help with a more detailed error is useful.

I tested this file on ubuntu 21.10 (impish) & ngspice36, compiled & works as intended