### PR TITLE
Add '+' to start of multiline model continuations

### DIFF
--- a/qucs/spicecomponents/sp_model.cpp
+++ b/qucs/spicecomponents/sp_model.cpp
@@ -80,9 +80,17 @@ QString S4Q_Model::getSpiceModel()
 
     QString s;
     s.clear();
+
+    bool first_line = true;
     foreach (Property *pp, Props) {
-        if (!pp->Value.isEmpty())
-            s += pp->Value + "\n";
+        if (!pp->Value.isEmpty()) {
+            if (first_line) {
+                s += pp->Value + "\n";
+                first_line = false;
+            } else {
+                s += "+ " +  pp->Value + "\n";
+            }
+        }
     }
     return s;
 }


### PR DESCRIPTION
I'm not sure whether this is expected behavior, but when you add in a multiline model you need to manually add in a '+' to each additional line. This adds it for you, no clue whether this is better or worse than the default behavior