### PR TITLE
qt6 native win build fixes

### DIFF
--- a/qucs-activefilter/CMakeLists.txt
+++ b/qucs-activefilter/CMakeLists.txt
@@ -17,14 +17,22 @@ set(PROJECT_DOMAIN_SECOND "org")
 
 #SET(CMAKE_BUILD_TYPE Debug)
 
-ADD_DEFINITIONS( -DHAVE_CONFIG_H )
+add_compile_definitions(HAVE_CONFIG_H)
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall ")
 IF(WITH_QT6)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 ")
-ELSE(WITH_QT6)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x ")
-ENDIF(WITH_QT6)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ELSE()
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ENDIF()
+
+if (MSVC)
+
+else()
+    # additional warnings
+    add_compile_options(-Wall -Wextra)
+endif()
 
 
 #configure the header config.h

--- a/qucs-attenuator/CMakeLists.txt
+++ b/qucs-attenuator/CMakeLists.txt
@@ -17,7 +17,7 @@ set(PROJECT_DOMAIN_SECOND "org")
 
 SET(CMAKE_BUILD_TYPE Debug)
 
-ADD_DEFINITIONS( -DHAVE_CONFIG_H )
+add_compile_definitions(HAVE_CONFIG_H)
 
 # configure the header config.h
 CONFIGURE_FILE (
@@ -27,9 +27,24 @@ CONFIGURE_FILE (
 
 INCLUDE_DIRECTORIES("${PROJECT_BINARY_DIR}")
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall ") # enable warning level
+
+
 IF(WITH_QT6)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 ") # enable C++11
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ELSE()
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ENDIF()
+
+if (MSVC)
+
+else()
+    # additional warnings
+    add_compile_options(-Wall -Wextra)
+endif()
+
+IF(WITH_QT6)
 FIND_PACKAGE( Qt6 COMPONENTS Core Gui Widgets REQUIRED )
 INCLUDE_DIRECTORIES(
       ${Qt6Core_INCLUDE_DIRS}
@@ -38,7 +53,6 @@ INCLUDE_DIRECTORIES(
 # bug, the find package does not seem to set the QT_LIBRARIES, do it manually
 SET(QT_LIBRARIES  ${Qt6Core_LIBRARIES} ${Qt6Widgets_LIBRARIES}  )
 ELSE(WITH_QT6)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x ") # enable C++11
 FIND_PACKAGE( Qt5 COMPONENTS Core Gui Widgets REQUIRED )
 INCLUDE_DIRECTORIES(
       ${Qt5Core_INCLUDE_DIRS}

--- a/qucs-filter/CMakeLists.txt
+++ b/qucs-filter/CMakeLists.txt
@@ -17,8 +17,7 @@ set(PROJECT_DOMAIN_SECOND "org")
 
 #SET(CMAKE_BUILD_TYPE Debug)
 
-ADD_DEFINITIONS( -DHAVE_CONFIG_H )
-
+add_compile_definitions(HAVE_CONFIG_H)
 
 # configure the header config.h
 CONFIGURE_FILE (
@@ -28,10 +27,24 @@ CONFIGURE_FILE (
 
 INCLUDE_DIRECTORIES("${PROJECT_BINARY_DIR}")
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall ") # enable warning level
 
 IF(WITH_QT6)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 ") # enable C++17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ELSE()
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ENDIF()
+
+if (MSVC)
+
+else()
+    # additional warnings
+    add_compile_options(-Wall -Wextra)
+endif()
+
+
+IF(WITH_QT6)
 FIND_PACKAGE( Qt6 COMPONENTS Core Gui Widgets REQUIRED)
 INCLUDE_DIRECTORIES(
       ${Qt6Core_INCLUDE_DIRS}
@@ -40,7 +53,6 @@ INCLUDE_DIRECTORIES(
 # bug, the find package does not seem to set the QT_LIBRARIES, do it manually
 SET(QT_LIBRARIES  ${Qt6Core_LIBRARIES} ${Qt6Widgets_LIBRARIES}  )
 ELSE(WITH_QT6)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x ") # enable C++11
 FIND_PACKAGE( Qt5 COMPONENTS Core Gui Widgets REQUIRED)
 INCLUDE_DIRECTORIES(
       ${Qt5Core_INCLUDE_DIRS}

--- a/qucs-powercombining/CMakeLists.txt
+++ b/qucs-powercombining/CMakeLists.txt
@@ -17,7 +17,7 @@ set(PROJECT_DOMAIN_SECOND "org")
 
 #SET(CMAKE_BUILD_TYPE Debug)
 
-ADD_DEFINITIONS( -DHAVE_CONFIG_H )
+add_compile_definitions(HAVE_CONFIG_H)
 
 # configure the header config.h
 CONFIGURE_FILE (
@@ -27,10 +27,22 @@ CONFIGURE_FILE (
 
 INCLUDE_DIRECTORIES("${PROJECT_BINARY_DIR}")
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall ") # enable warning level
+IF(WITH_QT6)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ELSE()
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ENDIF()
+
+if (MSVC)
+
+else()
+    # additional warnings
+    add_compile_options(-Wall -Wextra)
+endif()
 
 IF(WITH_QT6)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 ") # enable C++17
 FIND_PACKAGE( Qt6 COMPONENTS Core Gui Widgets Svg SvgWidgets REQUIRED)
 INCLUDE_DIRECTORIES(
       ${Qt6Core_INCLUDE_DIRS}
@@ -41,7 +53,6 @@ INCLUDE_DIRECTORIES(
 # bug, the find package does not seem to set the QT_LIBRARIES, do it manually
 SET(QT_LIBRARIES  ${Qt6Core_LIBRARIES} ${Qt6Widgets_LIBRARIES} ${Qt6Svg_LIBRARIES} ${Qt6SvgWidgets_LIBRARIES}  )
 ELSE(WITH_QT6)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x ") # enable C++11
 FIND_PACKAGE( Qt5 COMPONENTS Core Gui Widgets Svg REQUIRED)
 INCLUDE_DIRECTORIES(
       ${Qt5Core_INCLUDE_DIRS}

--- a/qucs-transcalc/CMakeLists.txt
+++ b/qucs-transcalc/CMakeLists.txt
@@ -17,7 +17,7 @@ set(PROJECT_DOMAIN_SECOND "org")
 
 SET(CMAKE_BUILD_TYPE Debug)
 
-ADD_DEFINITIONS( -DHAVE_CONFIG_H )
+add_compile_definitions(HAVE_CONFIG_H)
 
 # configure the header config.h
 CONFIGURE_FILE (
@@ -27,12 +27,23 @@ CONFIGURE_FILE (
 
 INCLUDE_DIRECTORIES("${PROJECT_BINARY_DIR}")
 
-SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall ") # enable warning level
-
 
 IF(WITH_QT6)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 ") # enable C++11
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ELSE()
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ENDIF()
+
+if (MSVC)
+
+else()
+    # additional warnings
+    add_compile_options(-Wall -Wextra)
+endif()
+
+IF(WITH_QT6)
 FIND_PACKAGE( Qt6 COMPONENTS Core Gui Widgets REQUIRED)
 INCLUDE_DIRECTORIES(
       ${Qt6Core_INCLUDE_DIRS}
@@ -41,7 +52,6 @@ INCLUDE_DIRECTORIES(
   # bug, the find package does not seem to set the QT_LIBRARIES, do it manually
 SET(QT_LIBRARIES  ${Qt6Core_LIBRARIES} ${Qt6Widgets_LIBRARIES}  )
 ELSE(WITH_QT6)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x ") # enable C++11
 FIND_PACKAGE( Qt5 COMPONENTS Core Gui Widgets REQUIRED)
 INCLUDE_DIRECTORIES(
       ${Qt5Core_INCLUDE_DIRS}

--- a/qucs/CMakeLists.txt
+++ b/qucs/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
 endif()
 
 #
-ADD_DEFINITIONS( -DHAVE_CONFIG_H )
+add_compile_definitions(HAVE_CONFIG_H)
 
 IF(WITH_QT6)
 FIND_PACKAGE( Qt6 COMPONENTS Core Gui Widgets Svg Xml PrintSupport REQUIRED)
@@ -94,13 +94,23 @@ CONFIGURE_FILE (
 
 INCLUDE_DIRECTORIES("${PROJECT_BINARY_DIR}")
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra ") # enable warning level
 IF(WITH_QT6)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 ") # enable C++11 c++0x
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 ELSE()
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x ") # enable C++11 c++0x
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 ENDIF()
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC ") # enable C++11
+
+if (MSVC)
+
+else()
+    # additional warnings
+    add_compile_options(-Wall -Wextra)
+endif()
 
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Qt6Widgets_EXECUTABLE_COMPILE_FLAGS}")
@@ -255,7 +265,7 @@ ADD_EXECUTABLE( ${QUCS_NAME} MACOSX_BUNDLE WIN32
 # Tell CMake which libraries we need to link our executable against.
 #
 TARGET_LINK_LIBRARIES( ${QUCS_NAME}  components diagrams dialogs paintings extsimkernels spicecomponents qt3_compat ${QT_LIBRARIES} )
-
+SET_TARGET_PROPERTIES(${QUCS_NAME} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 #
 # Prepare the installation
 #

--- a/qucs/dialogs/simmessage.cpp
+++ b/qucs/dialogs/simmessage.cpp
@@ -21,9 +21,6 @@
  *
  */
 
-#include <stdlib.h>
-#include <iostream>
-using namespace std;
 #include <QLabel>
 #include <QGroupBox>
 #include <QTimer>


### PR DESCRIPTION
fixed namespace std usage made win10 build break. I changed cmake options for compiler agnostic version. I didn't made it work for msvc build but mingw qt6.5.0 build was succesfully done in native win 10 env.

![Ekran görüntüsü 2023-02-13 135054](https://user-images.githubusercontent.com/41967334/218440919-bc212570-e78e-426f-bfb4-6e1b586cf12b.jpg)
