### PR TITLE
fixed current directions in ac sources

### DIFF
--- a/qucs/components/ampere_ac.cpp
+++ b/qucs/components/ampere_ac.cpp
@@ -80,11 +80,12 @@ Element* Ampere_ac::info(QString& Name, char* &BitmapFile, bool getNewOne)
 QString Ampere_ac::spice_netlist(bool)
 {
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
-        QString nam = p1->Connection->Name;
-        if (nam=="gnd") nam = "0";
-        s += " "+ nam;   // node names
-    }
+
+    QString plus = Ports.at(1)->Connection->Name;
+    if (plus=="gnd") plus = "0";
+    QString minus = Ports.at(0)->Connection->Name;
+    if (minus=="gnd") minus = "0";
+    s += QString(" %1 %2 ").arg(plus).arg(minus);
 
     QString amperes = spicecompat::normalize_value(Props.at(0)->Value);
     QString freq = spicecompat::normalize_value(Props.at(1)->Value);

--- a/qucs/components/ampere_ac.cpp
+++ b/qucs/components/ampere_ac.cpp
@@ -81,10 +81,8 @@ QString Ampere_ac::spice_netlist(bool)
 {
     QString s = spicecompat::check_refdes(Name,SpiceModel);
 
-    QString plus = Ports.at(1)->Connection->Name;
-    if (plus=="gnd") plus = "0";
-    QString minus = Ports.at(0)->Connection->Name;
-    if (minus=="gnd") minus = "0";
+    QString plus = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
+    QString minus = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
     s += QString(" %1 %2 ").arg(plus).arg(minus);
 
     QString amperes = spicecompat::normalize_value(Props.at(0)->Value);


### PR DESCRIPTION
The original ac Current Source and the I Source have different current direction. 

![different_directions](https://user-images.githubusercontent.com/60294840/225407927-5f147b85-20d4-4046-bdd4-4e5a8a0b9ed7.png)

Fixed this.

![same_directions](https://user-images.githubusercontent.com/60294840/225408066-06b0cfe9-6a70-4a4c-94bc-df8dbc8df2f1.png)

