### PR TITLE
Added digital source

### DIFF
--- a/qucs/components/digi_source.h
+++ b/qucs/components/digi_source.h
@@ -32,6 +32,7 @@ protected:
   QString netlist();
   QString vhdlCode(int);
   QString verilogCode(int);
+  QString spice_netlist(bool isXyce = false);
 };
 
 #endif

--- a/qucs/module.cpp
+++ b/qucs/module.cpp
@@ -433,7 +433,6 @@ void Module::registerModules (void) {
       REGISTER_VERILOGA_1 (vcresistor);
 
       // digital components
-      REGISTER_DIGITAL_1 (Digi_Source);
       REGISTER_DIGITAL_1 (andor4x2);
       REGISTER_DIGITAL_1 (andor4x3);
       REGISTER_DIGITAL_1 (andor4x4);
@@ -469,6 +468,7 @@ void Module::registerModules (void) {
 
   if (QucsSettings.DefaultSimulator == spicecompat::simNgspice ||
           QucsSettings.DefaultSimulator == spicecompat::simQucsator) {
+      REGISTER_DIGITAL_1 (Digi_Source);
       REGISTER_DIGITAL_1 (Logical_Buf);
       REGISTER_DIGITAL_1 (Logical_Inv);
       REGISTER_DIGITAL_1 (Logical_NAND);


### PR DESCRIPTION
Added a new method convert_notation to the spicecompat class that replaces common unit suffixes and SI prefixes in a value string with their corresponding exponent values. The supported unit suffixes include "p", "n", "u", "m", "k", "Meg", "G", and "T".
Added spice entry for digital source.

The digital source was created as a VPWL source, with the rise and fall times set to one hundredth of the first time step value. The main difference between the original digital source and this implementation is that the signal is not periodic.

The comparison between the two versions is shown below.
![ngspice_vs_qucsator](https://user-images.githubusercontent.com/60294840/234639705-180da489-da01-4f78-a35f-3985a311990c.png)
