### PR TITLE
qucs/main.cpp: fix variable 'S4Q_workdir' when first time it is run

### DIFF
--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -153,8 +153,6 @@ bool loadSettings()
     else QucsSettings.SpiceOpusExecutable = "spiceopus";
     if(settings.contains("Nprocs")) QucsSettings.NProcs = settings.value("Nprocs").toInt();
     else QucsSettings.NProcs = 4;
-    if(settings.contains("S4Q_workdir")) QucsSettings.S4Qworkdir = settings.value("S4Q_workdir").toString();
-    else QucsSettings.S4Qworkdir = QDir::toNativeSeparators(QucsSettings.QucsWorkDir.absolutePath()+"/spice4qucs");
     if(settings.contains("SimParameters")) QucsSettings.SimParameters = settings.value("SimParameters").toString();
     else QucsSettings.SimParameters = "";
     if(settings.contains("OctaveExecutable")) {
@@ -174,6 +172,8 @@ bool loadSettings()
       if(settings.value("QucsHomeDir").toString() != "")
          QucsSettings.QucsHomeDir.setPath(settings.value("QucsHomeDir").toString());
     QucsSettings.QucsWorkDir = QucsSettings.QucsHomeDir;
+    if(settings.contains("S4Q_workdir")) QucsSettings.S4Qworkdir = settings.value("S4Q_workdir").toString();
+    else QucsSettings.S4Qworkdir = QDir::toNativeSeparators(QucsSettings.QucsWorkDir.absolutePath()+"/spice4qucs");
 
     if (settings.contains("IgnoreVersion")) QucsSettings.IgnoreFutureVersion = settings.value("IgnoreVersion").toBool();
     // check also for old setting name with typo...


### PR DESCRIPTION
The variable must be assigned after QucsWorkDir is set, otherwise the wrong path '/spice4qucs' will be assigned the first time it is run.
See: https://bugzilla.altlinux.org/42122