### PR TITLE
Added spice entry for time-controlled switch

### DIFF
--- a/qucs/components/switch.cpp
+++ b/qucs/components/switch.cpp
@@ -17,34 +17,35 @@
 #include "switch.h"
 #include "node.h"
 #include "schematic.h"
+#include "misc.h"
 #include "extsimkernels/spicecompat.h"
-
+#include <QDebug>
 
 Switch::Switch()
 {
   Description = QObject::tr("switch (time controlled)");
-  Simulator = spicecompat::simQucsator;
 
   Props.append(new Property("init", "off", false,
 		QObject::tr("initial state")+" [on, off]"));
   Props.append(new Property("time", "1 ms", false,
 		QObject::tr("time when state changes (semicolon separated list possible, even numbered lists are repeated)")));
-  Props.append(new Property("Ron", "0", false,
+  Props.append(new Property("Ron", "1e-9", false,
 		QObject::tr("resistance of \"on\" state in ohms")));
   Props.append(new Property("Roff", "1e12", false,
 		QObject::tr("resistance of \"off\" state in ohms")));
   Props.append(new Property("Temp", "26.85", false,
-		QObject::tr("simulation temperature in degree Celsius")));
+        QObject::tr("simulation temperature in degree Celsius (Qucsator only)")));
   Props.append(new Property("MaxDuration", "1e-6", false,
 		QObject::tr("Max possible switch transition time (transition time 1/100 smallest value in 'time', or this number)")));
   Props.append(new Property("Transition", "spline", false,
-		QObject::tr("Resistance transition shape")+" [abrupt, linear, spline]"));
+        QObject::tr("Resistance transition shape (Qucsator only)")+" [abrupt, linear, spline]"));
 
   createSymbol();
   tx = x1+4;
   ty = y2+4;
   Model = "Switch";
   Name  = "S";
+  SpiceModel = "S";
 }
 
 // -------------------------------------------------------
@@ -84,6 +85,80 @@ QString Switch::netlist()
     s += " "+p2->Name+"=\""+p2->Value+"\"";
 
   return s + '\n';
+}
+
+QString Switch::spice_netlist(bool)
+{
+  QString s = spicecompat::check_refdes(Name,SpiceModel);
+  QString port1 = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
+  QString port2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
+
+  s += QString(" %1 %2 control_net%3 0 switch_model%3\n").arg(port1).arg(port2).arg(Name);
+
+  QString init = spicecompat::normalize_value(getProperty("init")->Value);
+  QString times = spicecompat::normalize_value(getProperty("time")->Value);
+  QStringList timesList = times.split(";");
+  QString Ron = spicecompat::normalize_value(getProperty("Ron")->Value);
+  QString Roff = spicecompat::normalize_value(getProperty("Roff")->Value);
+  QString Max_duration = spicecompat::normalize_value(getProperty("MaxDuration")->Value);
+
+  double fac, timeValue, changingTime, maxDuration, firstTimeVal, time = 0.0;
+  QString unit;
+
+  misc::str2num(timesList[0].toLower(), maxDuration,unit,fac);
+  maxDuration *= fac / 100;
+  misc::str2num(timesList[0].toLower(),firstTimeVal,unit,fac);
+  firstTimeVal *= fac / 100;
+
+  if (firstTimeVal > maxDuration){
+    changingTime = maxDuration;
+  }
+  else {
+    changingTime = firstTimeVal;
+  }
+
+  QString oddValue, evenValue;
+  if (init == "{OFF}") {
+    oddValue = "0";
+    evenValue = "1";
+  } else {
+    oddValue = "1";
+    evenValue = "0";
+  }
+
+  s += QString("V%1 control_net%1 0 DC %2 PWL(0 %2").arg(Name).arg(oddValue);
+
+  for (int i = 0; i < timesList.size(); i++) {
+    QString timeStep = timesList[i].toLower();
+    misc::str2num(timeStep,timeValue,unit,fac);
+    timeValue *= fac;
+
+    if (i == 0) {
+        time += timeValue - changingTime;
+        s += QString(" %1 %2").arg(time).arg(oddValue);
+        time += changingTime;
+        s += QString(" %1 %2").arg(time).arg(evenValue);
+
+    } else {
+        if (i % 2 == 1) {
+            time += timeValue- changingTime;
+            s += QString(" %1 %2").arg(time).arg(evenValue);
+            time += changingTime;
+            s += QString(" %1 %2").arg(time).arg(oddValue);
+        }
+        else{
+            time += timeValue- changingTime;
+            s += QString(" %1 %2").arg(time).arg(oddValue);
+            time += changingTime;
+            s += QString(" %1 %2").arg(time).arg(evenValue);
+        }
+    }
+  }
+
+  s += ")\n";
+
+  s += QString(".model switch_model%1 sw vt =0.5 ron =%2 roff =%3\n").arg(Name).arg(Ron).arg(Roff);
+  return s;
 }
 
 // -------------------------------------------------------

--- a/qucs/components/switch.h
+++ b/qucs/components/switch.h
@@ -29,6 +29,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
 
 protected:
+  QString spice_netlist(bool isXyce = false);
   QString netlist();
   void createSymbol();
 };


### PR DESCRIPTION
I've made some enhancements to the spice model:
- Added a spice entry for time-controlled switch #353;
- Updated descriptions for "Transition" and "Temp" parameters;
- Updated the default value for Ron.

The simulation test results are shown bellow:
![switch_test](https://github.com/ra3xdh/qucs_s/assets/60294840/55acc975-2d5f-489f-87d3-88f9dfb5270c)
