### PR TITLE
Add support for custom prefix to dataset variables

### DIFF
--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -1305,21 +1305,17 @@ void AbstractSpiceKernel::normalizeVarsNames(QStringList &var_list, const QStrin
     QString prefix="";
     QString iprefix="";
     QString indep = var_list.first();
-    QString cprefix = custom_prefix;
-    if(!cprefix.isEmpty())
-      cprefix.append(".");
     bool HB = false;
     indep = indep.toLower();
     if (indep=="time") {
-        prefix = cprefix + "tran.";
-        iprefix = cprefix + "i(tran.";
+        prefix = "tran.";
+        iprefix = "i(tran.";
     } else if (indep=="frequency") {
-        prefix = cprefix + "ac.";
-        iprefix = cprefix + "i(ac.";
+        prefix = "ac.";
+        iprefix = "i(ac.";
     } else if (indep=="hbfrequency") {
         HB = true;
     }
-    var_list.first().insert(0, cprefix);
 
     for(auto & it : var_list) { // For subcircuit nodes output i.e. v(X1:n1)
         it.replace(":","_");         // colon symbol is reserved in Qucs as dataset specifier
@@ -1361,6 +1357,11 @@ void AbstractSpiceKernel::normalizeVarsNames(QStringList &var_list, const QStrin
         }
     }
 
+    if ( !custom_prefix.isEmpty() ) {
+        for ( it = var_list.begin() ; it != var_list.end() ; ++it)
+            if ( !(*it).isEmpty() )
+                (*it).prepend(custom_prefix + ".");
+    }
 }
 
 /*!

--- a/qucs/extsimkernels/abstractspicekernel.h
+++ b/qucs/extsimkernels/abstractspicekernel.h
@@ -48,7 +48,7 @@ class AbstractSpiceKernel : public QObject
 private:
     enum outType {xyceSTD, spiceRaw, spiceRawSwp, xyceSTDswp, Unknown};
 
-    void normalizeVarsNames(QStringList &var_list);
+    void normalizeVarsNames(QStringList &var_list, const QString &custom_prefix);
     int checkRawOutupt(QString ngspice_file, QStringList &values);
     void extractBinSamples(QDataStream &dbl, QList< QList<double> > &sim_points,
                            int NumPoints, int NumVars, bool isComplex);

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -100,18 +100,18 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
        if(pc->isSimulation && pc->isActive == COMP_IS_ACTIVE) {
            s = pc->getSpiceNetlist();
            QString sim_typ = pc->Model;
-           if (sim_typ==".AC") simulations.append("ac");
-           if (sim_typ==".TR") simulations.append("tran");
-           if (sim_typ==".CUSTOMSIM") simulations.append("custom");
-           if (sim_typ==".DISTO") simulations.append("disto");
-           if (sim_typ==".NOISE") simulations.append("noise");
-           if (sim_typ==".PZ") simulations.append("pz");
-           if (sim_typ==".SENS") simulations.append("sens");
-           if (sim_typ==".SENS_AC") simulations.append("sens_ac");
-           if (sim_typ==".SP") simulations.append("sp");
-           if (sim_typ==".FFT") simulations.append("fft");
+           if (sim_typ==".AC") if(!simulations.contains("ac")) simulations.append("ac");
+           if (sim_typ==".TR") if(!simulations.contains("tran")) simulations.append("tran");
+           if (sim_typ==".CUSTOMSIM") if(!simulations.contains("custom")) simulations.append("custom");
+           if (sim_typ==".DISTO") if(!simulations.contains("disto")) simulations.append("disto");
+           if (sim_typ==".NOISE") if(!simulations.contains("noise")) simulations.append("noise");
+           if (sim_typ==".PZ") if(!simulations.contains("pz")) simulations.append("pz");
+           if (sim_typ==".SENS") if(!simulations.contains("sens")) simulations.append("sens");
+           if (sim_typ==".SENS_AC") if(!simulations.contains("sens_ac")) simulations.append("sens_ac");
+           if (sim_typ==".SP") if(!simulations.contains("sp")) simulations.append("sp");
+           if (sim_typ==".FFT") if(!simulations.contains("fft")) simulations.append("fft");
            if ((sim_typ==".SW")&&
-               (pc->Props.at(0)->Value.startsWith("DC"))) simulations.append("dc");
+               (pc->Props.at(0)->Value.startsWith("DC"))) if(!simulations.contains("dc")) simulations.append("dc");
            // stream<<s;
        }
     }


### PR DESCRIPTION
The prefix is enclosed between # # in the output file name. If the file name contains a #custom_prefix# section it will be prepended to the dataset variables. Useful for custom simulations where one can set multiple simulations and multiple output files.

Example nutmeg script:
```
AC DEC 10 1MEG 1G
write custom#ac1#.txt v(out)
destroy all

AC LIN 100 90MEG 110MEG
write custom#ac2#.txt v(out)
destroy all
```
The dataset will contain:
ac1.ac.v(out) ac1.frequency
ac2.ac.v(out) ac2.frequency


Prevent duplications in simulations QStringList of Ngspice::createNetlist. With current code if one has two nutmeg scripts both scripts are placed twice in the control section of the netlist.