### PR TITLE
Add "zoom to pointer" behaviour for zooming using mouse wheel

### DIFF
--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -35,7 +35,9 @@
 #include <QPaintDevice>
 #include <QPainter>
 #include <QPixmap>
+#include <QPoint>
 #include <QPrinter>
+#include <QRect>
 #include <QTextStream>
 #include <QUrl>
 #include <QWheelEvent>
@@ -761,6 +763,123 @@ void Schematic::paintSchToViewpainter(
             p->drawText(pn->Name, x, y);
         }
     }
+}
+
+double Schematic::scale(const double newScale) {
+  // If current scale is minimum or maximum possible one and new scale
+  // exceeds the limits then short-circuit and do nothing.
+  // Return 1.0 as relative scale because scale stays the same.
+  if ((Scale >= maxScale && newScale >= maxScale) ||
+      (Scale <= minScale && newScale <= minScale)) return 1.0;
+
+  const double originalScale = Scale;
+
+  if (newScale > maxScale) {
+    Scale = maxScale;
+  } else if (newScale < minScale) {
+    Scale = minScale;
+  } else {
+    Scale = newScale;
+  }
+
+  // Variable ViewX* and ViewY* describe "logical" size of the schematic.
+  // Logical schematic size and canvas size are connected:
+  // <canvas size> = <schematic logical size> * <scale>.
+  auto newWidth  = static_cast<int>(std::ceil(Scale * (ViewX2 - ViewX1)));
+  auto newHeight = static_cast<int>(std::ceil(Scale * (ViewY2 - ViewY1)));
+
+  resizeContents(newWidth, newHeight);
+
+  return Scale / originalScale;
+}
+
+// - - - - -
+// After changing canvas size schematic's logical size must be updated to reflect
+// this change, otherwise there would be inconsistency.
+//
+// Param d in each of grow* method must be non-negative.
+//
+void Schematic::growUp(const int d) {
+  if (d == 0) return;
+  resizeContents(contentsWidth(), contentsHeight() + d);
+  // logical bottom stays, logical top must be moved
+  ViewY1 = ViewY2 - static_cast<int>(std::round(contentsHeight() / Scale));
+}
+
+void Schematic::growDown(const int d) {
+  if (d == 0) return;
+  resizeContents(contentsWidth(), contentsHeight() + d);
+  // logical top stays, logical bottom must be moved
+  ViewY2 = ViewY1 + static_cast<int>(std::round(contentsHeight() / Scale));
+}
+
+void Schematic::growLeft(const int d) {
+  if (d == 0) return;
+  resizeContents(contentsWidth() + d, contentsHeight());
+  // logical left stays, logical right must be moved
+  ViewX1 = ViewX2 - static_cast<int>(std::round(contentsWidth() / Scale));
+}
+
+void Schematic::growRight(const int d) {
+  if (d == 0) return;
+  resizeContents(contentsWidth() + d, contentsHeight());
+  ViewX2 = ViewX1 + static_cast<int>(std::round(contentsWidth() / Scale));
+}
+// - - - - -
+
+double Schematic::zoomAroundPoint(double offeredScaleChange, const int zpx, const int zpy) {
+  // This statement is copied from the 'zoom' method. In 'zoom' it has the comment:
+  //  "resizeContents() performs an immediate repaint. So, set widget
+  //   to hidden. This causes some flicker, but it is still nicer"
+  //
+  // Maybe it's of no use and shouldn't be there, but for now, let's go the way 'zoom' goes,
+  // at least 'zoom' has proven to work.
+  viewport()->setHidden(true);
+
+  // zpx and zpy are coordinates relative to viewport's top-left corner. Convert them
+  // to coordinates on the canvas
+  QPoint zoomingCenter(contentsX() + zpx, contentsY() + zpy);
+
+  const double actualScaleChange = scale(Scale * offeredScaleChange);
+
+  // Canvas must have changed its size. If so, then zooming center coordinates
+  // has changed too.
+  zoomingCenter.setX(static_cast<int>(std::round(zoomingCenter.x() * actualScaleChange)));
+  zoomingCenter.setY(static_cast<int>(std::round(zoomingCenter.y() * actualScaleChange)));
+
+  // visibleArea describes an area on the canvas, which should be displayed in order
+  // to keep zoomingCenter in the same place relative to viewport.
+  QRect visibleArea(
+    zoomingCenter.x() - zpx, zoomingCenter.y() - zpy,
+    viewport()->width(), viewport()->height()
+  );
+
+  if (visibleArea.left() < 0) {
+    growLeft(std::abs(visibleArea.left()));
+    visibleArea.setLeft(0);
+  }
+
+  if (visibleArea.top() < 0) {
+    growUp(std::abs(visibleArea.top()));
+    visibleArea.setTop(0);
+  }
+
+  if (auto extraWidth = visibleArea.left() + visibleArea.width() - contentsWidth(); extraWidth > 0) {
+    growRight(extraWidth);
+  }
+
+  if (auto extraHeight = visibleArea.top() + visibleArea.height() - contentsHeight(); extraHeight > 0) {
+    growDown(extraHeight);
+  }
+
+  setContentsPos(visibleArea.left(), visibleArea.top());
+
+  // This block is also copied from 'zoom' method
+  viewport()->setHidden(false);
+  viewport()->update();
+  App->view->drawn = false;
+
+  return Scale;
 }
 
 // -----------------------------------------------------------
@@ -2169,13 +2288,10 @@ void Schematic::contentsWheelEvent(QWheelEvent *Event)
         //  values different from 60 (slower or faster zoom)
         int delta = Event->angleDelta().y();
         float Scaling = pow(1.1, delta / 60.0);
-        zoom(Scaling);
-        Scaling -= 1.0;
 #if QT_VERSION >= 0x050f00
-        scrollBy(int(Scaling * float(Event->position().x())),
-                 int(Scaling * float(Event->position().y())));
+      zoomAroundPoint(Scaling, Event->position().x(), Event->position().y());
 #else
-        scrollBy(int(Scaling * float(Event->pos().x())), int(Scaling * float(Event->pos().y())));
+      zoomAroundPoint(Scaling, Event->pos().x(), Event->pos().y());
 #endif
     }
     // ...................................................................

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -101,6 +101,22 @@ public:
   bool  elementsOnGrid();
 
   float zoom(float);
+
+  /**
+    Zoom around a "zooming center". Zooming center is a point on the canvas,
+    which doesn't move relative to a viewport while canvas is being zoomed in or out.
+
+    This produces the effect of "concentrating" on a zooming center: with each zoom-in step
+    one would get closer and closer to the point, while point's surroundings would go "out of sight",
+    beyound the viewport's borders.
+
+    Zooming out works in backwards order: everything is like being "sucked into" the zooming center.
+
+    @param scaleChange  a multiplier for a current scale value.
+    @param zpx          x coordinate of zooming center, relative to viewport's top-left corner
+    @param zpy          y coordinate of zooming center, relative to viewport's top-left corner
+  */
+  double zoomAroundPoint(double scaleChange, const int zpx, const int zpy);
   float zoomBy(float);
   void  showAll();
   void zoomToSelection();
@@ -216,6 +232,55 @@ private:
   bool dragIsOkay;
   /*! \brief hold system-independent information about a schematic file */
   QFileInfo FileInfo;
+
+  /**
+    Enlarge canvas by "moving" its top side up. Schematic::ViewY1 is updated accordingly.
+
+    @param d  number of size points (pixels) to add to canvas size. Must be non-negative.
+  */
+  void growUp(const int d);
+
+  /**
+    Enlarge canvas by "moving" its bottom side down. Schematic::ViewY2 is updated accordingly.
+
+    @param d  number of size points (pixels) to add to canvas size. Must be non-negative.
+  */
+  void growDown(const int d);
+
+  /**
+    Enlarge canvas by "moving" its left side to the left. Schematic::ViewX1 is updated accordingly.
+
+    @param d  number of size points (pixels) to add to canvas size. Must be non-negative.
+  */
+  void growLeft(const int d);
+
+  /**
+    Enlarge canvas by "moving" its right side to the right. Schematic::ViewX2 is updated accordingly.
+
+    @param d  number of size points (pixels) to add to canvas size. Must be non-negative.
+  */
+  void growRight(const int d);
+
+  /**
+    Redraw schematic at given scale.
+
+    If \a newScale is larger than Schematic::maxScale then Schematic::maxScale becomes new scale.
+    If \a newScale is less than Schematic::minScale then Schematic::minScale becomes new scale.
+
+    @param newScale   a desired scale for schematic to be drawn in
+    @return relative scale change, i.e. \c newScale/oldScale
+    */
+  double scale(const double newScale);
+
+  /**
+    Minimum scale at which schematic could be drawn.
+  */
+  static constexpr double minScale = 0.1;
+
+  /**
+    Maximum scale at which schematic could be drawn.
+  */
+  static constexpr double maxScale = 10.0;
 
 /* ********************************************************************
    *****  The following methods are in the file                   *****

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -145,8 +145,24 @@ public:
 
 
   int GridX, GridY;
-  int ViewX1, ViewY1, ViewX2, ViewY2;  // size of the document area
-  int UsedX1, UsedY1, UsedX2, UsedY2;  // document area used by elements
+
+  // Variables View* are the coordinates of top-level and bottom-right corners
+  // of a rectangle representing the schematic document as a whole. This
+  // rectangle may grow and shrink when user scrolls the view, and its
+  // coordinates change accordingly. Everything (elements, wires, etc.) lies
+  // inside this rectangle. The size of this rectangle is the "logical" size
+  // of the schematic.
+  // Schematic is displayed to user in some scale: its "logical" size
+  // is multiplied by scale factor, and the result describes the size of a
+  // canvas required to draw the schematic in chosen scale. Every element of
+  // the schematic is drawn in the same scale on this canvas. That's the way
+  // "zooming" works.
+  int ViewX1, ViewY1, ViewX2, ViewY2;
+
+  // Variables Used* hold the coordinates of top-left and bottom-right corners
+  // of a smallest rectangle which can fit all elements of the schematic.
+  // This rectangle exists in the same coordinate system as View*-rectangle
+  int UsedX1, UsedY1, UsedX2, UsedY2;
   int zx1, zy1, zx2, zy2, dx, dy = 0;
 
   int showFrame;


### PR DESCRIPTION
Hello! I've found out that it is quite hard to explain this zooming feature in plain words, so I'm attaching "before" and "after" videos. Nonetheless, let me try to explain what this PR is about. 

This PR alters "zoom in/out using mouse wheel" behavior so that the part of contents under the mouse pointer doesn't change its position relative to app's window while contents is being scaled. In effect it looks like you're "zooming into" the mouse pointer or "zooming out of" the mouse pointer.

PR is of two commits: one adds the described functionality, another adds a couple of comments which I think may be useful in future (it took some time for me to understand the "zooming" and "rendering" code, so I think it would be nice to leave some hints in source for others).
[after.webm](https://github.com/ra3xdh/qucs_s/assets/40355531/543c53a2-425c-4bd6-9898-f2b94077b64f)
[before.webm](https://github.com/ra3xdh/qucs_s/assets/40355531/756d8256-8cea-44ce-b191-8638aa0e1c4b)
