### PR TITLE
Fix wrong "View all" scaling when schematic contains a nutmeg script with many lines

### DIFF
--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -84,23 +84,26 @@ void Component::Bounding(int &_x1, int &_y1, int &_x2, int &_y2) {
 int Component::textSize(int &_dx, int &_dy) {
     // get size of text using the screen-compatible metric
     QFontMetrics metrics(QucsSettings.font, 0);
-
-    int tmp, count = 0;
+    int count = 0;
     _dx = _dy = 0;
+
     if (showName) {
         _dx = metrics.boundingRect(Name).width();
         _dy = metrics.height();
         count++;
     }
-    for (Property *pp = Props.first(); pp != 0; pp = Props.next())
-        if (pp->display) {
-            // get width of text
-            tmp = metrics.size(flags, pp->Name + "=" + pp->Value).width();
-            if (tmp > _dx) _dx = tmp;
-            _dy += metrics.height();
-            count++;
+
     constexpr int flags = 0b00000000;
+    for (Property* p : Props) {
+        if (!(p->display)) continue;
+
+        // Update overall width if text of the current property is wider
+        if (auto w = metrics.size(flags, p->Name + "=" + p->Value).width(); w > _dx) {
+            _dx = w;
         }
+        _dy += metrics.height();
+        count++;
+    }
     return count;
 }
 

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -95,10 +95,11 @@ int Component::textSize(int &_dx, int &_dy) {
     for (Property *pp = Props.first(); pp != 0; pp = Props.next())
         if (pp->display) {
             // get width of text
-            tmp = metrics.boundingRect(pp->Name + "=" + pp->Value).width();
+            tmp = metrics.size(flags, pp->Name + "=" + pp->Value).width();
             if (tmp > _dx) _dx = tmp;
             _dy += metrics.height();
             count++;
+    constexpr int flags = 0b00000000;
         }
     return count;
 }


### PR DESCRIPTION
This is a fix for #426. One commit is the fix itself, another is some refactoring.