### PR TITLE
Add resistor's parameters tc1 and tc2 to ngspice

### DIFF
--- a/qucs/components/capq.cpp
+++ b/qucs/components/capq.cpp
@@ -71,7 +71,7 @@ CapQ::CapQ()
 		QObject::tr("Q frequency profile")+
 		" [Linear, SquareRoot, Constant]"));
   Props.append(new Property("Temp", "26.85", false,
-                QObject::tr("simulation temperature in degree Celsius")));
+                QObject::tr("simulation temperature in degree Celsius (Qucsator only)")));
 }
 CapQ::~CapQ()
 {

--- a/qucs/components/indq.cpp
+++ b/qucs/components/indq.cpp
@@ -72,7 +72,7 @@ IndQ::IndQ()
 		QObject::tr("Q frequency profile")+
 		" [Linear, SquareRoot, Constant]"));
    Props.append(new Property("Temp", "26.85", false,
-		QObject::tr("simulation temperature in degree Celsius")));
+        QObject::tr("simulation temperature in degree Celsius (Qucsator only)")));
 }
 IndQ::~IndQ()
 {

--- a/qucs/components/resistor.cpp
+++ b/qucs/components/resistor.cpp
@@ -28,13 +28,13 @@ Resistor::Resistor(bool european)
   Props.append(new Property("R", "1 kOhm", true,
     QObject::tr("ohmic resistance in Ohms")));
   Props.append(new Property("Temp", "26.85", false,
-    QObject::tr("simulation temperature in degree Celsius")));
+    QObject::tr("simulation temperature in degree Celsius (Qucsator only)")));
   Props.append(new Property("Tc1", "0.0", false,
     QObject::tr("first order temperature coefficient")));
   Props.append(new Property("Tc2", "0.0", false,
     QObject::tr("second order temperature coefficient")));
   Props.append(new Property("Tnom", "26.85", false,
-    QObject::tr("temperature at which parameters were extracted")));
+    QObject::tr("temperature at which parameters were extracted (Qucsator only)")));
 
   // this must be the last property in the list !!!
   Props.append(new Property("Symbol", "european", false,
@@ -57,13 +57,26 @@ Component* Resistor::newOne()
 
 QString Resistor::spice_netlist(bool )
 {
-    QString s=spicecompat::check_refdes(Name,SpiceModel);
+    QString s = spicecompat::check_refdes(Name,SpiceModel);
 
     s += QString(" %1 %2 ").arg(Ports.at(0)->Connection->Name)
             .arg(Ports.at(1)->Connection->Name); // output 2 nodes
     s.replace(" gnd ", " 0 ");
 
-    s += QString(" %1\n").arg(spicecompat::normalize_value(Props.at(0)->Value));
+    QString Tc1 = getProperty("Tc1")->Value;
+    QString Tc2 = getProperty("Tc2")->Value;
+
+    s += QString(" %1").arg(spicecompat::normalize_value(Props.at(0)->Value));
+
+    if (!Tc1.isEmpty()) {
+        s += " tc1=" + Tc1;
+    }
+
+    if (!Tc2.isEmpty()) {
+        s += " tc2=" + Tc2;
+    }
+
+    s += QString(" \n");
 
     return s;
 }


### PR DESCRIPTION

I noticed that some people find it more convenient to change the parameters of passive components (resistor, capacitor, inductor) in the window 'Edit Component Properties', rather than using red components and specifying parameters in text.

I did some research on what parameters of passive blue components are supported to work with ngspice:

**capacitor**:

|Parameter|ngspice|
|---|---|
|capacitance in Farad (C) |✔|
|initial voltage for transient simulation (V)|✔|

**inductor**:

|Parameter|ngspice|
|---|---|
|inductance in Henry (L) |✔|
|initial current for transient simulation (I)|✔|

**resistor**:

|Parameter|ngspice|
|---|---|
|ohmic resistance in Ohms (R) |✔|
|simulation temperature in degree Celsius (Temp)|✖|
|first order temperature coefficient (Tc1)|✖|
|second order temperature coefficient (Tc2)|✖|
|temperature at which parameters were extracted (Tnom)|✖|

**Inductor with Q**

|Parameter|ngspice|
|---|---|
|Inductance (L) |✔|
|Quality factor (Q)|✔|
|Frequency at which Q is measured (f)|✔|
|Q frequency profile (Mode)|✔|
|simulation temperature in degree Celsius (Temp)|✖|

**Capacitor with Q**

|Parameter|ngspice|
|---|---|
|Capacitance (C) |✔|
|Quality factor (Q)|✔|
|Frequency at which Q is measured (f)|✔|
|Q frequency profile (Mode)|✔|
|simulation temperature in degree Celsius (Temp)|✖|

Thus since most of parameters for inductor and capacitor are supported, then they should also supported for the resistor, which is not true. 

And although this has already been discussed in the #193 I decided to add parsing temperature parameters for resistor. Also I added a comment 'Qucsator only' in the parameter Description for parameters that are ignored by Ngspice. 

Simulation results for blue and red resistors are shown bellow:

![temp_res](https://github.com/ra3xdh/qucs_s/assets/60294840/2722fefb-9360-40c5-9fda-297e50842765)