### PR TITLE
Refactor schematic scaling and resizing logic

### DIFF
--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1946,31 +1946,11 @@ void MouseActions::MReleaseZoomIn(Schematic *Doc, QMouseEvent *Event)
 
     MAx1 = Event->pos().x();
     MAy1 = Event->pos().y();
-    float DX = float(MAx2);
-    float DY = float(MAy2);
 
-    float initialScale = Doc->Scale;
-    float scale = 1;
-    float xShift = 0;
-    float yShift = 0;
-    if ((Doc->Scale * DX) < 6.0) {
-        // a simple click zooms by constant factor
-        scale = Doc->zoom(1.5) / initialScale;
 
-        xShift = scale * Event->pos().x();
-        yShift = scale * Event->pos().y();
-    } else {
-        float xScale = float(Doc->visibleWidth()) / std::abs(DX);
-        float yScale = float(Doc->visibleHeight()) / std::abs(DY);
-        scale = qMin(xScale, yScale) / initialScale;
-        scale = Doc->zoom(scale) / initialScale;
-
-        xShift = scale * (MAx1 - 0.5 * DX);
-        yShift = scale * (MAy1 - 0.5 * DY);
-    }
-    xShift -= (0.5 * Doc->visibleWidth() + Doc->contentsX());
-    yShift -= (0.5 * Doc->visibleHeight() + Doc->contentsY());
-    Doc->scrollBy(xShift, yShift);
+    const QPoint click{Event->pos().x() , Event->pos().y()};
+    // "false" = "coordinates are not relative to viewport"
+    Doc->zoomAroundPoint(1.5, click, false);
 
     QucsMain->MouseMoveAction = &MouseActions::MMoveZoomIn;
     QucsMain->MouseReleaseAction = 0;

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -1100,8 +1100,7 @@ void QucsApp::slotCursorUp(bool up)
     if(markerCount > 0) {  // only move marker if nothing else selected
       Doc->markerUpDown(up, &movingElements);
     } else if(up) { // nothing selected at all
-      if(Doc->scrollUp(Doc->verticalScrollBar()->singleStep()))
-        Doc->scrollBy(0, -Doc->verticalScrollBar()->singleStep());
+      Doc->scrollUp(Doc->verticalScrollBar()->singleStep());
     } else { // down
       Doc->scrollDown(Doc->verticalScrollBar()->singleStep());
     }

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -1103,8 +1103,7 @@ void QucsApp::slotCursorUp(bool up)
       if(Doc->scrollUp(Doc->verticalScrollBar()->singleStep()))
         Doc->scrollBy(0, -Doc->verticalScrollBar()->singleStep());
     } else { // down
-      if(Doc->scrollDown(-Doc->verticalScrollBar()->singleStep()))
-        Doc->scrollBy(0, Doc->verticalScrollBar()->singleStep());
+      Doc->scrollDown(Doc->verticalScrollBar()->singleStep());
     }
 
     Doc->viewport()->update();

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -1033,8 +1033,7 @@ void QucsApp::slotCursorLeft(bool left)
     if(markerCount > 0) {  // only move marker if nothing else selected
       Doc->markerLeftRight(left, &movingElements);
     } else if(left) {
-      if(Doc->scrollLeft(Doc->horizontalScrollBar()->singleStep()))
-        Doc->scrollBy(-Doc->horizontalScrollBar()->singleStep(), 0);
+      Doc->scrollLeft(Doc->horizontalScrollBar()->singleStep());
     }else{ // right
       if(Doc->scrollRight(-Doc->horizontalScrollBar()->singleStep()))
         Doc->scrollBy(Doc->horizontalScrollBar()->singleStep(), 0);

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -1035,8 +1035,7 @@ void QucsApp::slotCursorLeft(bool left)
     } else if(left) {
       Doc->scrollLeft(Doc->horizontalScrollBar()->singleStep());
     }else{ // right
-      if(Doc->scrollRight(-Doc->horizontalScrollBar()->singleStep()))
-        Doc->scrollBy(Doc->horizontalScrollBar()->singleStep(), 0);
+      Doc->scrollRight(-Doc->horizontalScrollBar()->singleStep());
     }
 
     Doc->viewport()->update();

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1028,12 +1028,10 @@ void Schematic::showNoZoom()
     }
  }
 
-// -----------------------------------------------------------
-// Enlarge the viewport area if the coordinates x1-x2/y1-y2 exceed the
-// visible area.
-void Schematic::enlargeView(int x1, int y1, int x2, int y2)
-{
-    int dx = 0, dy = 0;
+ // If the model plane is smaller than rectangle described by points (x1, y1)
+ // and (x2, y2) than extend the model plane size.
+ void Schematic::enlargeView(int x1, int y1, int x2, int y2) {
+    // Set 'Used' area size to the of the given rectangle
     if (x1 < UsedX1)
         UsedX1 = x1;
     if (y1 < UsedY1)
@@ -1043,22 +1041,22 @@ void Schematic::enlargeView(int x1, int y1, int x2, int y2)
     if (y2 > UsedY2)
         UsedY2 = y2;
 
-    if (x1 < ViewX1) {
-        dx = int(Scale * float(ViewX1 - x1 + 40));
-        ViewX1 = x1 - 40;
-    }
-    if (y1 < ViewY1) {
-        dy = int(Scale * float(ViewY1 - y1 + 40));
-        ViewY1 = y1 - 40;
-    }
+    // Construct the desired model plane
+    constexpr int margin = 40;
+    QRect newModel = modelRect();
+    if (x1 < ViewX1)
+        newModel.setLeft(x1 - margin);
+    if (y1 < ViewY1)
+        newModel.setTop(y1 - margin);
     if (x2 > ViewX2)
-        ViewX2 = x2 + 40;
+        newModel.setRight(x2 + margin);
     if (y2 > ViewY2)
-        ViewY2 = y2 + 40;
+        newModel.setBottom(y2 + margin);
 
-    resizeContents(int(Scale * float(ViewX2 - ViewX1)), int(Scale * float(ViewY2 - ViewY1)));
-    scrollBy(dx, dy);
-}
+    const auto vpCenter = viewportRect().center();
+    const auto displayedInCenter = viewportToModel(vpCenter);
+    renderModel(Scale, newModel, displayedInCenter, vpCenter);
+ }
 
 // ---------------------------------------------------
 // Sets an arbitrary coordinate onto the next grid coordinate.

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -908,10 +908,12 @@ float Schematic::zoom(float s)
 // -----------------------------------------------------------
 float Schematic::zoomBy(float s)
 {
-    zoom(s);
-    s -= 1.0;
-    scrollBy(int(s * float(contentsX() + visibleWidth() / 2)),
-             int(s * float(contentsY() + visibleHeight() / 2)));
+    // Change scale and keep the point displayed in the center
+    // of the viewport at same place after scaling.
+
+    const double newScale = Scale * s;
+    const auto vpCenter = viewportRect().center();
+    renderModel(newScale, viewportToModel(vpCenter), vpCenter);
     return Scale;
 }
 

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -884,17 +884,6 @@ double Schematic::zoomAroundPoint(double offeredScaleChange, const int zpx, cons
 }
 
 // -----------------------------------------------------------
-float Schematic::zoom(float s)
-{
-    // Change scale and position view so that model's top-left
-    // corner is displayed in the viewport's top-left corner
-
-    const double newScale = Scale * s;
-    renderModel(newScale, modelRect().topLeft(), viewportRect().topLeft());
-    return Scale;
-}
-
-// -----------------------------------------------------------
 float Schematic::zoomBy(float s)
 {
     // Change scale and keep the point displayed in the center

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -2630,3 +2630,65 @@ bool Schematic::checkDplAndDatNames()
     }
     return false;
 }
+
+QRect Schematic::modelRect()
+{
+    return QRect{ViewX1, ViewY1, ViewX2 - ViewX1, ViewY2 - ViewY1};
+}
+
+QRect Schematic::viewportRect() {
+    return QRect{0, 0, viewport()->width(), viewport()->height()};
+}
+
+QPoint Schematic::viewportToModel(QPoint viewportCoordinates)
+{
+    viewportCoordinates.setX(contentsX() + viewportCoordinates.x());
+    viewportCoordinates.setY(contentsY() + viewportCoordinates.y());
+    return viewToModel(viewportCoordinates);
+}
+
+QPoint Schematic::viewToModel(const QPoint& coordinates)
+{
+    // Sizes in the model and view planes are interconnected and obey the rule:
+    //     <size in model plane> * <Scale> = <size in view plane>
+    //
+    // View plane is a rectangle with (0, 0) at its top-left corner. Model plane
+    // is rectangular area of abstract infinite plane, so model plane's top-left
+    // corner may have any coordinates.
+    //
+    // To transform coordinates of a point on the view plane to coordinates
+    // of corresponding point on model plane:
+    // 1. Adjust "view" coordinates so that they become having the same scale
+    //    the model plane has
+    // 2. Adjust resulting coordinates so they become absolute coordinates
+    //    in model plane
+
+    // QPoint overrides operator /. It divides both coordinates on given value
+    QPoint modelCoords = coordinates / Scale;
+
+    modelCoords.setX(ViewX1 + modelCoords.x());
+    modelCoords.setY(ViewY1 + modelCoords.y());
+    return modelCoords;
+}
+
+QPoint Schematic::modelToView(const QPoint& coordinates)
+{
+    // Sizes in the model and view planes are interconnected and obey the rule:
+    //     <size in model plane> * <Scale> = <size in view plane>
+    //
+    // View plane is a rectangle with (0, 0) at its top-left corner. Model plane
+    // is rectangular area of abstract infinite plane, so model plane's top-left
+    // corner may have any coordinates.
+    //
+    // To transform coordinates of a point on the model plane to coordinates
+    // of corresponding point on the view plane:
+    // 1. Adjust coordinates so that they become relative to model planes'
+    //    top-left corner
+    // 2. Adjust resulting coordinates so thay they become having the same scale
+    //    as view plane
+
+    QPoint viewCoords{coordinates.x() - ViewX1, coordinates.y() - ViewY1};
+    viewCoords *= Scale;
+    return viewCoords;
+}
+

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -886,22 +886,11 @@ double Schematic::zoomAroundPoint(double offeredScaleChange, const int zpx, cons
 // -----------------------------------------------------------
 float Schematic::zoom(float s)
 {
-    Scale *= s;
-    if (Scale > 10.0)
-        Scale = 10.0f;
-    if (Scale < 0.1)
-        Scale = 0.1f;
+    // Change scale and position view so that model's top-left
+    // corner is displayed in the viewport's top-left corner
 
-    // "resizeContents()" performs an immediate repaint. So, set widget
-    // to hidden. This causes some flicker, but it is still nicer.
-    viewport()->setHidden(true);
-    //  setHidden(true);
-    resizeContents(int(Scale * float(ViewX2 - ViewX1)), int(Scale * float(ViewY2 - ViewY1)));
-    //  setHidden(false);
-    viewport()->setHidden(false);
-
-    viewport()->update();
-    App->view->drawn = false;
+    const double newScale = Scale * s;
+    renderModel(newScale, modelRect().topLeft(), viewportRect().topLeft());
     return Scale;
 }
 

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1726,17 +1726,7 @@ bool Schematic::load()
     // have to call this to avoid crash at sizeOfAll
     becomeCurrent(false);
 
-    sizeOfAll(UsedX1, UsedY1, UsedX2, UsedY2);
-    if (ViewX1 > UsedX1)
-        ViewX1 = UsedX1;
-    if (ViewY1 > UsedY1)
-        ViewY1 = UsedY1;
-    if (ViewX2 < UsedX2)
-        ViewX2 = UsedX2;
-    if (ViewY2 < UsedY2)
-        ViewY2 = UsedY2;
-    zoom(1.0f);
-    setContentsPos(tmpViewX1, tmpViewY1);
+    showAll();
     tmpViewX1 = tmpViewY1 = -200; // was used as temporary cache
     return true;
 }

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -175,7 +175,6 @@ public:
   // of a smallest rectangle which can fit all elements of the schematic.
   // This rectangle exists in the same coordinate system as View*-rectangle
   int UsedX1, UsedY1, UsedX2, UsedY2;
-  int zx1, zy1, zx2, zy2, dx, dy = 0;
 
   int showFrame;
   QString Frame_Text0, Frame_Text1, Frame_Text2, Frame_Text3;

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -100,8 +100,6 @@ public:
   void  setOnGrid(int&, int&);
   bool  elementsOnGrid();
 
-  float zoom(float);
-
   /**
     Zoom around a "zooming center". Zooming center is a point on the canvas,
     which doesn't move relative to a viewport while canvas is being zoomed in or out.

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -163,16 +163,12 @@ public:
   int GridX, GridY;
 
   // Variables View* are the coordinates of top-level and bottom-right corners
-  // of a rectangle representing the schematic document as a whole. This
+  // of a rectangle representing the schematic "model". This
   // rectangle may grow and shrink when user scrolls the view, and its
   // coordinates change accordingly. Everything (elements, wires, etc.) lies
   // inside this rectangle. The size of this rectangle is the "logical" size
-  // of the schematic.
-  // Schematic is displayed to user in some scale: its "logical" size
-  // is multiplied by scale factor, and the result describes the size of a
-  // canvas required to draw the schematic in chosen scale. Every element of
-  // the schematic is drawn in the same scale on this canvas. That's the way
-  // "zooming" works.
+  // of the schematic. The comment in "renderModel" method describes how
+  // these variables ("model") is used to draw the scematic.
   int ViewX1, ViewY1, ViewX2, ViewY2;
 
   // Variables Used* hold the coordinates of top-left and bottom-right corners
@@ -317,6 +313,65 @@ private:
     @return a corresponding point on the view plane
   */
   QPoint modelToView(const QPoint& modelCoordinates);
+
+  /**
+    If given value violates lower or upper scale limit, then returns
+    the limit value, original value otherwise.
+  */
+  static double clipScale(double);
+
+  /**
+    Tells whether the model should be rerendered. Model should be rendered
+    if the given scale differs from the current one or if the point displayed
+    at \a viewportCoords in the viewport differs from the point \a modelCoords.
+    Otherwise there is no changes and no need to rerender.
+
+    @param scale desired scale
+    @param newModelBounds a rectangle describing the desired model bounds
+    @param modelCoords coordinates of a point on the model plane
+    @param viewportCoords coordinates of a point in the viewport.
+  */
+  bool shouldRender(const double& scale, const QRect& newModelBounds, const QPoint& modelCoords, const QPoint& viewportCoords);
+
+  /**
+    Renders schematic model on Q3ScrollView's contents at a given scale,
+    and positions the contents so that the point \a modelPlaneCoords of the
+    model is displayed at location \a viewportCoords of the viewport.
+
+    There is no need to call "update" on Q3ScrollView after using this method.
+    It is done as a part of rendering process.
+
+    @param  scale            desired new scale. It is clipped when exceeds
+                             a lower or upperlimit
+    @param  newModelBounds   a rectangle describing the desired model bounds
+    @param  modelPlaneCoords coordinates of a point somewhere within
+                             \a newModelBounds
+    @param  viewportCoords   coordinates of the point on the viewport where
+                             \a modelPlaneCoords should be placed after rendering
+    @return new scale value
+  */
+  double renderModel(double scale, QRect newModelBounds, QPoint modelPlaneCoords, QPoint viewportCoords);
+
+  /**
+    Render the model without changing its size and position the contents
+    so that the center of the model is displayed at center of the viewport.
+
+    @param scale desired new scale. It is clipped if exceeds bounds.
+    @return new scale value
+  */
+  double renderModel(double scale);
+
+  /**
+    Render the model without changing its size and position the contents so that
+    the point \a modelPlaneCoords of the model is displayed at location \a
+    viewportCoords of the viewport.
+
+    @param scale desired new scale. It is clipped if exceeds limits
+    @param modelPlaneCoords coordinates of the point on the model plane
+    @param viewportCoords coordinates of the point on the viewport
+    @return new scale value
+  */
+  double renderModel(double scale, QPoint modelPlaneCoords, QPoint viewportCoords);
 
 /* ********************************************************************
    *****  The following methods are in the file                   *****

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -282,6 +282,42 @@ private:
   */
   static constexpr double maxScale = 10.0;
 
+  /**
+    Returns a rectangle which describes the model plane of the schematic.
+    The rectangle is a copy, changes made to it do not affect schematic state.
+  */
+  QRect modelRect();
+
+  /**
+    Returns a rectangle which describes the viewport. Top-left corner is (0,0),
+    width and height are equal to viewport's width and height.
+  */
+  QRect viewportRect();
+
+  /**
+    Given a coordinates of viewport point returns coordinates of the model plane point
+    displayed at given location of the viewport.
+  */
+  QPoint viewportToModel(QPoint viewportCoordinates);
+
+  /**
+    Given coordinates of a point on the view plane (schematic's canvas), this method
+    returns coordinates of a corresponding point on the model plane.
+
+    @param viewCoordinates a point on the view plane
+    @return a corresponding point on the model plane
+  */
+  QPoint viewToModel(const QPoint& viewCoordinates);
+
+  /**
+    Given coordinates of a point on the model plane, this method returns coordinates
+    of a corresponding point on the view plane (schematic's canvas).
+
+    @param modelCoordinates a point on the model plane
+    @return a corresponding point on the view plane
+  */
+  QPoint modelToView(const QPoint& modelCoordinates);
+
 /* ********************************************************************
    *****  The following methods are in the file                   *****
    *****  "schematic_element.cpp". They only access the QPtrList  *****

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -139,7 +139,7 @@ public:
   bool    undo();
   bool    redo();
 
-  bool scrollUp(int);
+  void scrollUp(int);
   void scrollDown(int);
   void scrollLeft(int);
   void scrollRight(int);

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -140,7 +140,7 @@ public:
   bool    redo();
 
   bool scrollUp(int);
-  bool scrollDown(int);
+  void scrollDown(int);
   void scrollLeft(int);
   void scrollRight(int);
 

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -142,7 +142,7 @@ public:
   bool scrollUp(int);
   bool scrollDown(int);
   void scrollLeft(int);
-  bool scrollRight(int);
+  void scrollRight(int);
 
   bool checkDplAndDatNames();
 

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -141,7 +141,7 @@ public:
 
   bool scrollUp(int);
   bool scrollDown(int);
-  bool scrollLeft(int);
+  void scrollLeft(int);
   bool scrollRight(int);
 
   bool checkDplAndDatNames();

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -102,19 +102,25 @@ public:
 
   /**
     Zoom around a "zooming center". Zooming center is a point on the canvas,
-    which doesn't move relative to a viewport while canvas is being zoomed in or out.
+    which doesn't move relative to a viewport while canvas is being zoomed in or
+    out.
 
-    This produces the effect of "concentrating" on a zooming center: with each zoom-in step
-    one would get closer and closer to the point, while point's surroundings would go "out of sight",
-    beyound the viewport's borders.
+    This produces the effect of "concentrating" on a zooming center: with each
+    zoom-in step one would get closer and closer to the point, while point's
+    surroundings would go "out of sight", beyound the viewport's borders.
 
-    Zooming out works in backwards order: everything is like being "sucked into" the zooming center.
+    Zooming out works in backwards order: everything is like being "sucked into"
+    the zooming center.
 
-    @param scaleChange  a multiplier for a current scale value.
-    @param zpx          x coordinate of zooming center, relative to viewport's top-left corner
-    @param zpy          y coordinate of zooming center, relative to viewport's top-left corner
+    If param \c viewportRelative is \c true then the given coordinates are
+    treated as relative to the viewport top-left corner. Otherwise they're
+    considered to be absolute i.e. relative to canvas top-left corner.
+
+    @param scaleChange       a multiplier for a current scale value
+    @param coords            coordinates of the "zooming center"
+    @param viewportRelative  tells if coordinates are absolute or relative to viewport
   */
-  double zoomAroundPoint(double scaleChange, const int zpx, const int zpy);
+  void zoomAroundPoint(double scaleChange, QPoint coords, bool viewportRelative);
   float zoomBy(float);
   void  showAll();
   void zoomToSelection();
@@ -225,45 +231,6 @@ private:
   bool dragIsOkay;
   /*! \brief hold system-independent information about a schematic file */
   QFileInfo FileInfo;
-
-  /**
-    Enlarge canvas by "moving" its top side up. Schematic::ViewY1 is updated accordingly.
-
-    @param d  number of size points (pixels) to add to canvas size. Must be non-negative.
-  */
-  void growUp(const int d);
-
-  /**
-    Enlarge canvas by "moving" its bottom side down. Schematic::ViewY2 is updated accordingly.
-
-    @param d  number of size points (pixels) to add to canvas size. Must be non-negative.
-  */
-  void growDown(const int d);
-
-  /**
-    Enlarge canvas by "moving" its left side to the left. Schematic::ViewX1 is updated accordingly.
-
-    @param d  number of size points (pixels) to add to canvas size. Must be non-negative.
-  */
-  void growLeft(const int d);
-
-  /**
-    Enlarge canvas by "moving" its right side to the right. Schematic::ViewX2 is updated accordingly.
-
-    @param d  number of size points (pixels) to add to canvas size. Must be non-negative.
-  */
-  void growRight(const int d);
-
-  /**
-    Redraw schematic at given scale.
-
-    If \a newScale is larger than Schematic::maxScale then Schematic::maxScale becomes new scale.
-    If \a newScale is less than Schematic::minScale then Schematic::minScale becomes new scale.
-
-    @param newScale   a desired scale for schematic to be drawn in
-    @return relative scale change, i.e. \c newScale/oldScale
-    */
-  double scale(const double newScale);
 
   /**
     Minimum scale at which schematic could be drawn.


### PR DESCRIPTION
Hi @ra3xdh

Finally I can present it :)

As you've probably seen the schematic's zooming and scrolling logic is quite convoluted and scattered across a bunch of methods. This is an attempt to refactor it and make it more streamlined and simple. 

First two commits lay the foundation for zooming, scrolling, resizing, etc. by introducing a _conceptual model_ of rendering (something alike to MVC) and a _declarative approach_ to do it. Other commits just switch already known actions to using new rendering approach.

The _conceptual model_ is the following: every schematic element "exists" in some abstract cartesian coordinate system, a rectangular area of this system which encloses the elements is a _model_. A widget canvas on which schematic is drawn is the _view_. And the `renderModel` method is the _controller_ – size and position calculations are confined within this method.

The _declarative approach_ enables to describe a model bounds, a point within the model and where to draw it on a screen, pass this parameters to renderer and see the result.

These two ideas allow to get rid of cryptic code to compute new size and position.

While changes are mostly internal, users will also see some differences if this PR is merged:
1. "Zoom In" tool follows the click, like when zooming using Ctrl and mouse wheel
2. "Show all" positions the view so that schematic center is shown at viewport center
3. "Zoom to selection" positions the view so that the center of selected elements bounding rectangle is shown at viewport center
4. "Show 1:1": keeps the point in the viewport center stable while changing scale if the point is within a schematic bounding rectangle. Otherwise it centers the view on schematic's center. 