### PR TITLE
Fix zero-size elements selection

### DIFF
--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -22,6 +22,32 @@
 #include <QDebug>
 
 
+/**
+    Given an element bounding rectangle and selection rectangle tells
+    whether the element should be marked as "selected".
+
+    If \c entirely param is \c false then an element is "selected"
+    if its bounding rectangle intersect with selection rectangle.
+    Otherwise the element must lie entirely within the selection
+    rectangle.
+*/
+static bool shouldBeSelected(const QRect& elementBoundingRect, const QRect& selectionRect, bool entirely)
+{
+    // QRect.contains() and QRect.intersects() always return false
+    // for empty rectangles. Thus an element with zero size can't be
+    // selected. To overcome this, lets treat it like a point, not
+    // as a rectangle (empty rectangle has all its corners in one spot)
+    if (elementBoundingRect.isNull()) {
+        return selectionRect.contains(elementBoundingRect.topLeft());
+    }
+
+    if (entirely) {
+        return selectionRect.contains(elementBoundingRect);
+    } else {
+        return selectionRect.intersects(elementBoundingRect);
+    }
+}
+
 /* *******************************************************************
    *****                                                         *****
    *****              Actions handling the nodes                 *****
@@ -1496,8 +1522,7 @@ int Schematic::selectElements(int x1, int y1, int x2, int y2, bool append, bool 
     for (Component *pc = Components->first(); pc != nullptr; pc = Components->next()) {
         pc->Bounding(cx1, cy1, cx2, cy2);
         QRect componentRect(cx1, cy1, cx2 - cx1, cy2 - cy1);
-        if ((entirely && selectionRect.contains(componentRect)) ||
-            (!entirely && selectionRect.intersects(componentRect))) {
+        if (shouldBeSelected(componentRect, selectionRect, entirely)) {
             pc->isSelected = true;
             z++;
             continue;
@@ -1510,8 +1535,7 @@ int Schematic::selectElements(int x1, int y1, int x2, int y2, bool append, bool 
     for (pw = Wires->first(); pw != nullptr; pw = Wires->next())   // test all wires
     {
         QRect componentRect(pw->x1, pw->y1, pw->x2 - pw->x1, pw->y2 - pw->y1);
-        if ((entirely && selectionRect.contains(componentRect)) ||
-            (!entirely && selectionRect.intersects(componentRect))) {
+        if (shouldBeSelected(componentRect, selectionRect, entirely)) {
             pw->isSelected = true;
             z++;
             continue;
@@ -1526,8 +1550,7 @@ int Schematic::selectElements(int x1, int y1, int x2, int y2, bool append, bool 
         if (pw->Label) {
             pl = pw->Label;
             QRect componentRect(pl->x1, pl->y1, pl->x2 - pl->x1, pl->y2 - pl->y1);
-            if ((entirely && selectionRect.contains(componentRect)) ||
-                (!entirely && selectionRect.intersects(componentRect))) {
+            if (shouldBeSelected(componentRect, selectionRect, entirely)) {
                 pl->isSelected = true;
                 z++;
                 continue;
@@ -1542,8 +1565,7 @@ int Schematic::selectElements(int x1, int y1, int x2, int y2, bool append, bool 
         pl = pn->Label;
         if (pl) {
             QRect componentRect(pl->x1, pl->y1, pl->x2 - pl->x1, pl->y2 - pl->y1);
-            if ((entirely && selectionRect.contains(componentRect)) ||
-                (!entirely && selectionRect.intersects(componentRect))) {
+            if (shouldBeSelected(componentRect, selectionRect, entirely)) {
                 pl->isSelected = true;
                 z++;
                 continue;
@@ -1563,8 +1585,7 @@ int Schematic::selectElements(int x1, int y1, int x2, int y2, bool append, bool 
             for (Marker *pm: pg->Markers) {
                 pm->Bounding(cx1, cy1, cx2, cy2);
                 QRect componentRect(cx1, cy1, cx2 - cx1, cy2 - cy1);
-                if ((entirely && selectionRect.contains(componentRect)) ||
-                    (!entirely && selectionRect.intersects(componentRect))) {
+                if (shouldBeSelected(componentRect, selectionRect, entirely)) {
                     pm->isSelected = true;
                     z++;
                     continue;
@@ -1576,8 +1597,7 @@ int Schematic::selectElements(int x1, int y1, int x2, int y2, bool append, bool 
         // test diagram itself
         pd->Bounding(cx1, cy1, cx2, cy2);
         QRect componentRect(cx1, cy1, cx2 - cx1, cy2 - cy1);
-        if ((entirely && selectionRect.contains(componentRect)) ||
-            (!entirely && selectionRect.intersects(componentRect))) {
+        if (shouldBeSelected(componentRect, selectionRect, entirely)) {
             pd->isSelected = true;
             z++;
             continue;
@@ -1589,8 +1609,7 @@ int Schematic::selectElements(int x1, int y1, int x2, int y2, bool append, bool 
     for (Painting *pp = Paintings->first(); pp != 0; pp = Paintings->next()) {
         pp->Bounding(cx1, cy1, cx2, cy2);
         QRect componentRect(cx1, cy1, cx2 - cx1, cy2 - cy1);
-        if ((entirely && selectionRect.contains(componentRect)) ||
-            (!entirely && selectionRect.intersects(componentRect))) {
+        if (shouldBeSelected(componentRect, selectionRect, entirely)) {
             pp->isSelected = true;
             z++;
             continue;


### PR DESCRIPTION
Rewrite element selection logic in a way that allows to select "invisible" zero-size elements.

Fixes ra3xdh/qucs_s#437