### PR TITLE
Fix: select-all does not select wires on the boundary

### DIFF
--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -643,6 +643,10 @@ void QucsApp::slotSelectAll()
   else {
     int xmin, ymin, xmax, ymax;
     ((Schematic*)Doc)->sizeOfAll(xmin, ymin, xmax, ymax);
+    xmin--;
+    ymin--;
+    xmax++;
+    ymax++;
     ((Schematic*)Doc)->selectElements(xmin, ymin, xmax, ymax, true, false);
     ((Schematic*)Doc)->viewport()->update();
     view->drawn = false;


### PR DESCRIPTION
When the wire is on the boundary of content, use method "QRect::contains" will not select linear element on the boundary. Expand the area of "sizeOfAll" to fix it.

![IMG_20240113_201812](https://github.com/ra3xdh/qucs_s/assets/104050808/84cd9aac-c60b-4c23-8965-ca957449b93b)
