### PR TITLE
Fix remaining dialogs with parent=0 or no parent

### DIFF
--- a/qucs/extsimkernels/externsimdialog.cpp
+++ b/qucs/extsimkernels/externsimdialog.cpp
@@ -24,8 +24,8 @@
 #include "main.h"
 #include "qucs.h"
 
-ExternSimDialog::ExternSimDialog(Schematic *sch, QWidget *parent, bool netlist_mode) :
-    QDialog(parent)
+ExternSimDialog::ExternSimDialog(Schematic *sch, bool netlist_mode) :
+    QDialog(sch)
 {
     Sch = sch;
     wasSimulated = false;

--- a/qucs/extsimkernels/externsimdialog.h
+++ b/qucs/extsimkernels/externsimdialog.h
@@ -47,7 +47,7 @@ private:
     Xyce *xyce;
 
 public:
-    explicit ExternSimDialog(Schematic *sch, QWidget *parent = 0,
+    explicit ExternSimDialog(Schematic *sch,
                              bool netlist_mode = false);
     ~ExternSimDialog();
 

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1396,7 +1396,7 @@ void MouseActions::MPressElement(Schematic *Doc, QMouseEvent *Event, float, floa
     } // of "if(isDiagram)"
 
     // ***********  it is a painting !!!
-    if (((Painting *) selElem)->MousePressing()) {
+    if (((Painting *) selElem)->MousePressing(Doc)) {
         Doc->Paintings->append((Painting *) selElem);
         ((Painting *) selElem)->Bounding(x1, y1, x2, y2);
         //Doc->enlargeView(x1, y1, x2, y2);
@@ -2091,7 +2091,7 @@ void MouseActions::editElement(Schematic *Doc, QMouseEvent *Event)
         break;
 
     case isPainting:
-        if (((Painting *) focusElement)->Dialog())
+        if (((Painting *) focusElement)->Dialog(Doc))
             Doc->setChanged(true, true);
         break;
 

--- a/qucs/paintings/arrow.cpp
+++ b/qucs/paintings/arrow.cpp
@@ -318,8 +318,9 @@ void Arrow::MouseMoving(
 }
 
 // --------------------------------------------------------------------------
-bool Arrow::MousePressing()
+bool Arrow::MousePressing(Schematic *sch)
 {
+  Q_UNUSED(sch)
   State++;
   if(State > 2) {
     x1 = y1 = 0;
@@ -491,11 +492,11 @@ void Arrow::mirrorY()
 // --------------------------------------------------------------------------
 // Calls the property dialog for the painting and changes them accordingly.
 // If there were changes, it returns 'true'.
-bool Arrow::Dialog()
+bool Arrow::Dialog(QWidget *parent)
 {
   bool changed = false;
 
-  ArrowDialog *d = new ArrowDialog();
+  ArrowDialog *d = new ArrowDialog(parent);
   d->HeadWidth->setText(QString::number(Width));
   d->HeadLength->setText(QString::number(Height));
 

--- a/qucs/paintings/arrow.h
+++ b/qucs/paintings/arrow.h
@@ -40,7 +40,7 @@ public:
   QString saveCpp();
   QString saveJSON();
   void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int, bool);
-  bool MousePressing();
+  bool MousePressing(Schematic *sch = 0);
   bool getSelected(float, float, float);
   void Bounding(int&, int&, int&, int&);
   bool resizeTouched(float, float, float);
@@ -49,7 +49,7 @@ public:
   void rotate(int, int);
   void mirrorX();
   void mirrorY();
-  bool Dialog();
+  bool Dialog(QWidget *parent = 0);
 
   void calcArrowHead();
 

--- a/qucs/paintings/ellipse.cpp
+++ b/qucs/paintings/ellipse.cpp
@@ -291,8 +291,9 @@ void qucs::Ellipse::MouseMoving(
 }
 
 // --------------------------------------------------------------------------
-bool qucs::Ellipse::MousePressing()
+bool qucs::Ellipse::MousePressing(Schematic *sch)
 {
+  Q_UNUSED(sch)
   State++;
   if(State == 1) {
     x1 = x2;
@@ -379,11 +380,11 @@ void qucs::Ellipse::mirrorY()
 // --------------------------------------------------------------------------
 // Calls the property dialog for the painting and changes them accordingly.
 // If there were changes, it returns 'true'.
-bool qucs::Ellipse::Dialog()
+bool qucs::Ellipse::Dialog(QWidget *parent)
 {
   bool changed = false;
 
-  FillDialog *d = new FillDialog(QObject::tr("Edit Ellipse Properties"));
+  FillDialog *d = new FillDialog(QObject::tr("Edit Ellipse Properties"), true, parent);
   misc::setPickerColor(d->ColorButt,Pen.color());
   d->LineWidth->setText(QString::number(Pen.width()));
   d->StyleBox->setCurrentIndex(Pen.style()-1);

--- a/qucs/paintings/ellipse.h
+++ b/qucs/paintings/ellipse.h
@@ -42,7 +42,7 @@ public:
   QString saveJSON();
   void paint(ViewPainter*);
   void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int, bool);
-  bool MousePressing();
+  bool MousePressing(Schematic *sch = 0);
   bool getSelected(float, float, float);
   bool resizeTouched(float, float, float);
   void MouseResizeMoving(int, int, Schematic*);
@@ -50,7 +50,7 @@ public:
   void rotate(int, int);
   void mirrorX();
   void mirrorY();
-  bool Dialog();
+  bool Dialog(QWidget *parent = 0);
 
   QPen  Pen;
   QBrush Brush;    // filling style/color

--- a/qucs/paintings/ellipsearc.cpp
+++ b/qucs/paintings/ellipsearc.cpp
@@ -298,8 +298,9 @@ void EllipseArc::MouseMoving(
 }
 
 // --------------------------------------------------------------------------
-bool EllipseArc::MousePressing()
+bool EllipseArc::MousePressing(Schematic *sch)
 {
+  Q_UNUSED(sch)
   State++;
   switch(State) {
     case 1 :
@@ -394,11 +395,11 @@ void EllipseArc::mirrorY()
 // --------------------------------------------------------------------------
 // Calls the property dialog for the painting and changes them accordingly.
 // If there were changes, it returns 'true'.
-bool EllipseArc::Dialog()
+bool EllipseArc::Dialog(QWidget *parent)
 {
   bool changed = false;
 
-  FillDialog *d = new FillDialog(QObject::tr("Edit Arc Properties"), false);
+  FillDialog *d = new FillDialog(QObject::tr("Edit Arc Properties"), false, parent);
   misc::setPickerColor(d->ColorButt,Pen.color());
   d->LineWidth->setText(QString::number(Pen.width()));
   d->StyleBox->setCurrentIndex(Pen.style()-1);

--- a/qucs/paintings/ellipsearc.h
+++ b/qucs/paintings/ellipsearc.h
@@ -40,7 +40,7 @@ public:
   QString saveJSON();
   void paint(ViewPainter*);
   void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int, bool);
-  bool MousePressing();
+  bool MousePressing(Schematic *sch = 0);
   bool getSelected(float, float, float);
   bool resizeTouched(float, float, float);
   void MouseResizeMoving(int, int, Schematic*);
@@ -48,7 +48,7 @@ public:
   void rotate(int, int);
   void mirrorX();
   void mirrorY();
-  bool Dialog();
+  bool Dialog(QWidget *parent = 0);
 
   QPen  Pen;
   int   Angle, ArcLen;   // start angle and arc length

--- a/qucs/paintings/graphicline.cpp
+++ b/qucs/paintings/graphicline.cpp
@@ -231,8 +231,9 @@ void GraphicLine::MouseMoving(
 }
 
 // --------------------------------------------------------------------------
-bool GraphicLine::MousePressing()
+bool GraphicLine::MousePressing(Schematic *sch)
 {
+  Q_UNUSED(sch)
   State++;
   if(State > 2) {
     x1 = y1 = 0;
@@ -331,11 +332,11 @@ void GraphicLine::mirrorY()
 // --------------------------------------------------------------------------
 // Calls the property dialog for the painting and changes them accordingly.
 // If there were changes, it returns 'true'.
-bool GraphicLine::Dialog()
+bool GraphicLine::Dialog(QWidget *parent)
 {
   bool changed = false;
 
-  FillDialog *d = new FillDialog(QObject::tr("Edit Line Properties"), false);
+  FillDialog *d = new FillDialog(QObject::tr("Edit Line Properties"), false, parent);
   misc::setPickerColor(d->ColorButt,Pen.color());
   d->LineWidth->setText(QString::number(Pen.width()));
   d->StyleBox->setCurrentIndex(Pen.style()-1);

--- a/qucs/paintings/graphicline.h
+++ b/qucs/paintings/graphicline.h
@@ -41,7 +41,7 @@ public:
   QString saveJSON();
   void paint(ViewPainter*);
   void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int, bool);
-  bool MousePressing();
+  bool MousePressing(Schematic *sch = 0);
   bool getSelected(float, float, float);
   void Bounding(int&, int&, int&, int&);
   bool resizeTouched(float, float, float);
@@ -50,7 +50,7 @@ public:
   void rotate(int, int);
   void mirrorX();
   void mirrorY();
-  bool Dialog();
+  bool Dialog(QWidget *parent = 0);
 
   QPen   Pen;
 };

--- a/qucs/paintings/graphictext.cpp
+++ b/qucs/paintings/graphictext.cpp
@@ -258,9 +258,9 @@ void GraphicText::MouseMoving(
 }
 
 // ------------------------------------------------------------------------
-bool GraphicText::MousePressing()
+bool GraphicText::MousePressing(Schematic *sch)
 {
-    return Dialog();
+    return Dialog(sch);
 }
 
 // ------------------------------------------------------------------------
@@ -373,12 +373,12 @@ void GraphicText::mirrorY()
 // -----------------------------------------------------------------------
 // Calls the property dialog for the painting and changes them accordingly.
 // If there were changes, it returns 'true'.
-bool GraphicText::Dialog()
+bool GraphicText::Dialog(QWidget *parent)
 {
     QFont f(QucsSettings.font); // to avoid wrong text width
     bool changed = false;
 
-    GraphicTextDialog *d = new GraphicTextDialog();
+    GraphicTextDialog *d = new GraphicTextDialog(parent);
 
     QPalette palette;
     palette.setColor(d->ColorButt->backgroundRole(), Color);

--- a/qucs/paintings/graphictext.h
+++ b/qucs/paintings/graphictext.h
@@ -42,14 +42,14 @@ public:
   QString saveJSON();
   void paint(ViewPainter*);
   void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int, bool);
-  bool MousePressing();
+  bool MousePressing(Schematic *sch = 0);
   bool getSelected(float, float, float);
   void Bounding(int&, int&, int&, int&);
 
   void rotate(int, int);
   void mirrorX();
   void mirrorY();
-  bool Dialog();
+  bool Dialog(QWidget *parent = 0);
 
   QColor   Color;
   QFont    Font;

--- a/qucs/paintings/id_dialog.cpp
+++ b/qucs/paintings/id_dialog.cpp
@@ -32,7 +32,8 @@
 #include <QMessageBox>
 
 
-ID_Dialog::ID_Dialog(ID_Text *idText_)
+ID_Dialog::ID_Dialog(ID_Text *idText_, QWidget *parent)
+    : QDialog(parent)
 {
   idText = idText_;
   setWindowTitle(tr("Edit Subcircuit Properties"));

--- a/qucs/paintings/id_dialog.h
+++ b/qucs/paintings/id_dialog.h
@@ -39,7 +39,7 @@ class QRegExpValidator;
 class ID_Dialog : public QDialog  {
 Q_OBJECT
 public:
-  ID_Dialog(ID_Text*);
+  ID_Dialog(ID_Text*, QWidget *parent = 0);
  ~ID_Dialog();
 
 private:

--- a/qucs/paintings/id_text.cpp
+++ b/qucs/paintings/id_text.cpp
@@ -187,9 +187,9 @@ void ID_Text::mirrorY()
 // --------------------------------------------------------------------------
 // Calls the property dialog for the painting and changes them accordingly.
 // If there were changes, it returns 'true'.
-bool ID_Text::Dialog()
+bool ID_Text::Dialog(QWidget *parent)
 {
-  ID_Dialog *d = new ID_Dialog(this);
+  ID_Dialog *d = new ID_Dialog(this, parent);
   if(d->exec() == QDialog::Rejected) {
     delete d;
     return false;

--- a/qucs/paintings/id_text.h
+++ b/qucs/paintings/id_text.h
@@ -54,7 +54,7 @@ public:
   void rotate(int, int);
   void mirrorX();
   void mirrorY();
-  bool Dialog();
+  bool Dialog(QWidget *parent = 0);
 
   QString Prefix;
   QList<SubParameter *> Parameter;

--- a/qucs/paintings/painting.h
+++ b/qucs/paintings/painting.h
@@ -38,7 +38,7 @@ public:
   virtual void paint(ViewPainter*) {};
   virtual void MouseMoving(Schematic*, int, int, int, int,
                            Schematic*, int, int, bool) {};
-  virtual bool MousePressing() { return false; };
+  virtual bool MousePressing(Schematic *sch = 0) { Q_UNUSED(sch) return false; };
   virtual void Bounding(int&, int&, int&, int&);
   virtual bool resizeTouched(float, float, float) { return false; };
   virtual void MouseResizeMoving(int, int, Schematic*) {};
@@ -46,7 +46,7 @@ public:
   virtual void rotate(int, int) {};
   virtual void mirrorX() {};
   virtual void mirrorY() {};
-  virtual bool Dialog() { return false; };
+  virtual bool Dialog(QWidget *parent = 0) { Q_UNUSED(parent) return false; };
 
   QString toPenString (int);
   QString toBrushString (int);

--- a/qucs/paintings/rectangle.cpp
+++ b/qucs/paintings/rectangle.cpp
@@ -292,8 +292,9 @@ void qucs::Rectangle::MouseMoving(
 }
 
 // --------------------------------------------------------------------------
-bool qucs::Rectangle::MousePressing()
+bool qucs::Rectangle::MousePressing(Schematic *sch)
 {
+  Q_UNUSED(sch)
   State++;
   if(State == 1) {
     x1 = x2;
@@ -380,11 +381,11 @@ void qucs::Rectangle::mirrorY()
 // --------------------------------------------------------------------------
 // Calls the property dialog for the painting and changes them accordingly.
 // If there were changes, it returns 'true'.
-bool qucs::Rectangle::Dialog()
+bool qucs::Rectangle::Dialog(QWidget *parent)
 {
   bool changed = false;
 
-  FillDialog *d = new FillDialog(QObject::tr("Edit Rectangle Properties"));
+  FillDialog *d = new FillDialog(QObject::tr("Edit Rectangle Properties"), true, parent);
   misc::setPickerColor(d->ColorButt,Pen.color());
   d->LineWidth->setText(QString::number(Pen.width()));
   d->StyleBox->setCurrentIndex(Pen.style()-1);

--- a/qucs/paintings/rectangle.h
+++ b/qucs/paintings/rectangle.h
@@ -42,7 +42,7 @@ public:
   QString saveJSON();
   void paint(ViewPainter*);
   void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int, bool);
-  bool MousePressing();
+  bool MousePressing(Schematic *sch = 0);
   bool getSelected(float, float, float);
   bool resizeTouched(float, float, float);
   void MouseResizeMoving(int, int, Schematic*);
@@ -50,7 +50,7 @@ public:
   void rotate(int, int);
   void mirrorX();
   void mirrorY();
-  bool Dialog();
+  bool Dialog(QWidget *parent = 0);
 
   QPen  Pen;
   QBrush Brush;    // filling style/color

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -3417,7 +3417,7 @@ void QucsApp::slotSaveNetlist()
     }
     if (!isTextDocument(DocumentTab->currentWidget())) {
         Schematic *sch = (Schematic*)DocumentTab->currentWidget();
-        ExternSimDialog *SimDlg = new ExternSimDialog(sch,this,true);
+        ExternSimDialog *SimDlg = new ExternSimDialog(sch, true);
         SimDlg->slotSaveNetlist();
         delete SimDlg;
     }


### PR DESCRIPTION
In sway tiling window manager these dialogs appear as maximized top-level windows.
Setting the schematic pointer as parent pointer makes them appear as normal floating dialogs.