### PR TITLE
Add "pan with mouse" feature

### DIFF
--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -228,6 +228,10 @@ protected slots:
   void slotScrollRight();
 
 private:
+  // Viewport-realative coordinates of the cursor between mouse movements.
+  // Used in "pan with mouse" feature.
+  QPoint previousCursorPosition;
+
   bool dragIsOkay;
   /*! \brief hold system-independent information about a schematic file */
   QFileInfo FileInfo;


### PR DESCRIPTION
Hello!

If merged this PR would add the ability to scroll schematic by moving mouse with middle button pressed down:
[panning.webm](https://github.com/ra3xdh/qucs_s/assets/40355531/788697ea-4e4e-4447-921c-2138509f8bf6)

It also introduces a change that I'm not quite sure about: I had to delete `setHidden(true)` and `setHidden(false)` before and after `resizeContents` in `renderModel` method because the `Q3ScrollView` contents widget didn't receive MouseMove events after hiding and then unhiding the widget. I haven't observed any differences after removing these lines though. May be they don't make any sense now (they were inherited from legacy implementation) and it's OK to remove them. 