### PR TITLE
Fix assertion fails in 'renderModel'

### DIFF
--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -66,6 +66,19 @@ Q3PtrList<Node> SymbolNodes;
 Q3PtrList<Diagram> SymbolDiags;
 Q3PtrList<Component> SymbolComps;
 
+/**
+    If \c point does not lie within \c rect then returns a new
+    rectangle made by enlarging the source rectangle to include
+    the \c point. Otherwise returns a rectangle of the same size.
+*/
+static QRect includePoint(QRect rect, QPoint point) {
+  if (rect.contains(point)) {
+    return rect;
+  } else {
+    return rect.united(QRect{point, point});
+  }
+}
+
 Schematic::Schematic(QucsApp *App_, const QString &Name_)
     : QucsDoc(App_, Name_)
 {
@@ -75,7 +88,7 @@ Schematic::Schematic(QucsApp *App_, const QString &Name_)
     // ...........................................................
     GridX = GridY = 10;
     ViewX1 = ViewY1 = 0;
-    ViewX2 = ViewY2 = 800;
+    ViewX2 = ViewY2 = 1;
     UsedX1 = UsedY1 = INT_MAX;
     UsedX2 = UsedY2 = INT_MIN;
 
@@ -803,19 +816,12 @@ void Schematic::paintSchToViewpainter(
 void Schematic::zoomAroundPoint(double offeredScaleChange, QPoint coords, bool viewportRelative=true)
 {
     const double desiredScale = Scale * offeredScaleChange;
+    const auto viewportCoords =
+        viewportRelative ? coords : coords - QPoint{contentsX(), contentsY()};
+    const auto focusPoint = viewportToModel(viewportCoords);
+    const auto model = includePoint(modelRect(), focusPoint);
 
-    if (viewportRelative) {
-        // Coordinates are relative to the viewport top-left corner.
-        // Let's find what model point is shown at these coordinates
-        // and show this point at the same spot after scaling.
-        renderModel(desiredScale, viewportToModel(coords), coords);
-    } else {
-        // Coordinates are absolute coordinates, i.e. relative
-        // to canvas' top-left corner, not viewport's top-left.
-        // Let's find viewport relative coordinates of the same point
-        const QPoint vpCoords = coords - QPoint{contentsX(), contentsY()};
-        renderModel(desiredScale, viewportToModel(vpCoords), vpCoords);
-    }
+    renderModel(desiredScale, model, focusPoint, viewportCoords);
 }
 
 // -----------------------------------------------------------
@@ -826,8 +832,10 @@ float Schematic::zoomBy(float s)
 
     const double newScale = Scale * s;
     const auto vpCenter = viewportRect().center();
-    renderModel(newScale, viewportToModel(vpCenter), vpCenter);
-    return Scale;
+    const auto centerPoint = viewportToModel(vpCenter);
+    const auto model = includePoint(modelRect(), centerPoint);
+
+    return renderModel(newScale, model, centerPoint, vpCenter);
 }
 
 // ---------------------------------------------------
@@ -927,7 +935,7 @@ void Schematic::showNoZoom()
                     UsedX2 = UsedY2 = INT_MIN;
                     // If there is no elements in schematic, then just set scale 1.0
                     // at the place we currently in.
-                    renderModel(noScale, displayedInCenter, vpCenter);
+                    renderModel(noScale, includePoint(modelRect(), displayedInCenter), displayedInCenter, vpCenter);
                     return;
                 }
 
@@ -979,6 +987,7 @@ void Schematic::showNoZoom()
 
     const auto vpCenter = viewportRect().center();
     const auto displayedInCenter = viewportToModel(vpCenter);
+    newModel = includePoint(newModel, displayedInCenter);
     renderModel(Scale, newModel, displayedInCenter, vpCenter);
  }
 


### PR DESCRIPTION
This is an attempt to fix #497.

Using the build from this branch I tested the following cases on new empty schematic and also on schematic from a file.
1. Place an element in the middle of the view
2. The same as 1 for every corner
3. Zoom in and zoom out
4. Scroll and pan

I haven't observed any oddities or crashes.