### PR TITLE
Use GHDL instead of FreeHDL for digital simulation [Linux Only]

### DIFF
--- a/converter/parse_vcd.ypp
+++ b/converter/parse_vcd.ypp
@@ -60,7 +60,7 @@
 %token t_DUMPVARS
 
 %token s_MODULE s_TASK s_FUNCTION s_FORK s_BEGIN
-%token ONE B Z ZERO HASHMARK X R TEN HUNDRET
+%token ONE B Z ZERO HASHMARK U R TEN HUNDRET
 
 %token PICO MICRO NANO FEMTO SECOND MILLI
 
@@ -320,7 +320,7 @@ ScalarValueChange:
 Value:
     ZERO  /* low level       */
   | ONE   /* high level      */
-  | X     /* undefined/error */
+  | U     /* undefined/error */
   | Z     /* high impedance  */
 ;
 

--- a/converter/scan_vcd.lpp
+++ b/converter/scan_vcd.lpp
@@ -2,7 +2,7 @@
 
 %{
 /*
- * scan_vcd.l - scanner for a VCD data file
+ * scan_vcd.lpp - scanner for a VCD data file
  *
  * Copyright (C) 2005 Raimund Jacob <raimi@lkcc.org>
  * Copyright (C) 2006, 2007, 2008 Stefan Jahn <stefan@lkcc.org>
@@ -63,9 +63,9 @@ DIGIT    [0-9]
 EXPONENT [Ee][+-]?{DIGIT}+
 INT      [+-]?{DIGIT}+
 REAL     [+-]?{DIGIT}+("."{DIGIT}+)?{EXPONENT}?
-BINARY   [01xXzZ]+
+BINARY   [01uUzZ]+
 DECIMAL  {DIGIT}+
-SCALAR   [01xXzZ]
+SCALAR   [01uUzZ]
 CODE     [!-~]+
 IDENT    [a-zA-Z_][a-zA-Z0-9_.-]*
 
@@ -155,10 +155,10 @@ IDENT    [a-zA-Z_][a-zA-Z0-9_.-]*
   return ZERO;
 }
 
-<INITIAL,DUMP>[xX] {
-  vcd_lval.value = strdup ("X");
+<INITIAL,DUMP>[uU] {
+  vcd_lval.value = strdup ("U");
   BEGIN(CHANGE);
-  return X;
+  return U;
 }
 
 <INITIAL,DUMP>[zZ] {

--- a/qucs/dialogs/simmessage.cpp
+++ b/qucs/dialogs/simmessage.cpp
@@ -397,9 +397,12 @@ void SimMessage::startSimulator()
         libs = "-c,-l" + libs;
       }
 #endif
+      // The following code runs the the qucs_run_hdl[.bat] script which in turn
+      // runs GHDL (three passes with -a -e and -r commands.). Note GHDL expects the
+      // time without spaces, so strip spaces from SimTime.
       Program = pathName(QucsSettings.BinDir + QucsDigi);
       Arguments  << QucsSettings.QucsHomeDir.filePath("netlist.txt")
-                 << DataSet << SimTime << pathName(SimPath)
+                 << DataSet << SimTime.remove(" ") << pathName(SimPath)
                  << pathName(QucsSettings.BinDir) << libs;
     }
     // Module.
@@ -572,7 +575,7 @@ void SimMessage::startSimulator()
 #else
     Program = QDir::toNativeSeparators(pathName(QucsSettings.BinDir + QucsDigi));
     Arguments << QucsSettings.QucsHomeDir.filePath("netlist.txt")
-              << DataSet << SimTime << pathName(SimPath)
+              << DataSet << SimTime.remove(" ") << pathName(SimPath)
 		      << pathName(QucsSettings.BinDir) << "-Wall" << "-c";
 
 #endif

--- a/qucs/qucs_run_hdl
+++ b/qucs/qucs_run_hdl
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# qucsdigi - wrapper script for digital simulation
+# qucs_run_hdl - wrapper script for digital simulation
 #
 # Copyright (C) 2005 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
 # Copyright (C) 2005, 2006, 2008, 2009 Stefan Jahn <stefan@lkcc.org>
@@ -26,7 +26,7 @@
 set -e
 
 # catch termination signal and kill all child processes
-#trap 'kill 0; exit 0' SIGTERM
+# trap 'kill 0; exit 0' SIGTERM
 
 if [ "$#" != 6 ]; then
     if [ "$#" != 7 ]; then
@@ -42,7 +42,8 @@ NAMEOUT=$2
 TIME=$3
 DIR=$4
 BINDIR=$5
-VLIBS=$6
+
+# echo "Filename: $NAME\nOutput: $NAMEOUT\nRuntime: $TIME\nDir: $DIR\nBinary Dir: $BINDIR\nOption: $OPTION"
 
 if [ ! -d "$DIR" ]; then
     echo "$DIR: Not a directory"
@@ -56,42 +57,19 @@ if [ ! -f $NAME ]; then
     exit 1
 fi
 
-CXX=`freehdl-config --cxx`
-CXXFLAGS=`freehdl-config --cxxflags`
-LIBS=`freehdl-config --libtool`
-IEEELIBS=`freehdl-config --ieee`
-LDFLAGS=`freehdl-config --ldflags|sed -e 's/ @LDFLAGS@/\/freehdl/g'|sed -e 's/@LIBS@//g'`
-LIBTOOL=`freehdl-config --linker`
-
 cp $NAME digi.vhdl
 NAME="digi"
 
-echo -n "running C++ conversion..."
-freehdl-v2cc -m $NAME._main_.cc -Lvhdl -o $NAME.cc $NAME.vhdl
+echo -n "running GHDL analysis pass..."
+ghdl -a $NAME.vhdl
 echo " done."
 
-echo -n "compiling functions..."
-$CXX $CXXFLAGS -c $NAME.cc
-echo " done."
-
-echo -n "compiling main..."
-$CXX $CXXFLAGS -c $NAME._main_.cc
-echo " done."cd
-
-echo -n "linking..."
-
-LTFLAGS="--mode=link"
-
-# on darwn glibtool asks for --tag=
-if [ $LIBTOOL = "glibtool" ]; then
-    LTFLAGS="$LTFLAGS --tag=CC"
-fi
-#$CXX -o $NAME $NAME._main_.o $NAME.o -L /usr/lib/freehdl -lfreehdl-kernel -lfreehdl-std -Lieee
-$LIBTOOL $LTFLAGS $CXX $NAME._main_.o $NAME.o $LDFLAGS $VLIBS $LIBS $IEEELIBS -o $NAME
+echo -n "running GHDL elaboration pass..."
+ghdl -e TestBench
 echo " done."
 
 echo "simulating..."
-./$NAME -q -cmd "dc -f $NAME.vcd -t 1 ps -q;d;run $TIME;q;" <&-
+ghdl -r TestBench --vcd=digi.vcd --stop-time=$TIME
 wait $!
 
 echo -n "running VCD conversion..."


### PR DESCRIPTION
The approach taken follows the advice given at Qucs/qucs#830. 
Includes syntax fixes to accommodate the slight differences between GHDL and FreeHDL.
It is not the full solution to #395 and does not address #396, but it allows basic digital simulation as previously.