### PR TITLE
Add 'wait for' clause to output-only VHDL models

### DIFF
--- a/qucs/components/logic_0.cpp
+++ b/qucs/components/logic_0.cpp
@@ -78,6 +78,7 @@ QString logic_0::vhdlCode( int )
   s = "\n  " + Name + ":process\n" +
      "  begin\n    " +
      LO + " <= '0';\n" + 
+     "    wait for 1 ns;\n" +
      "  end process;\n";
   return s;
 }

--- a/qucs/components/logic_1.cpp
+++ b/qucs/components/logic_1.cpp
@@ -79,6 +79,7 @@ QString logic_1::vhdlCode( int )
   s = "\n  " + Name + ":process\n" +
      "  begin\n    " +
      L1 + " <= '1';\n" + 
+     "    wait for 1 ns;\n" +
      "  end process;\n";
   return s;
 }

--- a/qucs/components/pad2bit.cpp
+++ b/qucs/components/pad2bit.cpp
@@ -81,7 +81,8 @@ QString pad2bit::vhdlCode( int )
        "      when 3 => "+A+" <= '1'; "+B+" <= '1';\n" +
        "      when others => null;\n" +
        "    end case;\n";
-  s3 = "  end process;\n";
+  s3 = "    wait for 1 ns;\n"
+       "  end process;\n";
   s = s1+s2+s3;
   return s;
 }

--- a/qucs/components/pad3bit.cpp
+++ b/qucs/components/pad3bit.cpp
@@ -89,7 +89,8 @@ QString pad3bit::vhdlCode( int )
        "      when 7 => "+A+" <= '1'; "+B+" <= '1'; "+C+" <= '1';\n"+
        "      when others => null;\n" +
        "    end case;\n";
-  s3 = "  end process;\n";
+  s3 = "    wait for 1 ns;\n"
+       "  end process;\n";
   s = s1+s2+s3;
   return s;
 }

--- a/qucs/components/pad4bit.cpp
+++ b/qucs/components/pad4bit.cpp
@@ -102,7 +102,8 @@ QString pad4bit::vhdlCode( int )
        "      when 15 => "+A+" <= '1'; "+B+" <= '1'; "+C+" <= '1'; "+D+" <= '1';\n"+
        "      when others => null;\n"
        "    end case;\n";
-  s3 = "  end process;\n";
+  s3 = "    wait for 1 ns;\n"
+       "  end process;\n";
   s = s1+s2+s3;
   return s;
 }


### PR DESCRIPTION
This avoids creating an infinite loop as these models do not have any sensitivity lists (i.e., 'inputs') to create the necessary timing.

I am not sure if it is right to hard-code the 'wait for', but I can't see that abstracting it to higher up is that helpful either.