### PR TITLE
Ngspice netlist rework, fixes #463

### DIFF
--- a/qucs/components/dc_sim.cpp
+++ b/qucs/components/dc_sim.cpp
@@ -88,7 +88,13 @@ Element* DC_Sim::info(QString& Name, char* &BitmapFile, bool getNewOne)
   return 0;
 }
 
-QString DC_Sim::spice_netlist(bool)
+QString DC_Sim::spice_netlist(bool isXyce)
 {
-    return QString("");
+    QString s;
+    if ( !isXyce ) {
+        s += "op\n";
+        s += QString("print all > spice4qucs.%1.ngspice.dc.print\n").arg(Name.toLower());
+    }
+
+    return s;
 }

--- a/qucs/components/equation.cpp
+++ b/qucs/components/equation.cpp
@@ -190,7 +190,8 @@ QString Equation::getEquations(QString sim, QStringList &dep_vars)
                 int idx = ng_vars.indexOf(Props.at(i)->Name);
                 if (idx>=0) used_sim = ngsims.at(idx);
             }
-            if ((sim == used_sim)||(used_sim=="all")) {
+            if ( used_sim.toLower() == "tran" ) used_sim = "tr";
+            if ( (sim.startsWith(used_sim.toLower())) || (used_sim=="all") ) {
                 eqn = tokens.join("");
                 s += QString("let %1=%2\n").arg(Props.at(i)->Name).arg(eqn);
                 dep_vars.append(Props.at(i)->Name);

--- a/qucs/components/param_sweep.cpp
+++ b/qucs/components/param_sweep.cpp
@@ -206,7 +206,7 @@ QString Param_Sweep::getNgspiceAfterSim(QString sim, int lvl)
 
     s = "set appendwrite\n";
 
-    if (lvl==0) s += QString("echo \"$&number_%1  $%2_act\">> spice4qucs.%3.cir.res\n").arg(par).arg(par).arg(sim);
+    if (lvl==0) s += QString("echo \"$&number_%1  $%2_act\" >> spice4qucs.%3.cir.res\n").arg(par).arg(par).arg(sim);
     else s += QString("echo \"$&number_%1\" $%1_act >> spice4qucs.%2.cir.res%3\n").arg(par).arg(sim).arg(lvl);
     s += QString("let number_%1 = number_%1 + 1\n").arg(par);
 
@@ -249,7 +249,7 @@ QString Param_Sweep::spice_netlist(bool isXyce)
         step = (stop-start)/points;
     }
 
-    if (Props.at(0)->Value.startsWith("DC")) {
+    if (Props.at(0)->Value.toLower().startsWith("dc")) {
         QString src = getProperty("Param")->Value;
         s = QString("DC %1 %2 %3 %4\n").arg(src).arg(start).arg(stop).arg(step);
         if (isXyce) s.prepend('.');

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -160,16 +160,18 @@ bool AbstractSpiceKernel::checkSimulations()
 
 bool AbstractSpiceKernel::checkDCSimulation()
 {
-    if (DC_OP_only) return true;
-    bool r = false;
-    for(Component *pc = Sch->DocComps.first(); pc != 0; pc = Sch->DocComps.next()) {
-        if (!pc->isActive) continue;
-        if (pc->isSimulation && pc->Model != ".DC") {
-            r = true;
-            break;
-        }
-    }
-    return r;
+    return true;  // DC OP is now saved in the dataset
+
+    //if (DC_OP_only) return true;
+    //bool r = false;
+    //for(Component *pc = Sch->DocComps.first(); pc != 0; pc = Sch->DocComps.next()) {
+    //    if (!pc->isActive) continue;
+    //    if (pc->isSimulation && pc->Model != ".DC") {
+    //        r = true;
+    //        break;
+    //    }
+    //}
+    //return r;
 }
 
 /*!

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -1153,8 +1153,13 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
         bool hasParSweep = false;
         bool hasDblParSweep = false;
 
-        QRegularExpression custom_prefix_rx("(?<=#).*?(?=#)");
-        QString custom_prefix = custom_prefix_rx.match(ngspice_output_filename).captured(0);
+        QString custom_prefix;
+        if ( ngspice_output_filename.startsWith("spice4qucs.") ) {
+            custom_prefix = ngspice_output_filename.section('.', 1, 1).toLower();
+        } else {
+            QRegularExpression custom_prefix_rx("(?<=#).*?(?=#)");
+            custom_prefix = custom_prefix_rx.match(ngspice_output_filename).captured(0).toLower();
+        }
         QRegularExpression four_rx(".*\\.four[0-9]+$");
         QString full_outfile = workdir+QDir::separator()+ngspice_output_filename;
         if (ngspice_output_filename.endsWith("HB.FD.prn")) {
@@ -1183,7 +1188,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             parseNoiseOutput(full_outfile,sim_points,var_list,hasParSweep);
             if (hasParSweep) {
                 QString res_file = QDir::toNativeSeparators(workdir + QDir::separator()
-                                                        + "spice4qucs.noise.cir.res");
+                                                        + "spice4qucs." + custom_prefix + ".cir.res");
                 parseResFile(res_file,swp_var,swp_var_val);
             }
         } else if (ngspice_output_filename.endsWith(".pz")) {
@@ -1191,7 +1196,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             parsePZOutput(full_outfile,sim_points,var_list,hasParSweep);
             if (hasParSweep) {
                 QString res_file = QDir::toNativeSeparators(workdir + QDir::separator()
-                                                        + "spice4qucs.pz.cir.res");
+                                                        + "spice4qucs." + custom_prefix + ".cir.res");
                 parseResFile(res_file,swp_var,swp_var_val);
             }
         } else if (ngspice_output_filename.endsWith(".SENS.prn")) {
@@ -1204,23 +1209,17 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
                                                         + "spice4qucs.sens.cir.res");
                 parseResFile(res_file,swp_var,swp_var_val);
             }
-        } else if (ngspice_output_filename.endsWith("_swp.txt")) {
+        } else if (ngspice_output_filename.endsWith("_swp.plot")) {
             hasParSweep = true;
-            QString simstr = full_outfile;
-            simstr.remove("_swp.txt");
-            if (ngspice_output_filename.endsWith("_swp_swp.txt")) { // 2-var parameter sweep
+            if (ngspice_output_filename.endsWith("_swp_swp.plot")) { // 2-var parameter sweep
                 hasDblParSweep = true;
-                simstr.chop(4);
-                simstr = simstr.split('_').last();
                 QString res2_file = QDir::toNativeSeparators(workdir + QDir::separator()
-                                                            + "spice4qucs." + simstr + ".cir.res1");
+                                                            + "spice4qucs." + custom_prefix + ".cir.res1");
                 parseResFile(res2_file,swp_var2,swp_var2_val);
-            } else {
-                simstr = simstr.split('_').last();
             }
 
             QString res_file = QDir::toNativeSeparators(workdir + QDir::separator()
-                                                    + "spice4qucs." + simstr + ".cir.res");
+                                                    + "spice4qucs." + custom_prefix + ".cir.res");
             parseResFile(res_file,swp_var,swp_var_val);
 
             parseSTEPOutput(full_outfile,sim_points,var_list,isComplex);
@@ -1343,6 +1342,11 @@ void AbstractSpiceKernel::removeAllSimulatorOutputs()
         QString full_outfile = workdir+QDir::separator()+output_filename;
         QFile::remove(full_outfile);
     }
+    QDir dir(workdir);
+    dir.setNameFilters(QStringList() << "*.cir.res*");
+    dir.setFilter(QDir::Files);
+    foreach(QString file, dir.entryList())
+        dir.remove(file);
 }
 
 /*!
@@ -1408,11 +1412,12 @@ void AbstractSpiceKernel::normalizeVarsNames(QStringList &var_list, const QStrin
         }
     }
 
-    if ( !custom_prefix.isEmpty() ) {
-        for ( it = var_list.begin() ; it != var_list.end() ; ++it)
-            if ( !(*it).isEmpty() )
-                (*it).prepend(custom_prefix + ".");
-    }
+    if ( needsPrefix )
+        if ( !custom_prefix.isEmpty() ) {
+            for ( it = var_list.begin() ; it != var_list.end() ; ++it)
+                if ( !(*it).isEmpty() )
+                    (*it).prepend(custom_prefix + ".");
+        }
 }
 
 /*!

--- a/qucs/extsimkernels/abstractspicekernel.h
+++ b/qucs/extsimkernels/abstractspicekernel.h
@@ -64,6 +64,7 @@ protected:
     QStringList sims,vars,output_files;
 
     bool DC_OP_only; // only calculate operating point to show DC bias
+    bool needsPrefix;
     Schematic *Sch;
 
     bool prepareSpiceNetlist(QTextStream &stream, bool isSubckt = false);

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -210,7 +210,8 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
         } else if ( sim_typ == ".CUSTOMSIM" ) {
             dcSims++; dcswpSims++; freqSims++; timeSims++; fourSims++;
             spiceNetlist.append(pc->getSpiceNetlist());
-            nods = pc->Props.at(1)->Value.replace(';', ' ');
+            nods = pc->Props.at(1)->Value;
+            nods.replace(';', ' ');
             outputs.append(pc->Props.at(2)->Value.split(';', qucs::SkipEmptyParts));
         } else if ( sim_typ == ".DISTO" ) {
             freqSims++;
@@ -276,6 +277,7 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
         nods.append(' ' + dep_vars.join(' '));
 
         if ( (sim_typ != ".PZ") && (sim_typ != ".SENS") && (sim_typ != ".SENS_AC") && (sim_typ != ".DC") ) {
+            nods = nods.simplified();
             if ( !nods.isEmpty() ) {
                 QString basenam = "spice4qucs";
                 QString filename;

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -69,6 +69,9 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
                        QStringList &simulations, QStringList &vars, QStringList &outputs)
 {
     Q_UNUSED(simulations);
+
+    if(!prepareSpiceNetlist(stream)) return; // Unable to perform spice simulation
+
     // include math. functions for inter-simulator compat.
     QString mathf_inc;
     bool found = findMathFuncInc(mathf_inc);
@@ -76,7 +79,6 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
     if (found && QucsSettings.DefaultSimulator != spicecompat::simSpiceOpus)
         stream<<QString(".INCLUDE \"%1\"\n").arg(mathf_inc);
 
-    if(!prepareSpiceNetlist(stream)) return; // Unable to perform spice simulation
     startNetlist(stream); // output .PARAM and components
 
     if (DC_OP_only) {

--- a/qucs/spicecomponents/sp_fourier.cpp
+++ b/qucs/spicecomponents/sp_fourier.cpp
@@ -73,9 +73,10 @@ QString SpiceFourier::spice_netlist(bool isXyce)
 {
     QString s;
     QString f0 = spicecompat::normalize_value(Props.at(2)->Value);
+    QString out = "spice4qucs." + Name.toLower() + ".four";
     if (!isXyce) {
         s = QString("set nfreqs=%1\n").arg(Props.at(1)->Value);
-        s += QString("fourier %1 %2 > spice4qucs.four\n").arg(f0).arg(Props.at(3)->Value);
+        s += QString("fourier %1 %2 > %3\n").arg(f0).arg(Props.at(3)->Value).arg(out);
     } else {
         s = QString(".FOUR %1 %2\n").arg(f0).arg(Props.at(3)->Value);
     }

--- a/qucs/spicecomponents/sp_noise.cpp
+++ b/qucs/spicecomponents/sp_noise.cpp
@@ -103,8 +103,9 @@ QString SpiceNoise::spice_netlist(bool isXyce)
 
     s = QString("noise %1 %2 %3 %4 %5 %6\n").arg(Props.at(4)->Value).arg(Props.at(5)->Value)
             .arg(swp).arg(points).arg(fstart).arg(fstop);
+    QString out = "spice4qucs." + Name.toLower() + ".cir.noise";
     if (!isXyce) {
-        s += QString("print inoise_total onoise_total >> spice4qucs.cir.noise\n");
+        s += QString("print inoise_total onoise_total >> %1\n").arg(out);
     } else {
         s.insert(0,'.');
     }

--- a/qucs/spicecomponents/sp_nutmeg.cpp
+++ b/qucs/spicecomponents/sp_nutmeg.cpp
@@ -48,8 +48,7 @@ NutmegEquation::NutmegEquation()
   SpiceModel = "NutmegEq";
   Name  = "NutmegEq";
 
-  Props.append(new Property("Simulation","ac",true,
-                            "Used simulation [ac, tran, dc, disto, sp, fft, all]"));
+  Props.append(new Property("Simulation", "ALL", true, "Simulation name"));
   Props.append(new Property("y", "1", true));
 }
 
@@ -76,8 +75,14 @@ QString NutmegEquation::getEquations(QString sim, QStringList &dep_vars)
     if (isActive != COMP_IS_ACTIVE) return QString("");
 
     QString s;
-    s.clear();
-    if (Props.at(0)->Value==sim) {
+    QRegularExpression sim_rx("^\\w+\\d+");
+    QString used_sim =  Props.at(0)->Value.toLower();
+    bool match = false;
+    if ( sim_rx.match(used_sim).hasMatch() )
+        match = sim == used_sim;
+    else
+        match = sim.startsWith(used_sim);
+    if ( match || used_sim == "all" ) {
         Property *pp = Props.first();
         pp = Props.next();
         for (;pp!=0;pp=Props.next()) {

--- a/qucs/spicecomponents/sp_pz.cpp
+++ b/qucs/spicecomponents/sp_pz.cpp
@@ -75,13 +75,13 @@ Element* SpicePZ::info(QString& Name, char* &BitmapFile, bool getNewOne)
 QString SpicePZ::spice_netlist(bool isXyce)
 {
     QString s;
+    QString out = "spice4qucs." + Name.toLower() + ".cir.pz";
     if (!isXyce) {
         s = QString("pz %1 %2 %3 %4\n").arg(Props.at(0)->Value).arg(Props.at(1)->Value)
                 .arg(Props.at(2)->Value).arg(Props.at(3)->Value);
-        s += "echo \"PZ analysis\" >> spice4qucs.cir.pz\n";
-        s += "let dummy_var = 0.0\n"; // To overcome featurebug of Ngspice
-                                               // when printing single variable
-        s += QString("print all >> spice4qucs.cir.pz\n");
+        s += QString("echo \"PZ analysis\" >> %1\n").arg(out);
+        s += "let dummy_var = 0.0\n"; // To overcome featurebug of Ngspice when printing single variable
+        s += QString("print all >> %1\n").arg(out);
     } else {
         s.clear();
     }

--- a/qucs/spicecomponents/sp_sens.cpp
+++ b/qucs/spicecomponents/sp_sens.cpp
@@ -84,7 +84,7 @@ QString SpiceSENS::spice_netlist(bool isXyce)
         QString start = spicecompat::normalize_value(Props.at(2)->Value);
         QString stop = spicecompat::normalize_value(Props.at(3)->Value);
         QString step = spicecompat::normalize_value(Props.at(4)->Value);
-        QString output = "spice4qucs.ngspice.sens.dc.prn";
+        QString output = "spice4qucs." + Name.toLower() + ".ngspice.sens.dc.prn";
         s += QString("echo \"Start\">%1\n").arg(output);
         s += QString("let %1_start=%2\n").arg(sweepvar).arg(start);
         s += QString("let %1_sweep=%1_start\n").arg(sweepvar);

--- a/qucs/spicecomponents/sp_sens_ac.cpp
+++ b/qucs/spicecomponents/sp_sens_ac.cpp
@@ -80,10 +80,11 @@ QString SpiceSENS_AC::spice_netlist(bool isXyce)
     if (!isXyce) {
         QString fstart = spicecompat::normalize_value(Props.at(2)->Value); // Start freq.
         QString fstop = spicecompat::normalize_value(Props.at(3)->Value); // Stop freq.
+        QString out = "spice4qucs." + Name.toLower() + ".sens.prn";
         s = QString("sens %1 ac %2 %3 %4 %5\n")
                 .arg(Props.at(0)->Value).arg(Props.at(1)->Value).arg(Props.at(4)->Value)
                 .arg(fstart).arg(fstop);
-        s += "write spice4qucs.sens.prn all\n";
+        s += QString("write %1 all\n").arg(out);
     }
 
     return s;


### PR DESCRIPTION
This rework fixes #463 using the recently added custom prefix feature.
Prefixing is activated only if conflicting simulations are found, so **the existing schematics are not affected**.

Every simulation has its own output file named spice4qucs.<simulation_name>.extension, ex: spice4qucs.ac1.plot.
If any conflicting simulations are found, ex: AC and FFT, prefixing is activated and when the dataset is built the <simulation_name> prefix applies to all simulations. If a conflicting simulation is added to a schematic the existing diagrams have to be updated with the new prefixed variables. 

Other changes:
- Nutmeg equation now uses a complete or partial simulation name. For example if 'SP' is specified as simulation name the equation is included in all SP simulations and if SP1 is specified it is included in SP1 only. if ALL is specified it is included in all simulations.
- If a DC simulation is placed in the schematic the operation point is saved in the dataset.

Here are some tests:
[463-tests.zip](https://github.com/ra3xdh/qucs_s/files/14106663/463-tests.zip)

