### PR TITLE
Refactor schematic's grid-drawing

### DIFF
--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -83,7 +83,7 @@ public:
 
   void setName(const QString&);
   void setChanged(bool, bool fillStack=false, char Op='*');
-  void paintGrid(ViewPainter*, int, int, int, int);
+  void drawGrid(const ViewPainter&);
   void print(QPrinter*, QPainter*, bool, bool);
 
   void paintSchToViewpainter(ViewPainter* p, bool printAll, bool toImage, int screenDpiX=96, int printerDpiX=300);
@@ -163,7 +163,7 @@ public:
   QList<PostedPaintEvent>   PostedPaintEvents;
   bool symbolMode;  // true if in symbol painting mode
 
-
+  // Horizontal and vertical grid step
   int GridX, GridY;
 
   // Variables View* are the coordinates of top-level and bottom-right corners


### PR DESCRIPTION
Hi! Legacy implementation looked a bit cryptic with all those bit-shifts and one-letter variable names, so I decided to refine it a bit.  Changes are mostly about code readability and about how the method is called. An overview:

- rename method. "Draw" is better name than "paint" because "painting" is about "covering a surface with a color". We paint a wall, a house, a garage door, but we draw a circle, a line a point
- reduce number of arguments. There is no need to pass some of the arguments as their values are accessible from within the method
- pass ViewPainter by const reference instead of a pointer
- rewrite method body to make it less cryptic

I've tested it on my machine, IMO the grid looks the same :)