### PR TITLE
Fix grid slip on wide displays

### DIFF
--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1122,9 +1122,9 @@ void Schematic::drawGrid(const ViewPainter& p)
     }
 
     // Finally draw the grid-nodes
-    for (double x = gridTopLeft.x(); x <= gridBottomRight.x(); x = std::round(x + horizontalStep)) {
-        for (double y = gridTopLeft.y(); y <= gridBottomRight.y(); y = std::round(y + verticalStep)) {
-            p.Painter->drawPoint(x, y);
+    for (double x = gridTopLeft.x(); x <= gridBottomRight.x(); x += horizontalStep) {
+        for (double y = gridTopLeft.y(); y <= gridBottomRight.y(); y += verticalStep) {
+            p.Painter->drawPoint(std::round(x), std::round(y));
         }
     }
 }


### PR DESCRIPTION
This is a possible fix for the problem described in #521 ([here](https://github.com/ra3xdh/qucs_s/pull/521#issuecomment-1924814223)

@iwbnwif, could please try this patch? Hopefully, it removes the grid slip in bottom-right areas of very wide screens…