### PR TITLE
more precise parameter parsing for Verilog-A files

### DIFF
--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -285,8 +285,13 @@ int Schematic::savePropsJSON()
         if (line.contains("parameter")) {
             auto tokens = line.split(QRegularExpression("[\\s=;]"),qucs::SkipEmptyParts);
             if (tokens.count() >= 4) {
-               prop_name.append(tokens.at(2));
-               prop_val.append(tokens.at(3));
+                for(int ic = 0; ic <= tokens.count(); ic++) {
+                    if (tokens.at(ic) == "parameter") {
+                        prop_name.append(tokens.at(ic+2));
+                        prop_val.append(tokens.at(ic+3));
+                        break;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Related to #366:
This code change helps the parameter parsing of Verilog-A model files.
There are still other flaws, e.g. that any "parameter" string in comments follows in wrong symbol files.