### PR TITLE
Persist geometry of ComponentDialog

### DIFF
--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -41,7 +41,9 @@
 ComponentDialog::ComponentDialog(Component *c, Schematic *d)
 			: QDialog(d)
 {
-  resize(450, 250);
+  QSettings settings("qucs","qucs_s");
+  restoreGeometry(settings.value("ComponentDialog/geometry").toByteArray());
+
   setWindowTitle(tr("Edit Component Properties"));
   Comp  = c;
   Doc   = d;
@@ -469,7 +471,7 @@ ComponentDialog::ComponentDialog(Component *c, Schematic *d)
         prop->setCurrentItem(prop->item(0,0));
         slotSelectProperty(prop->item(0,0));
     }
-
+ 
 
   /// \todo add key up/down browse and select prop
   connect(prop, SIGNAL(itemClicked(QTableWidgetItem*)),
@@ -826,6 +828,9 @@ void ComponentDialog::slotApplyState(int State)
 // Is called if the "OK"-button is pressed.
 void ComponentDialog::slotButtOK()
 {
+  QSettings settings("qucs","qucs_s");
+  settings.setValue("ComponentDialog/geometry", saveGeometry());
+
   slotApplyInput();
   slotButtCancel();
 }


### PR DESCRIPTION
The ComponentDialog default size is generally too small to see all the rows and text.

This change 'remembers' the last size that the dialog was set to when the user pressed 'OK'.

It might be better to implement the settings write in the close event.