### PR TITLE
Add clangd LSP support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ if("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
       "remove CMakeCache.txt and CMakeFiles.")
 endif()
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 file (STRINGS "${qucs-suite_SOURCE_DIR}/VERSION" QUCS_VERSION)
 message(STATUS "Configuring Qucs: VERSION ${QUCS_VERSION}")
 

--- a/README.md
+++ b/README.md
@@ -79,4 +79,19 @@ cd /your_installation prefix/bin
 ./qucs-s
 ~~~
 
+### clangd LSP support
+Clangd looks for `compile_commands.json` file in parent folders of the file it processes.
+`compile_commands.json` should be generated along with other build configuration files
+when you run `cmake` as part of building routine:
+```
+mkdir builddir
+cd builddir
+cmake ..  -DCMAKE_INSTALL_PREFIX=/your_install_prefix/
+```
+If `compile_commands.json` is already there, create a symbolic link to it from project root dir:
+```
+cd project_root
+ln -s ./builddir/compile_commands.json compile_commands.json
+```
 
+It may take some time to index files at first run. Clangd configuration is in `.clangd` file.


### PR DESCRIPTION
Hi! I think it would be nice to have clangd support "out of the box". I understand that maybe I'm the only one who thinks like that (ha-ha), so I will totally understand if PR won't be accepted :)

Changes:
- Alter cmake config so it generates `compile_commands.json`
- Add clangd config
- Add to README a section describing how to set up clangd LSP