### PR TITLE
Fix crash on schematic close

### DIFF
--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -2319,7 +2319,7 @@ void QucsApp::slotTune(bool checked)
         bool digi_found = false;
         bool exit = false;
         for(Component *pc = d->DocComps.first(); pc != 0; pc = d->DocComps.next()) {
-            if (pc->isSimulation && pc->Model != ".DC") {
+            if (pc->isSimulation) {
                 found = true;
             }
             if (pc->Type == isDigitalComponent) {

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -108,6 +108,12 @@ Schematic::Schematic(QucsApp *App_, const QString &Name_)
     DocPaints.setAutoDelete(true);
     SymbolPaints.setAutoDelete(true);
 
+    Nodes = &DocNodes;
+    Wires = &DocWires;
+    Diagrams = &DocDiags;
+    Paintings = &DocPaints;
+    Components = &DocComps;
+
     // The 'i' means state for being unchanged.
     undoActionIdx = 0;
     undoAction.append(new QString(" i\n</>\n</>\n</>\n</>\n"));


### PR DESCRIPTION
Pointers in `Schematic` class may remain unitialized at some conditions. This may lead to application crash on schematic close. The crash appears time to time. Crash happens at `Schematic::contentsMouseMoveEvent()`

Besides the crash fix, I have also allowed to tune DC OP simulation in this PR.