### PR TITLE
Add default TextDoc font to settings dialog

### DIFF
--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -84,18 +84,23 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     connect(AppFontButton, SIGNAL(clicked()), SLOT(slotAppFontDialog()));
     appSettingsGrid->addWidget(AppFontButton,1,1);
 
+    appSettingsGrid->addWidget(new QLabel(tr("Text document font (set after reload):"), appSettingsTab), 2,0);
+    TextFontButton = new QPushButton(appSettingsTab);
+    connect(TextFontButton, SIGNAL(clicked()), SLOT(slotTextFontDialog()));
+    appSettingsGrid->addWidget(TextFontButton,2,1);
+
     val50 = new QIntValidator(1, 50, this);
-    appSettingsGrid->addWidget(new QLabel(tr("Large font size:"), appSettingsTab), 2,0);
+    appSettingsGrid->addWidget(new QLabel(tr("Large font size:"), appSettingsTab), 3,0);
     LargeFontSizeEdit = new QLineEdit(appSettingsTab);
     LargeFontSizeEdit->setValidator(val50);
-    appSettingsGrid->addWidget(LargeFontSizeEdit,2,1);
+    appSettingsGrid->addWidget(LargeFontSizeEdit,3,1);
 
-    appSettingsGrid->addWidget(new QLabel(tr("Document Background Color:"), appSettingsTab) ,3,0);
+    appSettingsGrid->addWidget(new QLabel(tr("Document Background Color:"), appSettingsTab) ,4,0);
     BGColorButton = new QPushButton("      ", appSettingsTab);
     connect(BGColorButton, SIGNAL(clicked()), SLOT(slotBGColorDialog()));
-    appSettingsGrid->addWidget(BGColorButton,3,1);
+    appSettingsGrid->addWidget(BGColorButton,4,1);
 
-    appSettingsGrid->addWidget(new QLabel(tr("Language (set after reload):"), appSettingsTab) ,4,0);
+    appSettingsGrid->addWidget(new QLabel(tr("Language (set after reload):"), appSettingsTab) ,5,0);
     LanguageCombo = new QComboBox(appSettingsTab);
     LanguageCombo->insertItem(-1, tr("Ukrainian")+" (uk)");
     LanguageCombo->insertItem(-1, tr("Turkish")+" (tr)");
@@ -119,45 +124,45 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     LanguageCombo->insertItem(-1, tr("Arabic")+" (ar)");
     LanguageCombo->insertItem(-1, tr("English")+" (en)");
     LanguageCombo->insertItem(-1, tr("system language"));
-    appSettingsGrid->addWidget(LanguageCombo,4,1);
+    appSettingsGrid->addWidget(LanguageCombo,5,1);
 
     val200 = new QIntValidator(0, 200, this);
-    appSettingsGrid->addWidget(new QLabel(tr("Maximum undo operations:"), appSettingsTab) ,5,0);
+    appSettingsGrid->addWidget(new QLabel(tr("Maximum undo operations:"), appSettingsTab) ,6,0);
     undoNumEdit = new QLineEdit(appSettingsTab);
     undoNumEdit->setValidator(val200);
-    appSettingsGrid->addWidget(undoNumEdit,5,1);
+    appSettingsGrid->addWidget(undoNumEdit,6,1);
 
-    appSettingsGrid->addWidget(new QLabel(tr("Text editor:"), appSettingsTab) ,6,0);
+    appSettingsGrid->addWidget(new QLabel(tr("Text editor:"), appSettingsTab) ,7,0);
     editorEdit = new QLineEdit(appSettingsTab);
     editorEdit->setToolTip(tr("Set to qucs, qucsedit or the path to your favorite text editor."));
-    appSettingsGrid->addWidget(editorEdit,6,1);
+    appSettingsGrid->addWidget(editorEdit,7,1);
 
-    appSettingsGrid->addWidget(new QLabel(tr("Start wiring when clicking open node:"), appSettingsTab) ,7,0);
+    appSettingsGrid->addWidget(new QLabel(tr("Start wiring when clicking open node:"), appSettingsTab) ,8,0);
     checkWiring = new QCheckBox(appSettingsTab);
-    appSettingsGrid->addWidget(checkWiring,7,1);
+    appSettingsGrid->addWidget(checkWiring,8,1);
 
     appSettingsGrid->addWidget(new QLabel(tr("Load documents from future versions:")));
     checkLoadFromFutureVersions = new QCheckBox(appSettingsTab);
     checkLoadFromFutureVersions->setToolTip(tr("Try to load also documents created with newer versions of Qucs."));
-    appSettingsGrid->addWidget(checkLoadFromFutureVersions,8,1);
+    appSettingsGrid->addWidget(checkLoadFromFutureVersions,9,1);
     checkLoadFromFutureVersions->setChecked(QucsSettings.IgnoreFutureVersion);
 
     appSettingsGrid->addWidget(new QLabel(tr("Draw diagrams with anti-aliasing feature:")));
     checkAntiAliasing = new QCheckBox(appSettingsTab);
     checkAntiAliasing->setToolTip(tr("Use anti-aliasing for graphs for a smoother appearance."));
-    appSettingsGrid->addWidget(checkAntiAliasing,9,1);
+    appSettingsGrid->addWidget(checkAntiAliasing,10,1);
     checkAntiAliasing->setChecked(QucsSettings.GraphAntiAliasing);
 
     appSettingsGrid->addWidget(new QLabel(tr("Draw text with anti-aliasing feature:")));
     checkTextAntiAliasing = new QCheckBox(appSettingsTab);
     checkTextAntiAliasing->setToolTip(tr("Use anti-aliasing for text for a smoother appearance."));
-    appSettingsGrid->addWidget(checkTextAntiAliasing,10,1);
+    appSettingsGrid->addWidget(checkTextAntiAliasing,11,1);
     checkTextAntiAliasing->setChecked(QucsSettings.TextAntiAliasing);
 
     appSettingsGrid->addWidget(new QLabel(tr("Show trace name prefix on diagrams:")));
     checkFullTraceNames = new QCheckBox(appSettingsTab);
     checkFullTraceNames->setToolTip(tr("Show prefixes for trace names on diagrams like \"ngspice/\""));
-    appSettingsGrid->addWidget(checkFullTraceNames,11,1);
+    appSettingsGrid->addWidget(checkFullTraceNames,12,1);
     checkFullTraceNames->setChecked(QucsSettings.fullTraceName);
 
     QStringList lst_icons;
@@ -165,13 +170,13 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     PanelIconsCombo = new QComboBox;
     PanelIconsCombo->addItems(lst_icons);
     PanelIconsCombo->setCurrentIndex(QucsSettings.panelIconsTheme);
-    appSettingsGrid->addWidget(new QLabel(tr("Panel icons theme (set after reload):"),appSettingsTab),12,0);
-    appSettingsGrid->addWidget(PanelIconsCombo,12,1);
+    appSettingsGrid->addWidget(new QLabel(tr("Panel icons theme (set after reload):"),appSettingsTab),13,0);
+    appSettingsGrid->addWidget(PanelIconsCombo,13,1);
     CompIconsCombo = new QComboBox;
     CompIconsCombo->addItems(lst_icons);
     CompIconsCombo->setCurrentIndex(QucsSettings.compIconsTheme);
-    appSettingsGrid->addWidget(new QLabel(tr("Components icons theme (set after reload):"),appSettingsTab),13,0);
-    appSettingsGrid->addWidget(CompIconsCombo,13,1);
+    appSettingsGrid->addWidget(new QLabel(tr("Components icons theme (set after reload):"),appSettingsTab),14,0);
+    appSettingsGrid->addWidget(CompIconsCombo,14,1);
 
     t->addTab(appSettingsTab, tr("Settings"));
 
@@ -438,8 +443,10 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     // fill the fields with the Qucs-Properties
     Font  = QucsSettings.font;
     AppFont = QucsSettings.appFont;
+    TextFont = QucsSettings.textFont;
     FontButton->setText(Font.toString());
     AppFontButton->setText(AppFont.toString());
+    TextFontButton->setText(TextFont.toString());
     QString s = QString::number(QucsSettings.largeFontSize, 'f', 1);
     LargeFontSizeEdit->setText(s);
 
@@ -576,6 +583,7 @@ void QucsSettingsDialog::slotApply()
 
     QucsSettings.font=Font;
     QucsSettings.appFont = AppFont;
+    QucsSettings.textFont = TextFont;
 
     QucsSettings.panelIconsTheme = PanelIconsCombo->currentIndex();
     QucsSettings.compIconsTheme = CompIconsCombo->currentIndex();
@@ -740,6 +748,17 @@ void QucsSettingsDialog::slotAppFontDialog()
     }
 }
 
+void QucsSettingsDialog::slotTextFontDialog()
+{
+    bool ok;
+    QFont tmpFont = QFontDialog::getFont(&ok, TextFont, this);
+    if(ok)
+    {
+        TextFont = tmpFont;
+        TextFontButton->setText(TextFont.toString());
+    }
+}
+
 // -----------------------------------------------------------
 void QucsSettingsDialog::slotBGColorDialog()
 {
@@ -759,9 +778,10 @@ void QucsSettingsDialog::slotDefaultValues()
     QPalette p;
     Font = QApplication::font();
     AppFont = QucsSettings.sysDefaultFont;
-    Font.setPointSize(12);
+    TextFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
     FontButton->setText(Font.toString());
     AppFontButton->setText(AppFont.toString());
+    TextFontButton->setText(TextFont.toString());
     LargeFontSizeEdit->setText(QString::number(16.0));
 
     LanguageCombo->setCurrentIndex(0);

--- a/qucs/dialogs/qucssettingsdialog.h
+++ b/qucs/dialogs/qucssettingsdialog.h
@@ -49,6 +49,7 @@ private slots:
     void slotApply();
     void slotFontDialog();
     void slotAppFontDialog();
+    void slotTextFontDialog();
     void slotBGColorDialog();
     void slotDefaultValues();
     void slotAddFileType();
@@ -81,12 +82,13 @@ public:
 
     QFont Font;
     QFont AppFont;
+    QFont TextFont;
     QCheckBox *checkWiring, *checkLoadFromFutureVersions,
               *checkAntiAliasing, *checkTextAntiAliasing,
               *checkFullTraceNames;
     QComboBox *LanguageCombo;
     QComboBox *PanelIconsCombo, *CompIconsCombo;
-    QPushButton *FontButton, *AppFontButton, *BGColorButton;
+    QPushButton *FontButton, *AppFontButton, *TextFontButton, *BGColorButton;
     QLineEdit *LargeFontSizeEdit, *undoNumEdit, *editorEdit, *Input_Suffix,
               *Input_Program, *homeEdit, *admsXmlEdit, *ascoEdit, *octaveEdit,
               *OpenVAFEdit;

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -89,6 +89,7 @@ bool loadSettings()
     if(settings.contains("dy"))QucsSettings.dy=settings.value("dy").toInt();
     if(settings.contains("font"))QucsSettings.font.fromString(settings.value("font").toString());
     if(settings.contains("appFont"))QucsSettings.appFont.fromString(settings.value("appFont").toString());
+    if(settings.contains("textFont"))QucsSettings.textFont.fromString(settings.value("textFont").toString());
     if(settings.contains("LargeFontSize"))QucsSettings.largeFontSize=settings.value("LargeFontSize").toDouble(); // use toDouble() as it can interpret the string according to the current locale
     if(settings.contains("maxUndo"))QucsSettings.maxUndo=settings.value("maxUndo").toInt();
     if(settings.contains("NodeWiring"))QucsSettings.NodeWiring=settings.value("NodeWiring").toInt();
@@ -232,6 +233,7 @@ bool saveApplSettings()
     settings.setValue("dy", QucsSettings.dy);
     settings.setValue("font", QucsSettings.font.toString());
     settings.setValue("appFont", QucsSettings.appFont.toString());
+    settings.setValue("textFont", QucsSettings.textFont.toString());
     // store LargeFontSize as a string, so it will be also human-readable in the settings file (will be a @Variant() otherwise)
     settings.setValue("LargeFontSize", QString::number(QucsSettings.largeFontSize));
     settings.setValue("maxUndo", QucsSettings.maxUndo);
@@ -833,6 +835,7 @@ int main(int argc, char *argv[])
   //QDesktopWidget *d = a.desktop();
   QucsSettings.font = QApplication::font();
   QucsSettings.appFont = QApplication::font();
+  QucsSettings.textFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
   QucsSettings.font.setPointSize(12);
   QSize size = QGuiApplication::primaryScreen()->size();
   int w = size.width();

--- a/qucs/main.h
+++ b/qucs/main.h
@@ -52,6 +52,7 @@ struct tQucsSettings {
   int x, y, dx, dy;    // position and size of main window
   QFont font;
   QFont appFont;
+  QFont textFont;
   QFont sysDefaultFont;
   float largeFontSize;
   QColor BGColor;      // background color of view area

--- a/qucs/textdoc.cpp
+++ b/qucs/textdoc.cpp
@@ -42,10 +42,7 @@ Copyright (C) 2014 by Guilherme Brondani Torri <guitorri@gmail.com>
  */
 TextDoc::TextDoc(QucsApp *App_, const QString& Name_) : QPlainTextEdit(), QucsDoc(App_, Name_)
 {
-  QFont font("Courier New", QucsSettings.font.pointSize());
-  font.setStyleHint(QFont::Courier);
-  font.setFixedPitch(true);
-  setFont(font);
+  setFont(QucsSettings.textFont);
 
   simulation = true;
   Library = "";


### PR DESCRIPTION
This change adds an extra entry to the settings dialog to allow the user to choose a default font for any documents opened in the text editor. The initial default value follows the system setting for a monospaced font.

I wasn't going to do this until after the settings refactoring in #533, but on the other hand it would be nice to close #496 before releasing 24.1.0.