### PR TITLE
Fix component font size when Qt::HighDpiScaleFactorRoundingPolicy is set

### DIFF
--- a/qucs/viewpainter.cpp
+++ b/qucs/viewpainter.cpp
@@ -53,7 +53,11 @@ void ViewPainter::init(QPainter *p, float Scale_, int DX_, int DY_,
 #ifdef __MINGW32__
   FontScale = Scale;
 #endif
-  f.setPointSizeF( FontScale * float(f.pointSize()) );
+  {
+    QFontInfo fontInfo{ f };
+    double fontSize{ static_cast<double>(fontInfo.pixelSize()) * FontScale};
+    f.setPixelSize( static_cast<int>(fontSize) );
+  }
   p->setFont(f);
   LineSpacing = p->fontMetrics().lineSpacing();
   p-> setWorldMatrixEnabled(false);   // we use our own coordinate transformation


### PR DESCRIPTION
@zergud, hi!

This is an attempt to fix the bug you described [there](https://github.com/ra3xdh/qucs_s/issues/469#issuecomment-1903477584). Hopefully you still have access to HiDPI hardware you were using when you discovered the bug. Could you please check whether this patch helps or not?

I open PR as a draft in case the patch doesn't fix the issue.