### PR TITLE
Reduce view drifting away when using Ctrl + mouse wheel to zoom

### DIFF
--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -2817,8 +2817,8 @@ double Schematic::renderModel(const double offeredScale, QRect newModel, const Q
     QSize viewportSizeOnModelPlane = viewportRect().size() / newScale;
 
     QPoint vpTopLeftOnModelPlane{
-        modelPoint.x() - static_cast<int>(viewportPoint.x() / newScale),
-        modelPoint.y() - static_cast<int>(viewportPoint.y() / newScale)
+        modelPoint.x() - static_cast<int>(std::round(viewportPoint.x() / newScale)),
+        modelPoint.y() - static_cast<int>(std::round(viewportPoint.y() / newScale))
     };
 
     QRect viewportOnModelPlane{vpTopLeftOnModelPlane, viewportSizeOnModelPlane};


### PR DESCRIPTION
Hi! A small fix to schematic zooming.

This patch doesn't eliminate the drift, but replaces it with something more like a "jitter". This makes zoom-ins and zoom-outs more stable comparing to the old behavior where zoom-ins and zoom-outs made the view to drift towards bottom-right corner.