### PR TITLE
Custom simulation fixes

### DIFF
--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -1175,12 +1175,14 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
         bool hasParSweep = false;
         bool hasDblParSweep = false;
 
-        QString custom_prefix;
+        QString dataset_prefix;
+        bool isCustomPrefix = false;
         if ( ngspice_output_filename.startsWith("spice4qucs.") ) {
-            custom_prefix = ngspice_output_filename.section('.', 1, 1).toLower();
+            dataset_prefix = ngspice_output_filename.section('.', 1, 1).toLower();
         } else {
-            QRegularExpression custom_prefix_rx("(?<=#).*?(?=#)");
-            custom_prefix = custom_prefix_rx.match(ngspice_output_filename).captured(0).toLower();
+            QRegularExpression dataset_prefix_rx("(?<=#).*?(?=#)");
+            dataset_prefix = dataset_prefix_rx.match(ngspice_output_filename).captured(0).toLower();
+            isCustomPrefix = !dataset_prefix.isEmpty();
         }
         QRegularExpression four_rx(".*\\.four[0-9]+$");
         QString full_outfile = workdir+QDir::separator()+ngspice_output_filename;
@@ -1210,7 +1212,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             parseNoiseOutput(full_outfile,sim_points,var_list,hasParSweep);
             if (hasParSweep) {
                 QString res_file = QDir::toNativeSeparators(workdir + QDir::separator()
-                                                        + "spice4qucs." + custom_prefix + ".cir.res");
+                                                        + "spice4qucs." + dataset_prefix + ".cir.res");
                 parseResFile(res_file,swp_var,swp_var_val);
             }
         } else if (ngspice_output_filename.endsWith(".pz")) {
@@ -1218,7 +1220,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             parsePZOutput(full_outfile,sim_points,var_list,hasParSweep);
             if (hasParSweep) {
                 QString res_file = QDir::toNativeSeparators(workdir + QDir::separator()
-                                                        + "spice4qucs." + custom_prefix + ".cir.res");
+                                                        + "spice4qucs." + dataset_prefix + ".cir.res");
                 parseResFile(res_file,swp_var,swp_var_val);
             }
         } else if (ngspice_output_filename.endsWith(".SENS.prn")) {
@@ -1236,12 +1238,12 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             if (ngspice_output_filename.endsWith("_swp_swp.plot")) { // 2-var parameter sweep
                 hasDblParSweep = true;
                 QString res2_file = QDir::toNativeSeparators(workdir + QDir::separator()
-                                                            + "spice4qucs." + custom_prefix + ".cir.res1");
+                                                            + "spice4qucs." + dataset_prefix + ".cir.res1");
                 parseResFile(res2_file,swp_var2,swp_var2_val);
             }
 
             QString res_file = QDir::toNativeSeparators(workdir + QDir::separator()
-                                                    + "spice4qucs." + custom_prefix + ".cir.res");
+                                                    + "spice4qucs." + dataset_prefix + ".cir.res");
             parseResFile(res_file,swp_var,swp_var_val);
 
             parseSTEPOutput(full_outfile,sim_points,var_list,isComplex);
@@ -1273,7 +1275,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             }
         }
         if (var_list.isEmpty()) continue; // nothing to convert
-        normalizeVarsNames(var_list, custom_prefix);
+        normalizeVarsNames(var_list, dataset_prefix, isCustomPrefix);
 
         QString indep = var_list.first();
         //QList<double> sim_point;
@@ -1377,7 +1379,7 @@ void AbstractSpiceKernel::removeAllSimulatorOutputs()
  *        for harmonic balance variable and current probes variables are supported.
  * \param var_list This list contains variable names that need normalization.
  */
-void AbstractSpiceKernel::normalizeVarsNames(QStringList &var_list, const QString &custom_prefix)
+void AbstractSpiceKernel::normalizeVarsNames(QStringList &var_list, const QString &dataset_prefix, bool isCustom)
 {
     QString prefix="";
     QString iprefix="";
@@ -1434,11 +1436,11 @@ void AbstractSpiceKernel::normalizeVarsNames(QStringList &var_list, const QStrin
         }
     }
 
-    if ( needsPrefix )
-        if ( !custom_prefix.isEmpty() ) {
+    if ( needsPrefix || isCustom )
+        if ( !dataset_prefix.isEmpty() ) {
             for ( it = var_list.begin() ; it != var_list.end() ; ++it)
                 if ( !(*it).isEmpty() )
-                    (*it).prepend(custom_prefix + ".");
+                    (*it).prepend(dataset_prefix + ".");
         }
 }
 

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -1107,7 +1107,7 @@ int AbstractSpiceKernel::checkRawOutupt(QString ngspice_file, QStringList &value
     bool isXyce = false;
     if (ofile.open(QFile::ReadOnly)) {
         QTextStream ngsp_data(&ofile);
-        QRegularExpression prnln_rx("^\\D\\w*\\s=\\s-?\\d.\\d+[Ee][+-]\\d+");
+        QRegularExpression prnln_rx("^[A-Za-z].*\\s=\\s-?\\d.\\d+[Ee][+-]\\d+");
         QRegularExpression rx("^0\\s+[0-9].*"); // Zero index pattern
         while (!ngsp_data.atEnd()) {
             QString lin = ngsp_data.readLine();

--- a/qucs/extsimkernels/abstractspicekernel.h
+++ b/qucs/extsimkernels/abstractspicekernel.h
@@ -48,7 +48,7 @@ class AbstractSpiceKernel : public QObject
 private:
     enum outType {xyceSTD, spiceRaw, spiceRawSwp, xyceSTDswp, spicePrn, Unknown};
 
-    void normalizeVarsNames(QStringList &var_list, const QString &custom_prefix);
+    void normalizeVarsNames(QStringList &var_list, const QString &dataset_prefix, bool isCustom = false);
     int checkRawOutupt(QString ngspice_file, QStringList &values);
     void extractBinSamples(QDataStream &dbl, QList< QList<double> > &sim_points,
                            int NumPoints, int NumVars, bool isComplex);

--- a/qucs/extsimkernels/customsimdialog.cpp
+++ b/qucs/extsimkernels/customsimdialog.cpp
@@ -192,7 +192,7 @@ void CustomSimDialog::slotFindVars()
 
 
     QStringList strings = edtCode->toPlainText().split('\n');
-    QRegularExpression let_pattern("^\\s*let\\s+[A-Za-z]+\\w*\\s*=.+");
+    QRegularExpression let_pattern("^\\s*let\\s+[A-Za-z].*=.+");
 
     for (const QString& line : strings) {
         if (let_pattern.match(line).hasMatch()) {


### PR DESCRIPTION
This PR addresses a regression I found in netlist rework where the prefix enclosed by # is not applied when there is only a custom simulation in the schematic. It also parses the nutmeg script code to detect the simulations used and avoid unnecessary prefixing. Finally it changes regexes to allow variable names containing points to be detected in the customsim dialog and extracted by scalars print parser.