### PR TITLE
Make building workflow trigger fire only when the code is changed

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,8 +3,10 @@ name: CMake
 on:
   push:
     branches: [ "master","current" ]
+    paths: [ "**.cpp", "**.h", "**/CMakeLists.txt" ]
   pull_request:
     branches: [ "master","current" ]
+    paths: [ "**.cpp", "**.h", "**/CMakeLists.txt" ]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)


### PR DESCRIPTION
Hi!

After opening #585 I noticed that building workflow had started despite there were no changes to the _application_ source code. This PR is an attempt to make build trigger more sophisticated and skip such changes. 

Adding path filters to the trigger makes it more "granular" and gurantees that building process doesn't start when something that doesn't affect the build (like README or translation) is changed.

see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore