### PR TITLE
Make Qt6 building workflow trigger fire only when the code is changed

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,10 +2,10 @@ name: CMake
 
 on:
   push:
-    branches: [ "master","current" ]
+    branches: [ "master", "current", "release/*" ]
     paths: [ "**.cpp", "**.h", "**/CMakeLists.txt" ]
   pull_request:
-    branches: [ "master","current" ]
+    branches: [ "master", "current", "release/*" ]
     paths: [ "**.cpp", "**.h", "**/CMakeLists.txt" ]
 
 env:

--- a/.github/workflows/cmake_qt6.yml
+++ b/.github/workflows/cmake_qt6.yml
@@ -2,10 +2,10 @@ name: CMake-Qt6
 
 on:
   push:
-    branches: [ "master","current" ]
+    branches: [ "master", "current", "release/*" ]
     paths: [ "**.cpp", "**.h", "**/CMakeLists.txt" ]
   pull_request:
-    branches: [ "master","current" ]
+    branches: [ "master", "current", "release/*" ]
     paths: [ "**.cpp", "**.h", "**/CMakeLists.txt" ]
 
 env:

--- a/.github/workflows/cmake_qt6.yml
+++ b/.github/workflows/cmake_qt6.yml
@@ -3,8 +3,10 @@ name: CMake-Qt6
 on:
   push:
     branches: [ "master","current" ]
+    paths: [ "**.cpp", "**.h", "**/CMakeLists.txt" ]
   pull_request:
     branches: [ "master","current" ]
+    paths: [ "**.cpp", "**.h", "**/CMakeLists.txt" ]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)


### PR DESCRIPTION
Hi! In #586 I completely forgot that there are _two_ workflows and changed only the one with Qt5. This PR does the same but for Qt6 workflow this time.

Citing from #586:
>Adding path filters to the trigger makes it more "granular" and gurantees that building process doesn't start when something that doesn't affect the build (like README or translation) is changed.
>
>see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore