### PR TITLE
DC PZ SENS SENS_AC equations

### DIFF
--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -1543,6 +1543,9 @@ QStringList ComponentDialog::getSimulationList()
         Component *c = sch->DocComps.at(i);
         if (!c->isSimulation) continue;
         if (c->Model == ".FOUR") continue;
+        if (c->Model == ".PZ") continue;
+        if (c->Model == ".SENS") continue;
+        if (c->Model == ".SENS_AC") continue;
         if (c->Model == ".SW" && !c->Props.at(0)->Value.toUpper().startsWith("DC") ) continue;
         sim_lst.append(c->Name);
     }

--- a/qucs/components/dc_sim.cpp
+++ b/qucs/components/dc_sim.cpp
@@ -93,7 +93,6 @@ QString DC_Sim::spice_netlist(bool isXyce)
     QString s;
     if ( !isXyce ) {
         s += "op\n";
-        s += QString("print all > spice4qucs.%1.ngspice.dc.print\n").arg(Name.toLower());
     }
 
     return s;

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -290,7 +290,6 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
         } else if ( sim_typ == ".DC" ) {
             dcSims++;
             spiceNetlist.append(pc->getSpiceNetlist());
-            outputs.append("spice4qucs." + sim_name + ".ngspice.dc.print");
         } else if ( sim_typ == ".SW" ) {
             QString SwpSim = pc->Props.at(0)->Value.toLower();
             if ( SwpSim.startsWith("dc") ) {
@@ -310,7 +309,11 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
         }
         nods.append(' ' + dep_vars.join(' '));
 
-        if ( (sim_typ != ".PZ") && (sim_typ != ".SENS") && (sim_typ != ".SENS_AC") && (sim_typ != ".DC") ) {
+        if ( sim_typ == ".DC" ) {
+            QString out = "spice4qucs." + sim_name + ".ngspice.dc.print";
+            spiceNetlist.append(QString("print all > %1\n").arg(out));
+            outputs.append(out);
+        } else if ( (sim_typ != ".PZ") && (sim_typ != ".SENS") && (sim_typ != ".SENS_AC") ) {
             nods = nods.simplified();
             if ( !nods.isEmpty() ) {
                 QString basenam = "spice4qucs";

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -300,14 +300,16 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
         } else
             continue;
 
-        QStringList dep_vars;
-        for ( unsigned int i = 0 ; i < Sch->DocComps.count() ; i++ ) {
-            Component *pc1 = Sch->DocComps.at(i);
-            if ( pc1->isActive != COMP_IS_ACTIVE ) continue;
-            if ( pc1->Model == "Eqn" || pc1->Model == "NutmegEq" )
-                spiceNetlist.append(pc1->getEquations(sim_name, dep_vars));
+        if ( (sim_typ != ".PZ") && (sim_typ != ".SENS") && (sim_typ != ".SENS_AC") ) {
+            QStringList dep_vars;
+            for ( unsigned int i = 0 ; i < Sch->DocComps.count() ; i++ ) {
+                Component *pc1 = Sch->DocComps.at(i);
+                if ( pc1->isActive != COMP_IS_ACTIVE ) continue;
+                if ( pc1->Model == "Eqn" || pc1->Model == "NutmegEq" )
+                    spiceNetlist.append(pc1->getEquations(sim_name, dep_vars));
+            }
+            nods.append(' ' + dep_vars.join(' '));
         }
-        nods.append(' ' + dep_vars.join(' '));
 
         if ( sim_typ == ".DC" ) {
             QString out = "spice4qucs." + sim_name + ".ngspice.dc.print";


### PR DESCRIPTION
Enable equations in DC simulation to allow voltage diffs calculations etc.

Disable equations for PZ, SENS and SENS_AC.
Actually the equations have never worked. I don't have complete understanding how these simulations work and how their output is parsed.