### PR TITLE
Fix some parameter and frequency sweep issues #186

### DIFF
--- a/qucs/components/ac_sim.cpp
+++ b/qucs/components/ac_sim.cpp
@@ -114,7 +114,7 @@ QString AC_Sim::spice_netlist(bool isXyce)
         misc::str2num(Props.at(2)->Value,Fstop,unit,fac);
         Fstop *= fac;
         double Nd = ceil(log10(Fstop/Fstart)); // number of decades
-        double Npd = ceil(Np/Nd); // points per decade
+        double Npd = ceil((Np - 1)/Nd); // points per decade
         s += QString("DEC %1 ").arg(Npd);
     } else {  // no need conversion
         s += QString("LIN %1 ").arg(Props.at(3)->Value);

--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -1395,7 +1395,7 @@ void ComponentDialog::slotNumberChanged(const QString&)
     if(y == 0.0)  y = x / 10.0;
     if(x == 0.0)  x = y * 10.0;
     if(y == 0.0) { y = 1.0;  x = 10.0; }
-    x = editNumber->text().toDouble() / log10(fabs(x / y));
+    x = (editNumber->text().toDouble() - 1) / log10(fabs(x / y));
     Unit = QString::number(x);
   }
   else {

--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -1450,7 +1450,7 @@ void ComponentDialog::slotStepChanged(const QString& Step)
   }
 
   editNumber->blockSignals(true);  // do not calculate number again
-  editNumber->setText(QString::number(floor(x + 1.0)));
+  editNumber->setText(QString::number(round(x + 1.0), 'g', 16));
   editNumber->blockSignals(false);
 }
 

--- a/qucs/components/param_sweep.cpp
+++ b/qucs/components/param_sweep.cpp
@@ -143,14 +143,12 @@ QString Param_Sweep::getNgspiceBeforeSim(QString sim, int lvl)
         } else {
             start = log10(start);
             stop = log10(stop);
-            step = (stop - start)/points;
+            step = (stop - start)/(points - 1);
 
-            for(; start <= stop; start += step) {
+            while ( points > 0 ) {
                 s += QString("%1 ").arg(pow(10, start));
-            }
-
-            if (start - step < stop) {
-                s += QString("%1 ").arg(pow(10, stop));
+                start += step;
+                points -= 1;
             }
         }
     }

--- a/qucs/components/param_sweep.cpp
+++ b/qucs/components/param_sweep.cpp
@@ -249,7 +249,7 @@ QString Param_Sweep::spice_netlist(bool isXyce)
         stop *= fac;
         misc::str2num(getProperty("Points")->Value,points,unit,fac);
         points *= fac;
-        step = (stop-start)/points;
+        step = (stop-start)/(points-1);
     }
 
     if (Props.at(0)->Value.toLower().startsWith("dc")) {

--- a/qucs/components/param_sweep.cpp
+++ b/qucs/components/param_sweep.cpp
@@ -137,8 +137,10 @@ QString Param_Sweep::getNgspiceBeforeSim(QString sim, int lvl)
 
         if(type == "lin") {
             step = (stop-start)/(points-1);
-            for (; start <= stop; start += step) {
+            while ( points > 0 ) {
                 s += QString("%1 ").arg(start);
+                start += step;
+                points -= 1;
             }
         } else {
             start = log10(start);

--- a/qucs/components/param_sweep.cpp
+++ b/qucs/components/param_sweep.cpp
@@ -136,7 +136,7 @@ QString Param_Sweep::getNgspiceBeforeSim(QString sim, int lvl)
         stop = std::max(ostart,ostop);
 
         if(type == "lin") {
-            step = (stop-start)/points;
+            step = (stop-start)/(points-1);
             for (; start <= stop; start += step) {
                 s += QString("%1 ").arg(start);
             }

--- a/qucs/components/sp_sim.cpp
+++ b/qucs/components/sp_sim.cpp
@@ -190,7 +190,7 @@ QString SP_Sim::getSweepString()
         misc::str2num(Props.at(2)->Value,Fstop,unit,fac);
         Fstop *= fac;
         double Nd = ceil(log10(Fstop/Fstart)); // number of decades
-        double Npd = ceil(Np/Nd); // points per decade
+        double Npd = ceil((Np - 1)/Nd); // points per decade
         s += QString("DEC %1 ").arg(Npd);
     } else {  // no need conversion
         s += QString("LIN %1 ").arg(Props.at(3)->Value);

--- a/qucs/components/tr_sim.cpp
+++ b/qucs/components/tr_sim.cpp
@@ -116,7 +116,7 @@ QString TR_Sim::spice_netlist(bool isXyce)
     misc::str2num(Props.at(2)->Value,Tstop,unit,fac);
     Tstop *= fac;
     Npoints = Props.at(3)->Value.toDouble();
-    Tstep = (Tstop-Tstart)/Npoints;
+    Tstep = (Tstop-Tstart)/(Npoints-1);
 
     s += QString(" %1 %2 %3 ").arg(Tstep).arg(Tstop).arg(Tstart);
 

--- a/qucs/spicecomponents/sp_disto.cpp
+++ b/qucs/spicecomponents/sp_disto.cpp
@@ -94,7 +94,7 @@ QString SpiceDisto::spice_netlist(bool isXyce)
             misc::str2num(Props.at(2)->Value,Fstop,unit,fac);
             Fstop *= fac;
             double Nd = ceil(log10(Fstop/Fstart)); // number of decades
-            double Npd = ceil(Np/Nd); // points per decade
+            double Npd = ceil((Np - 1)/Nd); // points per decade
             points = QString::number(Npd);
         } else {
             points = Props.at(3)->Value;

--- a/qucs/spicecomponents/sp_noise.cpp
+++ b/qucs/spicecomponents/sp_noise.cpp
@@ -95,7 +95,7 @@ QString SpiceNoise::spice_netlist(bool isXyce)
         misc::str2num(Props.at(2)->Value,Fstop,unit,fac);
         Fstop *= fac;
         double Nd = ceil(log10(Fstop/Fstart)); // number of decades
-        double Npd = ceil(Np/Nd); // points per decade
+        double Npd = ceil((Np - 1)/Nd); // points per decade
         points = QString::number(Npd);
     } else {
         points = Props.at(3)->Value;


### PR DESCRIPTION
This PR addresses #186, linear parameter sweep issues when using ngspice.
It also addresses logarithmic parameter and frequency sweep issues. I submit it as a draft because it was tested with ngspice only  and my use cases for sweep values are quite limited.