### PR TITLE
Refactor: decouple Component::entireBody from Schematic

### DIFF
--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -113,18 +113,8 @@ int Component::textSize(int &_dx, int &_dy) {
 void Component::entireBounds(int& boundingRectLeft, int& boundingRectTop,
                              int& boundingRectRight, int& boundingRectBottom,
                              float Corr) {
-    boundingRectLeft   = x1 + cx;
-    boundingRectTop    = y1 + cy;
-    boundingRectRight  = x2 + cx;
-    boundingRectBottom = y2 + cy;
-
-    // text boundings
-    if (tx < x1) {
-        boundingRectLeft = tx + cx;
-    }
-    if (ty < y1) {
-        boundingRectTop = ty + cy;
-    }
+    boundingRectLeft = std::min(x1, tx) + cx;
+    boundingRectTop  = std::min(y1, ty) + cy;
 
     int textPropertyMaxWidth, totalTextPropertiesHeight, textPropertiesCount;
     textPropertiesCount = textSize(textPropertyMaxWidth, totalTextPropertiesHeight);
@@ -132,12 +122,8 @@ void Component::entireBounds(int& boundingRectLeft, int& boundingRectTop,
         int(float(textPropertiesCount) /
             Corr); // correction for unproportional font scaling
 
-    if ((tx + textPropertyMaxWidth) > x2) {
-        boundingRectRight = tx + textPropertyMaxWidth + cx;
-    }
-    if ((ty + totalTextPropertiesHeight) > y2) {
-        boundingRectBottom = ty + totalTextPropertiesHeight + cy;
-    }
+    boundingRectRight  = std::max(tx + textPropertyMaxWidth, x2) + cx;
+    boundingRectBottom = std::max(ty + totalTextPropertiesHeight, y2) + cy;
 }
 
 // -------------------------------------------------------

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -113,8 +113,7 @@ int Component::textSize(int &textPropertyMaxWidth, int &totalTextPropertiesHeigh
 // -------------------------------------------------------
 // Boundings including the component text.
 void Component::entireBounds(int& boundingRectLeft, int& boundingRectTop,
-                             int& boundingRectRight, int& boundingRectBottom,
-                             float Corr) {
+                             int& boundingRectRight, int& boundingRectBottom) {
     boundingRectLeft = std::min(x1, tx) + cx;
     boundingRectTop  = std::min(y1, ty) + cy;
 
@@ -460,7 +459,7 @@ void Component::paintScheme(Schematic *p) {
 
         int _x1, _x2, _y1, _y2;
         // textCorr to entireBounds
-        entireBounds(_x1, _y1, _x2, _y2, p->textCorr());
+        entireBounds(_x1, _y1, _x2, _y2);
         p->PostPaintEvent(_Rect, _x1, _y1, _x2 - _x1, _y2 - _y1);
 
         return;

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -117,8 +117,8 @@ void Component::entireBounds(int& boundingRectLeft, int& boundingRectTop,
     boundingRectLeft = std::min(x1, tx) + cx;
     boundingRectTop  = std::min(y1, ty) + cy;
 
-    int textPropertyMaxWidth, totalTextPropertiesHeight, textPropertiesCount;
-    textPropertiesCount = textSize(textPropertyMaxWidth, totalTextPropertiesHeight);
+    int textPropertyMaxWidth, totalTextPropertiesHeight;
+    textSize(textPropertyMaxWidth, totalTextPropertiesHeight);
 
     boundingRectRight  = std::max(tx + textPropertyMaxWidth, x2) + cx;
     boundingRectBottom = std::max(ty + totalTextPropertiesHeight, y2) + cy;

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -460,6 +460,7 @@ void Component::paintScheme(Schematic *p) {
 //        p->PostPaintEvent(_Line, cx + xb - 2, cy, cx + xb - 6, cy - 5);
 
         int _x1, _x2, _y1, _y2;
+        // textCorr to entireBounds
         entireBounds(_x1, _y1, _x2, _y2, p->textCorr());
         p->PostPaintEvent(_Rect, _x1, _y1, _x2 - _x1, _y2 - _y1);
 

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -110,22 +110,22 @@ int Component::textSize(int &_dx, int &_dy) {
 
 // -------------------------------------------------------
 // Boundings including the component text.
-void Component::entireBounds(int &_x1, int &_y1, int &_x2, int &_y2, float Corr) {
-    _x1 = x1 + cx;
-    _y1 = y1 + cy;
-    _x2 = x2 + cx;
-    _y2 = y2 + cy;
+void Component::entireBounds(int &boundingRectLeft, int &boundingRectTop, int &boundingRectRight, int &boundingRectBottom, float Corr) {
+    boundingRectLeft = x1 + cx;
+    boundingRectTop = y1 + cy;
+    boundingRectRight = x2 + cx;
+    boundingRectBottom = y2 + cy;
 
     // text boundings
-    if (tx < x1) _x1 = tx + cx;
-    if (ty < y1) _y1 = ty + cy;
+    if (tx < x1) boundingRectLeft = tx + cx;
+    if (ty < y1) boundingRectTop = ty + cy;
 
-    int dx, dy, ny;
-    ny = textSize(dx, dy);
-    dy = int(float(ny) / Corr);  // correction for unproportional font scaling
+    int textPropertyMaxWidth, totalTextPropertiesHeight, textPropertiesCount;
+    textPropertiesCount = textSize(textPropertyMaxWidth, totalTextPropertiesHeight);
+    totalTextPropertiesHeight = int(float(textPropertiesCount) / Corr);  // correction for unproportional font scaling
 
-    if ((tx + dx) > x2) _x2 = tx + dx + cx;
-    if ((ty + dy) > y2) _y2 = ty + dy + cy;
+    if ((tx + textPropertyMaxWidth) > x2) boundingRectRight = tx + textPropertyMaxWidth + cx;
+    if ((ty + totalTextPropertiesHeight) > y2) boundingRectBottom = ty + totalTextPropertiesHeight + cy;
 }
 
 // -------------------------------------------------------

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -81,16 +81,16 @@ void Component::Bounding(int &_x1, int &_y1, int &_x2, int &_y2) {
 
 // -------------------------------------------------------
 // Size of component text.
-int Component::textSize(int &_dx, int &_dy) {
+int Component::textSize(int &textPropertyMaxWidth, int &totalTextPropertiesHeight) {
     // get size of text using the screen-compatible metric
     QFontMetrics metrics(QucsSettings.font, 0);
-    int count = 0;
-    _dx = _dy = 0;
+    int textPropertiesCount = 0;
+    textPropertyMaxWidth = totalTextPropertiesHeight = 0;
 
     if (showName) {
-        _dx = metrics.boundingRect(Name).width();
-        _dy = metrics.height();
-        count++;
+        textPropertyMaxWidth = metrics.boundingRect(Name).width();
+        totalTextPropertiesHeight = metrics.height();
+        textPropertiesCount++;
     }
 
     constexpr int flags = 0b00000000;
@@ -99,13 +99,13 @@ int Component::textSize(int &_dx, int &_dy) {
 
         // Update overall width if text of the current property is wider
         auto w = metrics.size(flags, p->Name + "=" + p->Value).width();
-        if (w > _dx) {
-            _dx = w;
+        if (w > textPropertyMaxWidth) {
+            textPropertyMaxWidth = w;
         }
-        _dy += metrics.height();
-        count++;
+        totalTextPropertiesHeight += metrics.height();
+        textPropertiesCount++;
     }
-    return count;
+    return textPropertiesCount;
 }
 
 // -------------------------------------------------------

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -102,6 +102,8 @@ int Component::textSize(int &textPropertyMaxWidth, int &totalTextPropertiesHeigh
         if (w > textPropertyMaxWidth) {
             textPropertyMaxWidth = w;
         }
+        // keeps total height of all text properties of component
+        // taking line breaks into account
         totalTextPropertiesHeight += metrics.height();
         textPropertiesCount++;
     }
@@ -118,9 +120,6 @@ void Component::entireBounds(int& boundingRectLeft, int& boundingRectTop,
 
     int textPropertyMaxWidth, totalTextPropertiesHeight, textPropertiesCount;
     textPropertiesCount = textSize(textPropertyMaxWidth, totalTextPropertiesHeight);
-    totalTextPropertiesHeight =
-        int(float(textPropertiesCount) /
-            Corr); // correction for unproportional font scaling
 
     boundingRectRight  = std::max(tx + textPropertyMaxWidth, x2) + cx;
     boundingRectBottom = std::max(ty + totalTextPropertiesHeight, y2) + cy;

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -110,22 +110,34 @@ int Component::textSize(int &_dx, int &_dy) {
 
 // -------------------------------------------------------
 // Boundings including the component text.
-void Component::entireBounds(int &boundingRectLeft, int &boundingRectTop, int &boundingRectRight, int &boundingRectBottom, float Corr) {
-    boundingRectLeft = x1 + cx;
-    boundingRectTop = y1 + cy;
-    boundingRectRight = x2 + cx;
+void Component::entireBounds(int& boundingRectLeft, int& boundingRectTop,
+                             int& boundingRectRight, int& boundingRectBottom,
+                             float Corr) {
+    boundingRectLeft   = x1 + cx;
+    boundingRectTop    = y1 + cy;
+    boundingRectRight  = x2 + cx;
     boundingRectBottom = y2 + cy;
 
     // text boundings
-    if (tx < x1) boundingRectLeft = tx + cx;
-    if (ty < y1) boundingRectTop = ty + cy;
+    if (tx < x1) {
+        boundingRectLeft = tx + cx;
+    }
+    if (ty < y1) {
+        boundingRectTop = ty + cy;
+    }
 
     int textPropertyMaxWidth, totalTextPropertiesHeight, textPropertiesCount;
     textPropertiesCount = textSize(textPropertyMaxWidth, totalTextPropertiesHeight);
-    totalTextPropertiesHeight = int(float(textPropertiesCount) / Corr);  // correction for unproportional font scaling
+    totalTextPropertiesHeight =
+        int(float(textPropertiesCount) /
+            Corr); // correction for unproportional font scaling
 
-    if ((tx + textPropertyMaxWidth) > x2) boundingRectRight = tx + textPropertyMaxWidth + cx;
-    if ((ty + totalTextPropertiesHeight) > y2) boundingRectBottom = ty + totalTextPropertiesHeight + cy;
+    if ((tx + textPropertyMaxWidth) > x2) {
+        boundingRectRight = tx + textPropertyMaxWidth + cx;
+    }
+    if ((ty + totalTextPropertiesHeight) > y2) {
+        boundingRectBottom = ty + totalTextPropertiesHeight + cy;
+    }
 }
 
 // -------------------------------------------------------

--- a/qucs/components/component.h
+++ b/qucs/components/component.h
@@ -60,7 +60,7 @@ public:
   void    getCenter(int&, int&);
   int     textSize(int&, int&);
   void    Bounding(int&, int&, int&, int&);
-  void    entireBounds(int&, int&, int&, int&, float);
+  void    entireBounds(int&, int&, int&, int&);
   bool    getSelected(int, int);
   int     getTextSelected(int, int, float);
   void    rotate();

--- a/qucs/imagewriter.cpp
+++ b/qucs/imagewriter.cpp
@@ -326,7 +326,7 @@ void ImageWriter::getSelAreaWidthAndHeight(Schematic *sch, int &wsel, int &hsel,
      for(Component *pc = sch->Components->first(); pc != 0; pc = sch->Components->next()) {
          if (pc->isSelected) {
            int x1,y1,x2,y2;
-           pc->entireBounds(x1,y1,x2,y2,sch->textCorr());  // textCorr to entireBounds
+           pc->entireBounds(x1, y1, x2, y2);
            updateMinMax(xmin,xmax,ymin,ymax,x1,x2,y1,y2);
          }
     }

--- a/qucs/imagewriter.cpp
+++ b/qucs/imagewriter.cpp
@@ -326,7 +326,7 @@ void ImageWriter::getSelAreaWidthAndHeight(Schematic *sch, int &wsel, int &hsel,
      for(Component *pc = sch->Components->first(); pc != 0; pc = sch->Components->next()) {
          if (pc->isSelected) {
            int x1,y1,x2,y2;
-           pc->entireBounds(x1,y1,x2,y2,sch->textCorr());
+           pc->entireBounds(x1,y1,x2,y2,sch->textCorr());  // textCorr to entireBounds
            updateMinMax(xmin,xmax,ymin,ymax,x1,x2,y1,y2);
          }
     }

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1286,7 +1286,7 @@ void MouseActions::MPressRotate(Schematic *Doc, QMouseEvent *, float fX, float f
         ((Component *) e)->rotate();
         Doc->setCompPorts((Component *) e);
         // enlarge viewarea if component lies outside the view
-        ((Component *) e)->entireBounds(x1, y1, x2, y2, Doc->textCorr());
+        ((Component *) e)->entireBounds(x1, y1, x2, y2, Doc->textCorr());  // textCorr to entireBounds
         Doc->enlargeView(x1, y1, x2, y2);
         break;
 
@@ -1353,7 +1353,7 @@ void MouseActions::MPressElement(Schematic *Doc, QMouseEvent *Event, float, floa
             //    qDebug() << "  +-+ got to insert:" << Comp->Name;
 
             // enlarge viewarea if component lies outside the view
-            Comp->entireBounds(x1, y1, x2, y2, Doc->textCorr());
+            Comp->entireBounds(x1, y1, x2, y2, Doc->textCorr());  // textCorr to entireBounds
             Doc->enlargeView(x1, y1, x2, y2);
             //Doc->setOnGrid(Comp->cx,Comp->cy);
 
@@ -1983,7 +1983,7 @@ void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
             case isAnalogComponent:
             case isDigitalComponent:
                 Doc->insertComponent((Component *) pe);
-                ((Component *) pe)->entireBounds(x1, y1, x2, y2, Doc->textCorr());
+                ((Component *) pe)->entireBounds(x1, y1, x2, y2, Doc->textCorr());  // textCorr to entireBounds
                 Doc->enlargeView(x1, y1, x2, y2);
                 break;
             }
@@ -2124,7 +2124,7 @@ void MouseActions::editElement(Schematic *Doc, QMouseEvent *Event)
         }
 
         Doc->setChanged(true, true);
-        c->entireBounds(x1, y1, x2, y2, Doc->textCorr());
+        c->entireBounds(x1, y1, x2, y2, Doc->textCorr());  // textCorr to entireBounds
         Doc->enlargeView(x1, y1, x2, y2);
         break;
 

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1286,7 +1286,7 @@ void MouseActions::MPressRotate(Schematic *Doc, QMouseEvent *, float fX, float f
         ((Component *) e)->rotate();
         Doc->setCompPorts((Component *) e);
         // enlarge viewarea if component lies outside the view
-        ((Component *) e)->entireBounds(x1, y1, x2, y2, Doc->textCorr());  // textCorr to entireBounds
+        ((Component *) e)->entireBounds(x1, y1, x2, y2);
         Doc->enlargeView(x1, y1, x2, y2);
         break;
 
@@ -1353,7 +1353,7 @@ void MouseActions::MPressElement(Schematic *Doc, QMouseEvent *Event, float, floa
             //    qDebug() << "  +-+ got to insert:" << Comp->Name;
 
             // enlarge viewarea if component lies outside the view
-            Comp->entireBounds(x1, y1, x2, y2, Doc->textCorr());  // textCorr to entireBounds
+            Comp->entireBounds(x1, y1, x2, y2);
             Doc->enlargeView(x1, y1, x2, y2);
             //Doc->setOnGrid(Comp->cx,Comp->cy);
 
@@ -1983,7 +1983,7 @@ void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
             case isAnalogComponent:
             case isDigitalComponent:
                 Doc->insertComponent((Component *) pe);
-                ((Component *) pe)->entireBounds(x1, y1, x2, y2, Doc->textCorr());  // textCorr to entireBounds
+                ((Component *) pe)->entireBounds(x1, y1, x2, y2);
                 Doc->enlargeView(x1, y1, x2, y2);
                 break;
             }
@@ -2124,7 +2124,7 @@ void MouseActions::editElement(Schematic *Doc, QMouseEvent *Event)
         }
 
         Doc->setChanged(true, true);
-        c->entireBounds(x1, y1, x2, y2, Doc->textCorr());  // textCorr to entireBounds
+        c->entireBounds(x1, y1, x2, y2);
         Doc->enlargeView(x1, y1, x2, y2);
         break;
 

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1149,6 +1149,26 @@ float Schematic::textCorr()
     Font.setPointSizeF(Scale * float(Font.pointSize()));
     // use the screen-compatible metric
     QFontMetrics metrics(Font, 0);
+    // Line spacing is the distance from one base line to the next
+    // and I think it's obvious that line spacing value somehow depends on
+    // font size.
+    // For simplicity let's say that this dependency has the form of
+    // a coefficient <k>, i.e. line spacing is equal to
+    //   fontSize * k.
+    //
+    // Then:
+    //   metrics.lineSpacing = (Scale * QucsSettings.font.pointSize()) * k
+    //
+    // And then the value returned here is a fraction:
+    //                   Scale
+    //   ———————————————————————————————————————————
+    //   (Scale * QucsSettings.font.pointSize()) * k
+    //
+    // Which is equal to one divided by original, n o t - s c a l e d
+    // lines spacing:
+    //                 1
+    //   —————————————————————————————————
+    //   QucsSettings.font.pointSize() * k
     return (Scale / float(metrics.lineSpacing()));
 }
 

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1194,11 +1194,10 @@ void Schematic::sizeOfAll(int &xmin, int &ymin, int &xmax, int &ymax)
                     return;
                 }
 
-    float Corr = textCorr();
     int x1, y1, x2, y2;
     // find boundings of all components
     for (pc = Components->first(); pc != 0; pc = Components->next()) {
-        pc->entireBounds(x1, y1, x2, y2, Corr);
+        pc->entireBounds(x1, y1, x2, y2);
         if (x1 < xmin)
             xmin = x1;
         if (x2 > xmax)
@@ -1314,7 +1313,6 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
                     return;
                 }
 
-    float Corr = textCorr();
     int x1, y1, x2, y2;
     // find boundings of all components
     for (pc = Components->first(); pc != 0; pc = Components->next()) {
@@ -1322,7 +1320,7 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
             continue;
         }
         isAnySelected = true;
-        pc->entireBounds(x1, y1, x2, y2, Corr);
+        pc->entireBounds(x1, y1, x2, y2);
         if (x1 < xmin)
             xmin = x1;
         if (x2 > xmax)


### PR DESCRIPTION
Hi guys!

I continue looking for parts of a codebase which could be streamlined or simplified, this is another part in the series.

A short overview:
1.  The `Component` class has the `entireBounds` member function which is used to calculate the size of a bounding rectangle of a component *including* component's text properties, i.e. something likes this:
<img width="380" alt="image" src="https://github.com/ra3xdh/qucs_s/assets/40355531/1de06a87-f2ef-4b84-b75f-cbf0af536222">

2. `Component::entireBounds` has a `Corr` argument which is assigned return value of the `Schematic::textCorr` every time `entireBounds` is invoked.

I claim that `Corr` argument and its usage within `Component::entireBounds` is pointless and could be safely removed. This is a *bold move*, so I'll try to make my point clear below. 

Commits are structured in a way that they make up something like a "story", so I suggest to review them separately.

1. First four commits (dd72946, 5982ea2, 57cb0ff, 66de66d) make no changes to semantics, they just rename variables and format code to ease understanding of subsequent changes.
2. Fifth commit (280542d) make no semantic changes too. It highlights joint usage of `Component::entireBounds` and `Schematic::textCorr` through out the code to emphasise the coupling between them.
4. Commit №6 (b10dee4) is the core of this PR. Below is a brief explaination why it is safe to remove `Corr` from `entireBounds`, commit message has a more thorough explanation.
 - Value returned by `Schematic::textCorr` is always equal to `1 / <font line height>`
 - This value is always passed to `Component::entireBounds` as `Corr` argument where it is used to calculate `<number of lines> / Corr`, which is in turn equal to `<number of lines> / (1 / <font line height>) = <number of lines> * <font line height>`
 - If text properties of a component are one-liners, than `<number of lines> * <font line height>` is equal to `totalTextPropertiesHeight` calculated by `Component::textSize` called from `entireBounds`
 - If text properties of a component are **not** one-liners, then `<number of lines> * <font line height>` is just wrong because it doesn't account line breaks.

Summing all up, statement `totalTextPropertiesHeight = int(float(textPropertiesCount) / Corr);` seems to be at least useless, at most wrong. 

4. The rest of the commits (d8d9669, 1b36f5b) is "cleaning up and polishing"
