### PR TITLE
Add tiny repository tracking badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Boosty](https://img.shields.io/badge/Boosty-donate-orange.svg)](https://boosty.to/qucs_s)
 [![Telegram](https://img.shields.io/badge/Telegram-chat-blue.svg)](https://t.me/qucs_s)
 [![Website](https://img.shields.io/badge/Website-ra3xdh.github.io-29d682.svg)](https://ra3xdh.github.io/)
+[![Packaging status](https://repology.org/badge/tiny-repos/qucs-s.svg)](https://repology.org/project/qucs-s/versions)
 
 ## About Qucs-S
 


### PR DESCRIPTION
Hi! 

This PR offers fancy stuff — a little badge to README which when clicked leads to the page tracking Qucs-S in various repositories. I think it would be nice to have it among the badges already in README.

Also merging this may be considered the reason to close #306 as the badge actually tracks Qucs-S in repos. 