### PR TITLE
Refactor coordinates transforming in Schematic

### DIFF
--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1045,6 +1045,12 @@ void Schematic::showNoZoom()
     renderModel(Scale, newModel, displayedInCenter, vpCenter);
  }
 
+ QPoint Schematic::setOnGrid(const QPoint& p) {
+   QPoint snappedToGrid{p.x(), p.y()};
+   setOnGrid(snappedToGrid.rx(), snappedToGrid.ry());
+   return snappedToGrid;
+ }
+
 // ---------------------------------------------------
 // Sets an arbitrary coordinate onto the next grid coordinate.
 void Schematic::setOnGrid(int &x, int &y)

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1080,7 +1080,7 @@ void Schematic::drawGrid(const ViewPainter& p)
 
     {
         // Draw small cross at origin of coordinates
-        const QPoint origin = contentsToViewport(modelToContents(QPoint{0, 0}));
+        const QPoint origin = modelToViewport(QPoint{0, 0});
         p.Painter->drawLine(origin.x() - 3, origin.y(), origin.x() + 4, origin.y());  // horizontal stick
         p.Painter->drawLine(origin.x(), origin.y() - 3, origin.x(), origin.y() + 4);  // vertical stick
     }
@@ -1102,18 +1102,11 @@ void Schematic::drawGrid(const ViewPainter& p)
     // grid-nodes should be drawn — where to start and where to finish drawing
     // these nodes.
 
-    // Find a point displayed in top-left corner
-    QPoint gridTopLeft = viewportToModel(viewportRect().topLeft());
-    // Set its coordinates to coordinates of nearest grid-point
-    setOnGrid(gridTopLeft.rx(), gridTopLeft.ry());
-    // Convert coordinates from model back to viewport
-    gridTopLeft = modelToContents(gridTopLeft);
-    gridTopLeft = contentsToViewport(gridTopLeft);
+    QPoint topLeft = viewportToModel(viewportRect().topLeft());
+    const QPoint gridTopLeft = modelToViewport(setOnGrid(topLeft));
 
-    QPoint gridBottomRight = viewportToModel(viewportRect().bottomRight());
-    setOnGrid(gridBottomRight.rx(), gridBottomRight.ry());
-    gridBottomRight = modelToContents(gridBottomRight);
-    gridBottomRight = contentsToViewport(gridBottomRight);
+    QPoint bottomRight = viewportToModel(viewportRect().bottomRight());
+    const QPoint gridBottomRight = modelToViewport(setOnGrid(bottomRight));
 
     // This is the minimal distance between drawn grid-nodes. No matter how
     // a user scales the view, any two adjacent nodes must have at least this

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -97,6 +97,7 @@ public:
   bool  rotateElements();
   bool  mirrorXComponents();
   bool  mirrorYComponents();
+  QPoint setOnGrid(const QPoint& p);
   void  setOnGrid(int&, int&);
   bool  elementsOnGrid();
 


### PR DESCRIPTION
Hi! 

This little piece rewrites coordinate conversions:
- "hand-crafted" and macro-based conversions are replaced with specialised member functions
- chained calls like "a-to-b then b-to-c" are replaced with "a-to-c" functions