### PR TITLE
Refactor Schematic::sizeOfSelection

### DIFF
--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1290,11 +1290,6 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
     ymin = INT_MAX;
     xmax = INT_MIN;
     ymax = INT_MIN;
-    Component *pc;
-    Diagram *pd;
-    Wire *pw;
-    WireLabel *pl;
-    Painting *pp;
 
     bool isAnySelected = false;
 
@@ -1309,7 +1304,7 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
 
     int x1, y1, x2, y2;
     // find boundings of all components
-    for (pc = Components->first(); pc != 0; pc = Components->next()) {
+    for (auto *pc = Components->first(); pc != 0; pc = Components->next()) {
         if (!pc->isSelected) {
             continue;
         }
@@ -1326,7 +1321,7 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
     }
 
     // find boundings of all wires
-    for (pw = Wires->first(); pw != 0; pw = Wires->next()) {
+    for (auto *pw = Wires->first(); pw != 0; pw = Wires->next()) {
         if (!pw->isSelected) {
             continue;
         }
@@ -1340,8 +1335,7 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
         if (pw->y2 > ymax)
             ymax = pw->y2;
 
-        pl = pw->Label;
-        if (pl) { // check position of wire label
+        if (auto *pl = pw->Label; pl) { // check position of wire label
             pl->getLabelBounding(x1, y1, x2, y2);
             if (x1 < xmin)
                 xmin = x1;
@@ -1355,12 +1349,12 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
     }
 
     // find boundings of all node labels
-    for (Node *pn = Nodes->first(); pn != 0; pn = Nodes->next()) {
+    for (auto *pn = Nodes->first(); pn != 0; pn = Nodes->next()) {
         if (!pn->isSelected) {
             continue;
         }
-        pl = pn->Label;
-        if (pl) { // check position of node label
+
+        if (auto *pl = pn->Label; pl) { // check position of node label
             isAnySelected = true;
             pl->getLabelBounding(x1, y1, x2, y2);
             if (x1 < xmin)
@@ -1375,7 +1369,7 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
     }
 
     // find boundings of all diagrams
-    for (pd = Diagrams->first(); pd != 0; pd = Diagrams->next()) {
+    for (auto *pd = Diagrams->first(); pd != 0; pd = Diagrams->next()) {
         if (!pd->isSelected) {
             continue;
         }
@@ -1406,7 +1400,7 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
     }
 
     // find boundings of all Paintings
-    for (pp = Paintings->first(); pp != nullptr; pp = Paintings->next()) {
+    for (auto *pp = Paintings->first(); pp != nullptr; pp = Paintings->next()) {
         if (!pp->isSelected) {
             continue;
         }

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -934,14 +934,10 @@ void Schematic::zoomToSelection() {
                     return;
                 }
 
-    // Coordinates of top-left and bottom-right corners of the selected
-    // elements bounding rectangle
-    int selectedX1, selectedX2, selectedY1, selectedY2 = 0;
-    sizeOfSelection(selectedX1, selectedY1, selectedX2, selectedY2);
+    const QRect selectedBoundingRect{ sizeOfSelection() };
 
     // Working with raw coordinates is clumsy, abstract them out
     const QRect usedBoundingRect{UsedX1, UsedY1, UsedX2 - UsedX1, UsedY2 - UsedY1};
-    const QRect selectedBoundingRect{selectedX1, selectedY1, selectedX2 - selectedX1, selectedY2 - selectedY1};
 
     if (selectedBoundingRect.width() == 0 || selectedBoundingRect.height() == 0) {
         // If nothing is selected, then what should be shown? Probably it's best
@@ -1284,12 +1280,12 @@ void Schematic::sizeOfAll(int &xmin, int &ymin, int &xmax, int &ymax)
     }
 }
 
-void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
+QRect Schematic::sizeOfSelection() const
 {
-    xmin = INT_MAX;
-    ymin = INT_MAX;
-    xmax = INT_MIN;
-    ymax = INT_MIN;
+    int xmin = INT_MAX;
+    int ymin = INT_MAX;
+    int xmax = INT_MIN;
+    int ymax = INT_MIN;
 
     bool isAnySelected = false;
 
@@ -1297,9 +1293,7 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
         if (Wires->isEmpty())
             if (Diagrams->isEmpty())
                 if (Paintings->isEmpty()) {
-                    xmin = xmax = 0;
-                    ymin = ymax = 0;
-                    return;
+                    return QRect{};
                 }
 
     int x1, y1, x2, y2;
@@ -1417,9 +1411,10 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
     }
 
     if (!isAnySelected) {
-        xmin = xmax = 0;
-        ymin = ymax = 0;
+        return QRect{};
     }
+
+    return QRect{xmin, ymin, xmax - xmin, ymax - ymin};
 }
 
 // ---------------------------------------------------

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1304,7 +1304,7 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
 
     int x1, y1, x2, y2;
     // find boundings of all components
-    for (auto *pc = Components->first(); pc != 0; pc = Components->next()) {
+    for (auto *pc : *Components) {
         if (!pc->isSelected) {
             continue;
         }
@@ -1321,7 +1321,7 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
     }
 
     // find boundings of all wires
-    for (auto *pw = Wires->first(); pw != 0; pw = Wires->next()) {
+    for (auto *pw : *Wires) {
         if (!pw->isSelected) {
             continue;
         }
@@ -1349,7 +1349,7 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
     }
 
     // find boundings of all node labels
-    for (auto *pn = Nodes->first(); pn != 0; pn = Nodes->next()) {
+    for (auto *pn : *Nodes) {
         if (!pn->isSelected) {
             continue;
         }
@@ -1369,7 +1369,7 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
     }
 
     // find boundings of all diagrams
-    for (auto *pd = Diagrams->first(); pd != 0; pd = Diagrams->next()) {
+    for (auto *pd : *Diagrams) {
         if (!pd->isSelected) {
             continue;
         }
@@ -1400,7 +1400,7 @@ void Schematic::sizeOfSelection(int &xmin, int &ymin, int &xmax, int &ymax)
     }
 
     // find boundings of all Paintings
-    for (auto *pp = Paintings->first(); pp != nullptr; pp = Paintings->next()) {
+    for (auto *pp : *Paintings) {
         if (!pp->isSelected) {
             continue;
         }

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1289,12 +1289,9 @@ QRect Schematic::sizeOfSelection() const
 
     bool isAnySelected = false;
 
-    if (Components->isEmpty())
-        if (Wires->isEmpty())
-            if (Diagrams->isEmpty())
-                if (Paintings->isEmpty()) {
-                    return QRect{};
-                }
+    if (Components->isEmpty() && Wires->isEmpty() && Diagrams->isEmpty() && Paintings->isEmpty()) {
+        return QRect{};
+    }
 
     int x1, y1, x2, y2;
     // find boundings of all components

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1280,8 +1280,7 @@ void Schematic::sizeOfAll(int &xmin, int &ymin, int &xmax, int &ymax)
     }
 }
 
-QRect Schematic::sizeOfSelection() const
-{
+QRect Schematic::sizeOfSelection() const {
     int xmin = INT_MAX;
     int ymin = INT_MAX;
     int xmax = INT_MIN;
@@ -1289,13 +1288,14 @@ QRect Schematic::sizeOfSelection() const
 
     bool isAnySelected = false;
 
-    if (Components->isEmpty() && Wires->isEmpty() && Diagrams->isEmpty() && Paintings->isEmpty()) {
+    if (Components->isEmpty() && Wires->isEmpty() && Diagrams->isEmpty() &&
+        Paintings->isEmpty()) {
         return QRect{};
     }
 
     int x1, y1, x2, y2;
     // find boundings of all components
-    for (auto *pc : *Components) {
+    for (auto* pc : *Components) {
         if (!pc->isSelected) {
             continue;
         }
@@ -1308,17 +1308,17 @@ QRect Schematic::sizeOfSelection() const
     }
 
     // find boundings of all wires
-    for (auto *pw : *Wires) {
+    for (auto* pw : *Wires) {
         if (!pw->isSelected) {
             continue;
         }
         isAnySelected = true;
-        xmin = std::min(pw->x1, xmin);
-        xmax = std::max(pw->x2, xmax);
-        ymin = std::min(pw->y1, ymin);
-        ymax = std::max(pw->y2, ymax);
+        xmin          = std::min(pw->x1, xmin);
+        xmax          = std::max(pw->x2, xmax);
+        ymin          = std::min(pw->y1, ymin);
+        ymax          = std::max(pw->y2, ymax);
 
-        if (auto *pl = pw->Label; pl) { // check position of wire label
+        if (auto* pl = pw->Label; pl) { // check position of wire label
             pl->getLabelBounding(x1, y1, x2, y2);
             xmin = std::min(x1, xmin);
             xmax = std::max(x2, xmax);
@@ -1328,12 +1328,12 @@ QRect Schematic::sizeOfSelection() const
     }
 
     // find boundings of all node labels
-    for (auto *pn : *Nodes) {
+    for (auto* pn : *Nodes) {
         if (!pn->isSelected) {
             continue;
         }
 
-        if (auto *pl = pn->Label; pl) { // check position of node label
+        if (auto* pl = pn->Label; pl) { // check position of node label
             isAnySelected = true;
             pl->getLabelBounding(x1, y1, x2, y2);
             xmin = std::min(x1, xmin);
@@ -1344,7 +1344,7 @@ QRect Schematic::sizeOfSelection() const
     }
 
     // find boundings of all diagrams
-    for (auto *pd : *Diagrams) {
+    for (auto* pd : *Diagrams) {
         if (!pd->isSelected) {
             continue;
         }
@@ -1355,19 +1355,20 @@ QRect Schematic::sizeOfSelection() const
         ymin = std::min(y1, ymin);
         ymax = std::max(y2, ymax);
 
-        for (Graph *pg : pd->Graphs)
+        for (Graph* pg : pd->Graphs) {
             // test all markers of diagram
-            for (Marker *pm : pg->Markers) {
+            for (Marker* pm : pg->Markers) {
                 pm->Bounding(x1, y1, x2, y2);
                 xmin = std::min(x1, xmin);
                 xmax = std::max(x2, xmax);
                 ymin = std::min(y1, ymin);
                 ymax = std::max(y2, ymax);
             }
+        }
     }
 
     // find boundings of all Paintings
-    for (auto *pp : *Paintings) {
+    for (auto* pp : *Paintings) {
         if (!pp->isSelected) {
             continue;
         }

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1304,14 +1304,10 @@ QRect Schematic::sizeOfSelection() const
         }
         isAnySelected = true;
         pc->entireBounds(x1, y1, x2, y2);
-        if (x1 < xmin)
-            xmin = x1;
-        if (x2 > xmax)
-            xmax = x2;
-        if (y1 < ymin)
-            ymin = y1;
-        if (y2 > ymax)
-            ymax = y2;
+        xmin = std::min(x1, xmin);
+        xmax = std::max(x2, xmax);
+        ymin = std::min(y1, ymin);
+        ymax = std::max(y2, ymax);
     }
 
     // find boundings of all wires
@@ -1320,25 +1316,17 @@ QRect Schematic::sizeOfSelection() const
             continue;
         }
         isAnySelected = true;
-        if (pw->x1 < xmin)
-            xmin = pw->x1;
-        if (pw->x2 > xmax)
-            xmax = pw->x2;
-        if (pw->y1 < ymin)
-            ymin = pw->y1;
-        if (pw->y2 > ymax)
-            ymax = pw->y2;
+        xmin = std::min(pw->x1, xmin);
+        xmax = std::max(pw->x2, xmax);
+        ymin = std::min(pw->y1, ymin);
+        ymax = std::max(pw->y2, ymax);
 
         if (auto *pl = pw->Label; pl) { // check position of wire label
             pl->getLabelBounding(x1, y1, x2, y2);
-            if (x1 < xmin)
-                xmin = x1;
-            if (x2 > xmax)
-                xmax = x2;
-            if (y1 < ymin)
-                ymin = y1;
-            if (y2 > ymax)
-                ymax = y2;
+            xmin = std::min(x1, xmin);
+            xmax = std::max(x2, xmax);
+            ymin = std::min(y1, ymin);
+            ymax = std::max(y2, ymax);
         }
     }
 
@@ -1351,14 +1339,10 @@ QRect Schematic::sizeOfSelection() const
         if (auto *pl = pn->Label; pl) { // check position of node label
             isAnySelected = true;
             pl->getLabelBounding(x1, y1, x2, y2);
-            if (x1 < xmin)
-                xmin = x1;
-            if (x2 > xmax)
-                xmax = x2;
-            if (y1 < ymin)
-                ymin = y1;
-            if (y2 > ymax)
-                ymax = y2;
+            xmin = std::min(x1, xmin);
+            xmax = std::max(x2, xmax);
+            ymin = std::min(y1, ymin);
+            ymax = std::max(y2, ymax);
         }
     }
 
@@ -1369,27 +1353,19 @@ QRect Schematic::sizeOfSelection() const
         }
         isAnySelected = true;
         pd->Bounding(x1, y1, x2, y2);
-        if (x1 < xmin)
-            xmin = x1;
-        if (x2 > xmax)
-            xmax = x2;
-        if (y1 < ymin)
-            ymin = y1;
-        if (y2 > ymax)
-            ymax = y2;
+        xmin = std::min(x1, xmin);
+        xmax = std::max(x2, xmax);
+        ymin = std::min(y1, ymin);
+        ymax = std::max(y2, ymax);
 
         for (Graph *pg : pd->Graphs)
             // test all markers of diagram
             for (Marker *pm : pg->Markers) {
                 pm->Bounding(x1, y1, x2, y2);
-                if (x1 < xmin)
-                    xmin = x1;
-                if (x2 > xmax)
-                    xmax = x2;
-                if (y1 < ymin)
-                    ymin = y1;
-                if (y2 > ymax)
-                    ymax = y2;
+                xmin = std::min(x1, xmin);
+                xmax = std::max(x2, xmax);
+                ymin = std::min(y1, ymin);
+                ymax = std::max(y2, ymax);
             }
     }
 
@@ -1400,14 +1376,10 @@ QRect Schematic::sizeOfSelection() const
         }
         isAnySelected = true;
         pp->Bounding(x1, y1, x2, y2);
-        if (x1 < xmin)
-            xmin = x1;
-        if (x2 > xmax)
-            xmax = x2;
-        if (y1 < ymin)
-            ymin = y1;
-        if (y2 > ymax)
-            ymax = y2;
+        xmin = std::min(x1, xmin);
+        xmax = std::max(x2, xmax);
+        ymin = std::min(y1, ymin);
+        ymax = std::max(y2, ymax);
     }
 
     if (!isAnySelected) {

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -93,7 +93,7 @@ public:
   float textCorr();
   bool sizeOfFrame(int&, int&);
   void  sizeOfAll(int&, int&, int&, int&);
-  void  sizeOfSelection(int&, int&, int&, int&);
+  QRect  sizeOfSelection() const;
   bool  rotateElements();
   bool  mirrorXComponents();
   bool  mirrorYComponents();


### PR DESCRIPTION
Hi!

A bit of refactoring of one of the `Schematic`'s member functions. The main idea is to move the function from returning result via a set of argument reference variables to returning it the usual way, packed in suitable abstraction.

Commits are logically independent and reasonably small, so I suggest reviewing them one by one.

The function is invoked only when "zoom to selection" is performed, so if there any bugs they will affect zooming.