### PR TITLE
Add Qucs-RFlayout integration

### DIFF
--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -475,6 +475,7 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     ascoEdit->setText(QucsSettings.AscoBinDir.canonicalPath());
     octaveEdit->setText(QucsSettings.OctaveExecutable);
     OpenVAFEdit->setText(QucsSettings.OpenVAFExecutable);
+    RFLayoutEdit->setText(QucsSettings.RFLayoutExecutable);
 
 
     resize(300, 200);
@@ -674,6 +675,7 @@ void QucsSettingsDialog::slotApply()
     QucsSettings.AscoBinDir.setPath(ascoEdit->text());
     QucsSettings.OctaveExecutable = octaveEdit->text();
     QucsSettings.OpenVAFExecutable = OpenVAFEdit->text();
+    QucsSettings.RFLayoutExecutable = RFLayoutEdit->text();
 
     if (QucsSettings.IgnoreFutureVersion != checkLoadFromFutureVersions->isChecked())
     {

--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -374,6 +374,13 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     locationsGrid->addWidget(OpenVAFButt, 5, 2);
     connect(OpenVAFButt, SIGNAL(clicked()), SLOT(slotOpenVAFDirBrowse()));
 
+    locationsGrid->addWidget(new QLabel(tr("RF Layout Path:"), locationsTab) ,6,0);
+    RFLayoutEdit = new QLineEdit(locationsTab);
+    locationsGrid->addWidget(RFLayoutEdit,6,1);
+    QPushButton *RFLButt = new QPushButton("Browse");
+    locationsGrid->addWidget(RFLButt, 6, 2);
+    connect(RFLButt, SIGNAL(clicked()), SLOT(slotRFLayoutDirBrowse()));
+
 
     // the pathsTableWidget displays the path list
     pathsTableWidget = new QTableWidget(locationsTab);
@@ -394,20 +401,20 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     pathsTableWidget->setSelectionMode(QAbstractItemView::ExtendedSelection);
     connect(pathsTableWidget, SIGNAL(cellClicked(int,int)), SLOT(slotPathTableClicked(int,int)));
     connect(pathsTableWidget, SIGNAL(itemSelectionChanged()), SLOT(slotPathSelectionChanged()));
-    locationsGrid->addWidget(pathsTableWidget,6,0,3,2);
+    locationsGrid->addWidget(pathsTableWidget,7,0,3,2);
 
     QPushButton *AddPathButt = new QPushButton("Add Path");
-    locationsGrid->addWidget(AddPathButt, 6, 2);
+    locationsGrid->addWidget(AddPathButt, 7, 2);
     connect(AddPathButt, SIGNAL(clicked()), SLOT(slotAddPath()));
 
     QPushButton *AddPathSubFolButt = new QPushButton("Add Path With SubFolders");
-    locationsGrid->addWidget(AddPathSubFolButt, 7, 2);
+    locationsGrid->addWidget(AddPathSubFolButt, 8, 2);
     connect(AddPathSubFolButt, SIGNAL(clicked()), SLOT(slotAddPathWithSubFolders()));
 
     RemovePathButt = new QPushButton("Remove Path");
     // disable button if no paths in the table are selected
     RemovePathButt->setEnabled(false);
-    locationsGrid->addWidget(RemovePathButt , 8, 2);
+    locationsGrid->addWidget(RemovePathButt , 9, 2);
     connect(RemovePathButt, SIGNAL(clicked()), SLOT(slotRemovePath()));
 
     // create a copy of the current global path list
@@ -1010,10 +1017,19 @@ void QucsSettingsDialog::slotOctaveDirBrowse()
 void QucsSettingsDialog::slotOpenVAFDirBrowse()
 {
   QString d = QFileDialog::getOpenFileName(this, tr("Select the OpenVAF executable"),
-                                           octaveEdit->text(), "All files (*)");
+                                           OpenVAFEdit->text(), "All files (*)");
 
   if(!d.isEmpty())
     OpenVAFEdit->setText(d);
+}
+
+void QucsSettingsDialog::slotRFLayoutDirBrowse()
+{
+  QString d = QFileDialog::getOpenFileName(this, tr("Select the Qucs-RFLayout executable"),
+                                           RFLayoutEdit->text(), "All files (*)");
+
+  if(!d.isEmpty())
+    RFLayoutEdit->setText(d);
 }
 
 /*! \brief (seems unused at present)

--- a/qucs/dialogs/qucssettingsdialog.h
+++ b/qucs/dialogs/qucssettingsdialog.h
@@ -71,6 +71,7 @@ private slots:
     void slotAscoDirBrowse();
     void slotOctaveDirBrowse();
     void slotOpenVAFDirBrowse();
+    void slotRFLayoutDirBrowse();
 
     void slotAddPath();
     void slotAddPathWithSubFolders();
@@ -91,7 +92,7 @@ public:
     QPushButton *FontButton, *AppFontButton, *TextFontButton, *BGColorButton;
     QLineEdit *LargeFontSizeEdit, *undoNumEdit, *editorEdit, *Input_Suffix,
               *Input_Program, *homeEdit, *admsXmlEdit, *ascoEdit, *octaveEdit,
-              *OpenVAFEdit;
+              *OpenVAFEdit, *RFLayoutEdit;
     QTableWidget *fileTypesTableWidget, *pathsTableWidget;
     QStandardItemModel *model;
     QPushButton *ColorComment, *ColorString, *ColorInteger,

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -171,6 +171,11 @@ bool loadSettings()
     } else {
         QucsSettings.OpenVAFExecutable = "openvaf" + QString(executableSuffix);
     }
+    if(settings.contains("RFLayoutExecutable")) {
+        QucsSettings.RFLayoutExecutable = settings.value("RFLayoutExecutable").toString();
+    } else {
+        QucsSettings.RFLayoutExecutable = "qucsrflayout" + QString(executableSuffix);
+    }
     if(settings.contains("QucsHomeDir"))
       if(settings.value("QucsHomeDir").toString() != "")
          QucsSettings.QucsHomeDir.setPath(settings.value("QucsHomeDir").toString());
@@ -272,6 +277,7 @@ bool saveApplSettings()
     // settings.setValue("OctaveBinDir", QucsSettings.OctaveBinDir.canonicalPath());
     settings.setValue("OctaveExecutable",QucsSettings.OctaveExecutable);
     settings.setValue("OpenVAFExecutable",QucsSettings.OpenVAFExecutable);
+    settings.setValue("RFLayoutExecutable",QucsSettings.RFLayoutExecutable);
     settings.setValue("QucsHomeDir", QucsSettings.QucsHomeDir.canonicalPath());
     settings.setValue("IgnoreVersion", QucsSettings.IgnoreFutureVersion);
     settings.setValue("GraphAntiAliasing", QucsSettings.GraphAntiAliasing);

--- a/qucs/main.h
+++ b/qucs/main.h
@@ -91,6 +91,7 @@ struct tQucsSettings {
   unsigned int NProcs; // Number of processors for Xyce
   QString OctaveExecutable; // OctaveExecutable location
   QString QucsOctave; // OUCS_OCTAVE variable
+  QString RFLayoutExecutable;
 
   // registered filename extensions with program to open the file
   QStringList FileTypes;

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -355,7 +355,7 @@ public:
           *distrHor, *distrVert, *selectAll, *callMatch, *changeProps,
           *addToProj, *editFind, *insEntity, *selectMarker,
           *createLib, *importData, *graph2csv, *createPkg, *extractPkg,
-          *callAtt, *centerHor, *centerVert, *loadModule, *buildModule, *callPwrComb;
+          *callAtt, *centerHor, *centerVert, *loadModule, *buildModule, *callPwrComb, *callRFLayout;
 
   QAction *helpQucsIndex;
   QAction *simSettings;
@@ -406,6 +406,7 @@ public slots:
   void slotCallMatch();
   void slotCallAtt();
   void slotCallPwrComb();
+  void slotCallRFLayout();
   void slotHelpIndex();       // shows a HTML docu: Help Index
   void slotHelpQucsIndex();
   void slotGettingStarted();  // shows a HTML docu: Getting started

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -931,7 +931,36 @@ void QucsApp::launchTool(const QString& prog, const QString& progDesc, const QSt
 
 void QucsApp::slotCallRFLayout()
 {
+    QString input_file;
+    if (!isTextDocument(DocumentTab->currentWidget())) {
+        Schematic *sch = (Schematic*)DocumentTab->currentWidget();
+        if(sch->fileSuffix() == "dpl") {
+            QMessageBox::critical(this,tr("Error"),
+                                  tr("Layouting of display pages is not supported!"));
+            return;
+        }
+        input_file = sch->DocName;
+    } else {
+        QMessageBox::critical(this,tr("Error"),
+                              tr("Layouting of text documents is not supported!"));
+        return;
+    }
 
+    QProcess *tool = new QProcess();
+    QStringList args;
+    args.append("-G");
+    args.append("-i");
+    args.append(input_file);
+    tool->start(QucsSettings.RFLayoutExecutable,args);
+
+    if(!tool->waitForStarted(1000) ) {
+      QMessageBox::critical(this, tr("Error"),
+                            tr("Cannot start Qucs-RFLayout: \n%1")
+                            .arg(QucsSettings.RFLayoutExecutable));
+      delete tool;
+      return;
+    }
+    connect(this, SIGNAL(signalKillEmAll()), tool, SLOT(kill()));
 }
 
 // --------------------------------------------------------------

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -890,7 +890,6 @@ void QucsApp::slotCallPwrComb()
   launchTool(QUCS_NAME "powercombining", "power combining calculation",QStringList());
 }
 
-
 /*!
  * \brief launch an external application passing arguments
  *
@@ -929,6 +928,11 @@ void QucsApp::launchTool(const QString& prog, const QString& progDesc, const QSt
   connect(this, SIGNAL(signalKillEmAll()), tool, SLOT(kill()));
 }
 
+
+void QucsApp::slotCallRFLayout()
+{
+
+}
 
 // --------------------------------------------------------------
 void QucsApp::slotHelpIndex()

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -537,6 +537,12 @@ void QucsApp::initActions()
   callPwrComb->setWhatsThis(tr("Power combining\n\nStarts power combining calculation program"));
   connect(callPwrComb, SIGNAL(triggered()), SLOT(slotCallPwrComb()));
 
+  callRFLayout = new QAction(tr("RF Layout"), this);
+  callRFLayout->setShortcut(tr("Ctrl+8"));
+  callRFLayout->setStatusTip(tr("Starts Qucs-RFLayout"));
+  callRFLayout->setWhatsThis(tr("Power combining\n\nStarts power combining calculation program"));
+  connect(callRFLayout, SIGNAL(triggered()), SLOT(slotCallRFLayout()));
+
   simulate = new QAction(QIcon((":/bitmaps/svg/gear.svg")), tr("Simulate"), this);
   simulate->setShortcut(Qt::Key_F2);
   simulate->setStatusTip(tr("Simulates the current schematic"));
@@ -774,6 +780,7 @@ void QucsApp::initMenuBar()
   toolMenu->addAction(callMatch);
   toolMenu->addAction(callAtt);
   toolMenu->addAction(callPwrComb);
+  toolMenu->addAction(callRFLayout);
   toolMenu->addSeparator();
 
   cmMenu = new QMenu(tr("Compact modelling"));


### PR DESCRIPTION
This PR adds a basic Qucs-RFLayout integration. The following things are implemented.

* The RFLayout tool could be launched from *Tools* menu in GUI mode. The schematic, netlist, and output directory are substituted automatically. 
* The location of RFLayout tool could be configured in *File->Application settings* on *Locations* tab
* No old Qucs installation is needed. The netlist is generated by means of Qucs-S

@thomaslepoix You are welcome to test it and post feedback. I am planning to include this integration in the next release.