### PR TITLE
Fixed Qucsconv start error

### DIFF
--- a/qucs/components/spicedialog.cpp
+++ b/qucs/components/spicedialog.cpp
@@ -392,6 +392,7 @@ bool SpiceDialog::loadSpiceNetList(const QString& s)
       prestream = new QTextStream(&PrepFile);
     }
     SpicePrep->start(spiceExe, spiceArgs);
+    SpicePrep->waitForStarted();
     if ((SpicePrep->state() != QProcess::Starting) &&
         (SpicePrep->state() != QProcess::Running))
     {
@@ -446,6 +447,7 @@ bool SpiceDialog::loadSpiceNetList(const QString& s)
       connect(QucsConv, SIGNAL(finished(int, QProcess::ExitStatus)), MBox, SLOT(close()));
 
       QucsConv->start(Program, Arguments);
+      QucsConv->waitForStarted();
 
       if(QucsConv->state() != QProcess::Running)
       {


### PR DESCRIPTION
Fixes Qucsconv start failure #652. The `No .END` directive warning removed in qucsartor_rf repository: https://github.com/ra3xdh/qucsator_rf/commit/bfb98b18317a2415f3139d0cca97b593795830c9