### PR TITLE
Change Qucs-S workspace and tempfile paths

### DIFF
--- a/qucs/components/opt_sim.cpp
+++ b/qucs/components/opt_sim.cpp
@@ -80,7 +80,7 @@ QString Optimize_Sim::netlist()
 bool Optimize_Sim::createASCOFiles()
 {
   Property* pp;
-  QFile afile(QucsSettings.QucsHomeDir.filePath("asco_netlist.cfg"));
+  QFile afile(QucsSettings.tempFilesDir.filePath("asco_netlist.cfg"));
   if(afile.open(QIODevice::WriteOnly)) {
     QTextStream stream(&afile);
     stream << "*\n";
@@ -164,7 +164,7 @@ bool Optimize_Sim::createASCOFiles()
     afile.close();
   } else return false;
 
-  QDir ExtractDir(QucsSettings.QucsHomeDir);
+  QDir ExtractDir(QucsSettings.tempFilesDir);
   if(!ExtractDir.cd("extract")) {
     if(!ExtractDir.mkdir("extract"))
       return false;
@@ -210,8 +210,8 @@ bool Optimize_Sim::createASCOnetlist()
     }
   }
 
-  QFile infile(QucsSettings.QucsHomeDir.filePath("netlist.txt"));
-  QFile outfile(QucsSettings.QucsHomeDir.filePath("asco_netlist.txt"));
+  QFile infile(QucsSettings.tempFilesDir.filePath("netlist.txt"));
+  QFile outfile(QucsSettings.tempFilesDir.filePath("asco_netlist.txt"));
   if(!infile.open(QIODevice::ReadOnly)) return false;
   if(!outfile.open(QIODevice::WriteOnly)) return false;
   QTextStream instream(&infile);
@@ -260,7 +260,7 @@ bool Optimize_Sim::loadASCOout()
     }
   }
 
-  QFile infile(QucsSettings.QucsHomeDir.filePath("asco_out.log"));
+  QFile infile(QucsSettings.tempFilesDir.filePath("asco_out.log"));
   if(!infile.open(QIODevice::ReadOnly)) return false;
   QTextStream instream(&infile);
   QString Line;

--- a/qucs/dialogs/librarydialog.cpp
+++ b/qucs/dialogs/librarydialog.cpp
@@ -255,7 +255,7 @@ void LibraryDialog::slotCreateNext()
     return;
   }
 
-  LibDir = QDir(QucsSettings.QucsHomeDir);
+  LibDir = QDir(QucsSettings.qucsWorkspaceDir);
   if(!LibDir.cd("user_lib")) { // user library directory exists ?
     if(!LibDir.mkdir("user_lib")) { // no, then create it
       QMessageBox::warning(this, tr("Warning"),

--- a/qucs/dialogs/packagedialog.cpp
+++ b/qucs/dialogs/packagedialog.cpp
@@ -101,7 +101,7 @@ PackageDialog::PackageDialog(QWidget *parent_, bool create_)
 
     // ...........................................................
     // insert all projects
-    QStringList PrDirs = QucsSettings.QucsHomeDir.entryList(QStringList("*"), QDir::Dirs, QDir::Name);
+    QStringList PrDirs = QucsSettings.qucsWorkspaceDir.entryList(QStringList("*"), QDir::Dirs, QDir::Name);
     QStringList::iterator it;
     for(it = PrDirs.begin(); it != PrDirs.end(); it++)
        if((*it).right(4) == "_prj"){   // project directories end with "_prj"
@@ -230,7 +230,7 @@ int PackageDialog::insertDirectory(const QString& DirName,
 int PackageDialog::insertLibraries(QDataStream& Stream)
 {
   QFile File;
-  QDir myDir(QucsSettings.QucsHomeDir.absolutePath() + QDir::separator() + "user_lib");
+  QDir myDir(QucsSettings.qucsWorkspaceDir.absolutePath() + QDir::separator() + "user_lib");
   QStringList Entries = myDir.entryList(QStringList("*"), QDir::Files, QDir::Name);
   QStringList::iterator it;
   for(it = Entries.begin(); it != Entries.end(); ++it) {
@@ -299,7 +299,7 @@ void PackageDialog::slotCreate()
     if(p->isChecked()) {
       s = p->text() + "_prj";
       Stream << Q_UINT32(CODE_DIR) << s.toLatin1();
-      s = QucsSettings.QucsHomeDir.absolutePath() + QDir::separator() + s;
+      s = QucsSettings.qucsWorkspaceDir.absolutePath() + QDir::separator() + s;
       if(insertDirectory(s, Stream) < 0) {
         PkgFile.close();
         PkgFile.remove();
@@ -369,7 +369,7 @@ void PackageDialog::extractPackage()
   }
   QDataStream Stream(&PkgFile);
 
-  QDir currDir = QucsSettings.QucsHomeDir;
+  QDir currDir = QucsSettings.qucsWorkspaceDir;
   QString Version;
   VersionTriplet PackageVersion;
   quint16 Checksum, Checksum1;
@@ -494,7 +494,7 @@ int PackageDialog::extractLibrary(QFile& PkgFile, Q_UINT32 Count)
   free(p);
 
   p = Content.data();
-  QFile File(QucsSettings.QucsHomeDir.absolutePath() +
+  QFile File(QucsSettings.qucsWorkspaceDir.absolutePath() +
              QDir::toNativeSeparators("/user_lib/") + QString(p));
   if(File.exists()) {
     MsgText->append(tr("ERROR: User library \"%1\" already exists!").arg(QString(p)));

--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -470,7 +470,7 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
             LanguageCombo->setCurrentIndex(z);
 
     /*! Load paths from settings */
-    homeEdit->setText(QucsSettings.QucsHomeDir.canonicalPath());
+    homeEdit->setText(QucsSettings.qucsWorkspaceDir.canonicalPath());
     admsXmlEdit->setText(QucsSettings.AdmsXmlBinDir.canonicalPath());
     ascoEdit->setText(QucsSettings.AscoBinDir.canonicalPath());
     octaveEdit->setText(QucsSettings.OctaveExecutable);
@@ -558,12 +558,12 @@ void QucsSettingsDialog::slotApply()
     bool homeDirChanged = false;
 
     // check QucsHome is changed, will require to close all files and refresh tree
-    if (homeEdit->text() != QucsSettings.QucsHomeDir.path()) {
+    if (homeEdit->text() != QucsSettings.qucsWorkspaceDir.path()) {
       // close all open files, asking the user whether to save the modified ones
       // if user aborts closing, just return
       if(!App->closeAllFiles()) return;
 
-      QucsSettings.QucsHomeDir.setPath(homeEdit->text());
+      QucsSettings.qucsWorkspaceDir.setPath(homeEdit->text());
       homeDirChanged = true;
       // later below the file tree will be refreshed
     }

--- a/qucs/dialogs/simmessage.cpp
+++ b/qucs/dialogs/simmessage.cpp
@@ -171,7 +171,7 @@ bool SimMessage::startProcess()
 
   Collect.clear();  // clear list for NodeSets, SPICE components etc.
   ProgText->appendPlainText(tr("creating netlist... "));
-  NetlistFile.setFileName(QucsSettings.QucsHomeDir.filePath("netlist.txt"));
+  NetlistFile.setFileName(QucsSettings.tempFilesDir.filePath("netlist.txt"));
    if(!NetlistFile.open(QIODevice::WriteOnly)) {
     ErrText->appendPlainText(tr("ERROR: Cannot write netlist file!"));
     FinishSimulation(-1);
@@ -351,7 +351,7 @@ void SimMessage::startSimulator()
 
   QString SimTime;
   QStringList Arguments;
-  QString SimPath = QDir::toNativeSeparators(QucsSettings.QucsHomeDir.absolutePath());
+  QString SimPath = QDir::toNativeSeparators(QucsSettings.tempFilesDir.absolutePath());
 #ifdef __MINGW32__
   QString QucsDigiLib = "qucs_mkdigilib.bat";
   QString QucsDigi = "qucs_run_hdl.bat";
@@ -401,7 +401,7 @@ void SimMessage::startSimulator()
       // runs GHDL (three passes with -a -e and -r commands.). Note GHDL expects the
       // time without spaces, so strip spaces from SimTime.
       Program = pathName(QucsSettings.BinDir + QucsDigi);
-      Arguments  << QucsSettings.QucsHomeDir.filePath("netlist.txt")
+      Arguments  << QucsSettings.tempFilesDir.filePath("netlist.txt")
                  << DataSet << SimTime.remove(" ") << pathName(SimPath)
                  << pathName(QucsSettings.BinDir) << libs;
     }
@@ -412,7 +412,7 @@ void SimMessage::startSimulator()
       QString entity = VInfo.EntityName.toLower();
       QString lib = Doc->Library.toLower();
       if (lib.isEmpty()) lib = "work";
-      QString dir = QDir::toNativeSeparators(QucsSettings.QucsHomeDir.path());
+      QString dir = QDir::toNativeSeparators(QucsSettings.tempFilesDir.absolutePath());
       QDir vhdlDir(dir);
       if(!vhdlDir.exists("vhdl"))
 	if(!vhdlDir.mkdir("vhdl")) {
@@ -438,7 +438,7 @@ void SimMessage::startSimulator()
       destFile.write(text.toLatin1(), text.length());
       destFile.close();
       Program = pathName(QucsSettings.BinDir + QucsDigiLib);
-      Arguments << QucsSettings.QucsHomeDir.filePath("netlist.txt")
+      Arguments << QucsSettings.tempFilesDir.filePath("netlist.txt")
                 << pathName(SimPath)
                 << entity
                 << lib;
@@ -538,7 +538,7 @@ void SimMessage::startSimulator()
 
         Program = QucsSettings.AscoBinDir.canonicalPath();
         Program = QDir::toNativeSeparators(Program+"/"+"asco"+QString(executableSuffix));
-        Arguments << "-qucs" << QucsSettings.QucsHomeDir.filePath("asco_netlist.txt")
+        Arguments << "-qucs" << QucsSettings.tempFilesDir.filePath("asco_netlist.txt")
                   << "-o" << "asco_out";
       }
       else {
@@ -550,14 +550,14 @@ void SimMessage::startSimulator()
           }
         } else Program = QucsSettings.QucsatorVar;
         Arguments << "-b" << "-g" << "-i"
-                  << QucsSettings.QucsHomeDir.filePath("netlist.txt")
+                  << QucsSettings.tempFilesDir.filePath("netlist.txt")
                   << "-o" << DataSet;
       }
     }
     else {
       if (isVerilog) {
           Program = QDir::toNativeSeparators(QucsSettings.BinDir + QucsVeri);
-          Arguments << QDir::toNativeSeparators(QucsSettings.QucsHomeDir.filePath("netlist.txt"))
+          Arguments << QDir::toNativeSeparators(QucsSettings.tempFilesDir.filePath("netlist.txt"))
                     << DataSet
                     << SimTime
                     << QDir::toNativeSeparators(SimPath)
@@ -574,7 +574,7 @@ void SimMessage::startSimulator()
               << QDir::toNativeSeparators(QucsSettings.BinDir) << "-Wall" << "-c";
 #else
     Program = QDir::toNativeSeparators(pathName(QucsSettings.BinDir + QucsDigi));
-    Arguments << QucsSettings.QucsHomeDir.filePath("netlist.txt")
+    Arguments << QucsSettings.tempFilesDir.filePath("netlist.txt")
               << DataSet << SimTime.remove(" ") << pathName(SimPath)
 		      << pathName(QucsSettings.BinDir) << "-Wall" << "-c";
 
@@ -801,7 +801,7 @@ void SimMessage::FinishSimulation(int Status)
     ProgText->appendPlainText("\n" + txt + "\n" + tr("Aborted."));
   }
 
-  QFile file(QucsSettings.QucsHomeDir.filePath("log.txt"));  // save simulator messages
+  QFile file(QucsSettings.tempFilesDir.filePath("log.txt"));  // save simulator messages
   if(file.open(QIODevice::WriteOnly)) {
     QTextStream stream(&file);
     stream << tr("Output:\n-------") << "\n\n";
@@ -816,7 +816,7 @@ void SimMessage::FinishSimulation(int Status)
 
   if(Status == 0) {
     if(SimOpt) { // save optimization data
-      QFile ifile(QucsSettings.QucsHomeDir.filePath("asco_out.dat"));
+      QFile ifile(QucsSettings.tempFilesDir.filePath("asco_out.dat"));
       QFile ofile(DataSet);
       if(ifile.open(QIODevice::ReadOnly)) {
 	if(ofile.open(QIODevice::WriteOnly)) {

--- a/qucs/extsimkernels/externsimdialog.cpp
+++ b/qucs/extsimkernels/externsimdialog.cpp
@@ -307,7 +307,7 @@ void ExternSimDialog::slotSaveNetlist()
 
 void ExternSimDialog::saveLog()
 {
-    QString filename = QucsSettings.QucsHomeDir.filePath("log.txt");
+    QString filename = QucsSettings.tempFilesDir.filePath("log.txt");
     QFile log(filename);
     if (log.open(QIODevice::WriteOnly)) {
         QTextStream ts_log(&log);

--- a/qucs/extsimkernels/simsettingsdialog.cpp
+++ b/qucs/extsimkernels/simsettingsdialog.cpp
@@ -33,7 +33,6 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     lblSpiceOpus = new QLabel(tr("SpiceOpus executable location"));
     lblQucsator = new QLabel(tr("Qucsator executable location"));
     //lblNprocs = new QLabel(tr("Number of processors in a system:"));
-    lblWorkdir = new QLabel(tr("Directory to store netlist and simulator output"));
     lblSimParam = new QLabel(tr("Extra simulator parameters"));
 
 //    cbxSimulator = new QComboBox(this);
@@ -59,7 +58,6 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
 //    spbNprocs->setMaximum(256);
 //    spbNprocs->setValue(1);
 //    spbNprocs->setValue(QucsSettings.NProcs);
-    edtWorkdir = new QLineEdit(QucsSettings.S4Qworkdir);
     edtSimParam = new QLineEdit(QucsSettings.SimParameters);
 
     btnOK = new QPushButton(tr("Apply changes"));
@@ -77,8 +75,6 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     connect(btnSetSpOpus,SIGNAL(clicked()),this,SLOT(slotSetSpiceOpus()));
     btnSetQucsator = new QPushButton(tr("Select ..."));
     connect(btnSetQucsator,SIGNAL(clicked()),this,SLOT(slotSetQucsator()));
-    btnSetWorkdir = new QPushButton(tr("Select ..."));
-    connect(btnSetWorkdir,SIGNAL(clicked()),this,SLOT(slotSetWorkdir()));
 
     QVBoxLayout *top = new QVBoxLayout;
 
@@ -119,12 +115,6 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     h7->addWidget(btnSetSpOpus,1);
     top2->addLayout(h7);
 
-
-    top2->addWidget(lblWorkdir);
-    QHBoxLayout *h6 = new QHBoxLayout;
-    h6->addWidget(edtWorkdir,3);
-    h6->addWidget(btnSetWorkdir,1);
-    top2->addLayout(h6);
 
     top2->addWidget(lblSimParam);
     QHBoxLayout *h10 = new QHBoxLayout;
@@ -175,7 +165,6 @@ void SimSettingsDialog::slotApply()
     QucsSettings.SpiceOpusExecutable = edtSpiceOpus->text();
     QucsSettings.Qucsator = edtQucsator->text();
     //QucsSettings.NProcs = spbNprocs->value();
-    QucsSettings.S4Qworkdir = edtWorkdir->text();
     QucsSettings.SimParameters = edtSimParam->text();
 //    if ((QucsSettings.DefaultSimulator != cbxSimulator->currentIndex())&&
 //        (QucsSettings.DefaultSimulator != spicecompat::simNotSpecified)) {
@@ -232,16 +221,5 @@ void SimSettingsDialog::slotSetQucsator()
     QString s = QFileDialog::getOpenFileName(this,tr("Select Qucsator executable location"),edtQucsator->text(),"All files (*)");
     if (!s.isEmpty()) {
         edtQucsator->setText(s);
-    }
-}
-
-void SimSettingsDialog::slotSetWorkdir()
-{
-    QFileDialog dlg( this, tr("Select directory to store netlist and simulator output"), edtWorkdir->text() );
-    dlg.setAcceptMode(QFileDialog::AcceptOpen);
-    dlg.setFileMode(QFileDialog::Directory);
-    if (dlg.exec()) {
-        QString s = dlg.selectedFiles().first();
-        if (!s.isEmpty()) edtWorkdir->setText(s);
     }
 }

--- a/qucs/extsimkernels/simsettingsdialog.h
+++ b/qucs/extsimkernels/simsettingsdialog.h
@@ -33,7 +33,6 @@ private:
     //QLabel *lblXycePar;
     //QLabel *lblNprocs;
     QLabel *lblQucsator;
-    QLabel *lblWorkdir;
     //QLabel *lblSimulator;
     QLabel *lblSimParam;
 
@@ -45,7 +44,6 @@ private:
     //QLineEdit *edtXycePar;
     QLineEdit *edtQucsator;
     //QSpinBox  *spbNprocs;
-    QLineEdit *edtWorkdir;
     QLineEdit *edtSimParam;
 
     QPushButton *btnOK;
@@ -56,7 +54,6 @@ private:
     QPushButton *btnSetXyce;
     //QPushButton *btnSetXycePar;
     QPushButton *btnSetQucsator;
-    QPushButton *btnSetWorkdir;
 
 public:
     explicit SimSettingsDialog(QWidget *parent = 0);
@@ -70,7 +67,6 @@ private slots:
     void slotSetXycePar();
     void slotSetSpiceOpus();
     void slotSetQucsator();
-    void slotSetWorkdir();
     
 };
 

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -178,10 +178,12 @@ bool loadSettings()
     } else {
         QucsSettings.RFLayoutExecutable = "qucsrflayout" + QString(executableSuffix);
     }
-    if(settings.contains("QucsHomeDir"))
-      if(settings.value("QucsHomeDir").toString() != "")
-         QucsSettings.QucsHomeDir.setPath(settings.value("QucsHomeDir").toString());
-    QucsSettings.QucsWorkDir = QucsSettings.QucsHomeDir;
+
+    if (auto path = settings.value("QucsHomeDir", "").toString(); path != "") {
+      QucsSettings.qucsWorkspaceDir.setPath(path);
+    }
+
+    QucsSettings.QucsWorkDir = QucsSettings.qucsWorkspaceDir;
     QucsSettings.tempFilesDir.setPath(QStandardPaths::writableLocation(QStandardPaths::CacheLocation));
 
     if (settings.contains("IgnoreVersion")) QucsSettings.IgnoreFutureVersion = settings.value("IgnoreVersion").toBool();
@@ -281,7 +283,7 @@ bool saveApplSettings()
     settings.setValue("OctaveExecutable",QucsSettings.OctaveExecutable);
     settings.setValue("OpenVAFExecutable",QucsSettings.OpenVAFExecutable);
     settings.setValue("RFLayoutExecutable",QucsSettings.RFLayoutExecutable);
-    settings.setValue("QucsHomeDir", QucsSettings.QucsHomeDir.canonicalPath());
+    settings.setValue("QucsHomeDir", QucsSettings.qucsWorkspaceDir.canonicalPath());
     settings.setValue("IgnoreVersion", QucsSettings.IgnoreFutureVersion);
     settings.setValue("GraphAntiAliasing", QucsSettings.GraphAntiAliasing);
     settings.setValue("TextAntiAliasing", QucsSettings.TextAntiAliasing);
@@ -858,10 +860,10 @@ int main(int argc, char *argv[])
   QucsSettings.dy = h*3/4;
 
   // default
-  QString QucsWorkdirPath = QDir::homePath()+QDir::toNativeSeparators ("/.qucs");
+  QString QucsWorkdirPath = QDir::homePath()+QDir::toNativeSeparators ("/QucsWorkspace");
   QDir().mkpath(QucsWorkdirPath);
-  QucsSettings.QucsHomeDir.setPath(QucsWorkdirPath);
-  QucsSettings.QucsWorkDir.setPath(QucsSettings.QucsHomeDir.canonicalPath());
+  QucsSettings.qucsWorkspaceDir.setPath(QucsWorkdirPath);
+  QucsSettings.QucsWorkDir.setPath(QucsSettings.qucsWorkspaceDir.canonicalPath());
 
   // load existing settings (if any)
   loadSettings();

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -861,13 +861,13 @@ int main(int argc, char *argv[])
 
   // default
   QString QucsWorkdirPath = QDir::homePath()+QDir::toNativeSeparators ("/QucsWorkspace");
-  QDir().mkpath(QucsWorkdirPath);
   QucsSettings.qucsWorkspaceDir.setPath(QucsWorkdirPath);
   QucsSettings.QucsWorkDir.setPath(QucsSettings.qucsWorkspaceDir.canonicalPath());
 
   // load existing settings (if any)
   loadSettings();
 
+  QDir().mkpath(QucsSettings.qucsWorkspaceDir.absolutePath());
   QDir().mkpath(QucsSettings.tempFilesDir.absolutePath());
 
   // continue to set up overrides or default settings (some are saved on exit)

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -154,8 +154,10 @@ bool loadSettings()
     else QucsSettings.SpiceOpusExecutable = "spiceopus";
     if(settings.contains("Nprocs")) QucsSettings.NProcs = settings.value("Nprocs").toInt();
     else QucsSettings.NProcs = 4;
-    if(settings.contains("S4Q_workdir")) QucsSettings.S4Qworkdir = settings.value("S4Q_workdir").toString();
-    else QucsSettings.S4Qworkdir = QDir::toNativeSeparators(QucsSettings.QucsWorkDir.absolutePath()+"/spice4qucs");
+    // All usages of this path look like something involving a temporary data.
+    // This should be replaced with generic temp dir, but for now let's just
+    // place it under generic temp dir.
+    QucsSettings.S4Qworkdir = QDir::toNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/spice4qucs");
     if(settings.contains("SimParameters")) QucsSettings.SimParameters = settings.value("SimParameters").toString();
     else QucsSettings.SimParameters = "";
     if(settings.contains("OctaveExecutable")) {
@@ -180,6 +182,7 @@ bool loadSettings()
       if(settings.value("QucsHomeDir").toString() != "")
          QucsSettings.QucsHomeDir.setPath(settings.value("QucsHomeDir").toString());
     QucsSettings.QucsWorkDir = QucsSettings.QucsHomeDir;
+    QucsSettings.tempFilesDir.setPath(QStandardPaths::writableLocation(QStandardPaths::CacheLocation));
 
     if (settings.contains("IgnoreVersion")) QucsSettings.IgnoreFutureVersion = settings.value("IgnoreVersion").toBool();
     // check also for old setting name with typo...
@@ -863,6 +866,7 @@ int main(int argc, char *argv[])
   // load existing settings (if any)
   loadSettings();
 
+  QDir().mkpath(QucsSettings.tempFilesDir.absolutePath());
 
   // continue to set up overrides or default settings (some are saved on exit)
 

--- a/qucs/main.h
+++ b/qucs/main.h
@@ -77,7 +77,9 @@ struct tQucsSettings {
 
   unsigned int NodeWiring;
   QDir QucsWorkDir;
-  QDir QucsHomeDir;
+
+  // A dir for user projects and libraries. See also https://github.com/ra3xdh/qucs_s/issues/145
+  QDir qucsWorkspaceDir;
 
   // This is the dir where all temporary or intermediate data should be stored.
   // Consider a data "temporary" if its used only once or it makes sense only

--- a/qucs/main.h
+++ b/qucs/main.h
@@ -78,6 +78,13 @@ struct tQucsSettings {
   unsigned int NodeWiring;
   QDir QucsWorkDir;
   QDir QucsHomeDir;
+
+  // This is the dir where all temporary or intermediate data should be stored.
+  // Consider a data "temporary" if its used only once or it makes sense only
+  // through out a single app run or a shorter period of time.
+  // Don't make any assumptions about the lifetime of contents in this dir,
+  // think that everything placed in here is deleted when app is terminated.
+  QDir tempFilesDir;
   QDir projsDir; // current user projects subdirectory
   QDir AdmsXmlBinDir;  // dir of admsXml executable
   QDir AscoBinDir;     // dir of asco executable

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -496,7 +496,7 @@ void QucsApp::initView()
     m_homeDirModel->setFilter(QDir::NoDot | QDir::AllDirs);
 
     // ............................................
-    QString path = QucsSettings.QucsHomeDir.absolutePath();
+    QString path = QucsSettings.qucsWorkspaceDir.absolutePath();
     QDir ProjDir(path);
     // initial projects directory is the Qucs home directory
     QucsSettings.projsDir.setPath(path);
@@ -539,7 +539,7 @@ void QucsApp::fillLibrariesTreeView ()
     newitem->setFont (0, sectionFont);
     topitems.append (newitem);
 
-    QString UserLibDirPath = QucsSettings.QucsHomeDir.canonicalPath () + "/user_lib/";
+    QString UserLibDirPath = QucsSettings.qucsWorkspaceDir.canonicalPath () + "/user_lib/";
     populateLibTreeFromDir(UserLibDirPath, topitems);
 
     // make the user libraries section header
@@ -1290,7 +1290,7 @@ void QucsApp::slotCMenuInsert()
 void QucsApp::readProjects()
 {
     QString path = QucsSettings.projsDir.absolutePath();
-    QString homepath = QucsSettings.QucsHomeDir.absolutePath();
+    QString homepath = QucsSettings.qucsWorkspaceDir.absolutePath();
 
     if (path == homepath) {
         // in Qucs Home, disallow further up in the dirs tree
@@ -1389,7 +1389,7 @@ void QucsApp::slotMenuProjOpen()
 {
   QString d = QFileDialog::getExistingDirectory(
       this, tr("Choose Project Directory for Opening"),
-      QucsSettings.QucsHomeDir.path(),
+      QucsSettings.qucsWorkspaceDir.path(),
       QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
   if(d.isEmpty()) return;
 
@@ -1500,7 +1500,7 @@ void QucsApp::slotMenuProjDel()
 {
   QString d = QFileDialog::getExistingDirectory(
       this, tr("Choose Project Directory for Deleting"),
-      QucsSettings.QucsHomeDir.path(),
+      QucsSettings.qucsWorkspaceDir.path(),
       QFileDialog::ShowDirsOnly
       | QFileDialog::DontResolveSymlinks);
 

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -787,7 +787,7 @@ void QucsApp::editFile(const QString& File)
 // Is called to show the output messages of the last simulation.
 void QucsApp::slotShowLastMsg()
 {
-  editFile(QucsSettings.QucsHomeDir.filePath("log.txt"));
+  editFile(QucsSettings.tempFilesDir.filePath("log.txt"));
 }
 
 // ------------------------------------------------------------------------
@@ -814,7 +814,7 @@ void QucsApp::slotShowLastNetlist()
 
     switch (QucsSettings.DefaultSimulator) {
     case spicecompat::simQucsator :
-        netlists.append(QucsSettings.QucsHomeDir.filePath("netlist.txt"));
+        netlists.append(QucsSettings.tempFilesDir.filePath("netlist.txt"));
         break;
     case spicecompat::simNgspice :
     case spicecompat::simSpiceOpus :
@@ -835,7 +835,7 @@ void QucsApp::slotShowLastNetlist()
         Schematic *sch = (Schematic *) w;
         if (sch->isDigitalCircuit()) {
             netlists.clear();
-            netlists.append(QucsSettings.QucsHomeDir.filePath("netlist.txt"));
+            netlists.append(QucsSettings.tempFilesDir.filePath("netlist.txt"));
         }
     }
 

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -664,7 +664,7 @@ int Schematic::saveDocument()
 
           qDebug() << "App path : " << qApp->applicationDirPath();
           qDebug() << "workdir"  << workDir;
-          qDebug() << "homedir"  << QucsSettings.QucsHomeDir.absolutePath();
+          qDebug() << "workspacedir"  << QucsSettings.qucsWorkspaceDir.absolutePath();
 
           vaFile = QucsSettings.QucsWorkDir.filePath(fileBase()+".va");
 


### PR DESCRIPTION
Hi!

This pull request addresses three issues described in #145.

1. Set root path for all temporary files produced by Qucs-S to QStandardPaths::CacheLocation (which is `~/.cache/qucs-s` on GNU/Linux)
2. Set default Qucs-S workspace path to `~/QucsWorkspace`
3.  Fix a bug which led to recreation of default workspace dir on app start even if it was changed in app settings

I've tested all three changes, but testing of the first one was incomplete: I've tested only the `ngspice` simulation because I don't have a single clue how to run other types like VHDL, ASCO, etc. (I am complete noob in electrical engineering to be honest)