### PR TITLE
Fixed zero output on DC bias simulation

### DIFF
--- a/qucs/extsimkernels/externsimdialog.cpp
+++ b/qucs/extsimkernels/externsimdialog.cpp
@@ -88,7 +88,7 @@ ExternSimDialog::ExternSimDialog(Schematic *sch, bool netlist_mode) :
     this->setMinimumWidth(500);
 
     slotSetSimulator();
-    if (!netlist_mode && !QucsMain->TuningMode)
+    if (!netlist_mode && !QucsMain->TuningMode && Sch->showBias != 0)
         slotStart(); // Start simulation
 
 }


### PR DESCRIPTION
This PR provides a fix for #667 