### PR TITLE
Add detailed warning messages

### DIFF
--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -423,12 +423,16 @@ void Ngspice::slotSimulate()
     }
 
     if (!checkGround()) {
-        output.append("No Ground found. Please add at least one ground!\n");
+        output.append("No Ground found. Please add at least one ground!\n"
+                      "Press Insert->Ground in the main menu and connect ground to one "
+                      "of the schematic nodes.\n");
         checker_error = true;
     }
 
     if (!checkSimulations()) {
-        output.append("No simulation found. Please add at least one simulation!\n");
+        output.append("No simulation found. Please add at least one simulation!\n"
+                      "Navigate to the \"simulations\" group in the components panel (left)"
+                      " and drag simulation to the schematic sheet. Then define its parameters.\n");
         checker_error = true;
     }
 

--- a/qucs/extsimkernels/xyce.cpp
+++ b/qucs/extsimkernels/xyce.cpp
@@ -423,7 +423,9 @@ void Xyce::nextSimulation()
         cmd_args.removeAt(0);
         SimProcess->start(xyce_cmd,cmd_args);
     } else {
-        output += "No simulations!\n"
+        output += "No simulation found. Please add at least one simulation!\n"
+                  "Navigate to the \"simulations\" group in the components panel (left)"
+                  " and drag simulation to the schematic sheet. Then define its parameters.\n"
                   "Exiting...\n";
         emit progress(100);
         emit finished(); // nothing to simulate


### PR DESCRIPTION
This PR adds detailed warning messages from schematic checker. Now it prints user what to do if schematic contains no simulation or no ground. The new warnings tells where to find the ground and simulation devices. I hope this will help to prevent asking questions about "No simulation" and "No ground" errors over and over again. 