### PR TITLE
Use standard open-file dialog to open example schematics

### DIFF
--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -1962,12 +1962,19 @@ bool QucsApp::closeAllFiles()
   return true;
 }
 
+void QucsApp::slotFileExamples() {
+  statusBar()->showMessage(tr("Open example…"));
 
-void QucsApp::slotFileExamples()
-{
-  statusBar()->showMessage(tr("Open examples directory..."));
-  // pass the QUrl representation of a local file
-  QDesktopServices::openUrl(QUrl::fromLocalFile(QucsSettings.ExamplesDir));
+  auto exampleFile =
+      QFileDialog::getOpenFileName(this, tr("Select example schematic"),
+                                   QucsSettings.ExamplesDir, QucsFileFilter);
+
+  if (exampleFile.isEmpty()) {
+      statusBar()->showMessage(tr("Open example canceled"), 2000);
+      return;
+  }
+
+  gotoPage(exampleFile);
   statusBar()->showMessage(tr("Ready."));
 }
 

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -98,9 +98,9 @@ void QucsApp::initActions()
   connect(fileClearRecent, SIGNAL(triggered()), SLOT(slotClearRecentFiles()));
 
   fileExamples = new QAction(tr("&Examples"), this);
-  fileExamples->setStatusTip(tr("Opens a file explorer with example documents"));
+  fileExamples->setStatusTip(tr("Starts file chooser dialog to open one of example schematics"));
   fileExamples->setWhatsThis(
-	        tr("Examples\n\nOpens a file explorer with example documents"));
+	        tr("Examples\n\nStart file chooser dialog and open one of example schematics"));
   connect(fileExamples, SIGNAL(triggered()), SLOT(slotFileExamples()));
 
 


### PR DESCRIPTION
With this commit the click on "Examples" entry of "File" menu instead of opening a new file manager window starts a standard dialog to select and open a file.

I reused logic from `QucsApp::slotFileOpen` and altered it a bit: example files don't go to "recent files" list.

Also a handful of new `tr` strings are introduced which lack translations. I guess I'll make a separate PR after running `lupdate` on all files, removing obsolete entries too.

Closes: ra3xdh#672