### PR TITLE
Refactor: make private UsedX1, UsedY1, UsedX2, UsedY2 members of Schematic

### DIFF
--- a/qucs/imagewriter.cpp
+++ b/qucs/imagewriter.cpp
@@ -302,17 +302,19 @@ int ImageWriter::print(QWidget *doc)
 
 void ImageWriter::getSchWidthAndHeight(Schematic *sch, int &w, int &h, int &xmin, int &ymin)
 {
-    int xmax,ymax;
-    sch->sizeOfAll(xmin,ymin,xmax,ymax);
-    w = abs(xmax - xmin);
-    h = abs(ymax - ymin);
+    auto allBoundingRect = sch->allBoundingRect();
+    xmin = allBoundingRect.left();
+    ymin = allBoundingRect.top();
+
+    w = allBoundingRect.width();
+    h = allBoundingRect.height();
 
     int f_w, f_h;
     if (sch->sizeOfFrame(f_w,f_h)) {
         xmin = std::min(0,xmin); // For components
         ymin = std::min(0,ymin); // that fall out of frame
-        w = abs(std::max(f_w,sch->UsedX2) - xmin);
-        h = abs(std::max(f_h,sch->UsedY2) - ymin);
+        w = abs(std::max(f_w, allBoundingRect.right()) - xmin);
+        h = abs(std::max(f_h, allBoundingRect.bottom()) - ymin);
     }
 }
 

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -176,7 +176,7 @@ void MouseActions::editLabel(Schematic *Doc, WireLabel *pl)
             pl->x1 -= pl->x2 - old_x2; // don't change position due to text width
     }
 
-    Doc->sizeOfAll(Doc->UsedX1, Doc->UsedY1, Doc->UsedX2, Doc->UsedY2);
+    Doc->updateAllBoundingRect();
     Doc->viewport()->update();
     drawn = false;
     Doc->setChanged(true, true);
@@ -232,9 +232,11 @@ void MouseActions::endElementMoving(Schematic *Doc,
   if ((MAx3 != 0) || (MAy3 != 0)) // moved or put at the same place ?
     Doc->setChanged(true, true);
 
-  // enlarge viewarea if components lie outside the view
-  Doc->sizeOfAll(Doc->UsedX1, Doc->UsedY1, Doc->UsedX2, Doc->UsedY2);
-  Doc->enlargeView(Doc->UsedX1, Doc->UsedY1, Doc->UsedX2, Doc->UsedY2);
+  // Position of some elements of schematic has changed. This change
+  // is "external" to schematic and its state must be updated to
+  // take the changes into account
+  auto totalBounds = Doc->allBoundingRect();
+  Doc->enlargeView(totalBounds.left(), totalBounds.top(), totalBounds.right(), totalBounds.bottom());
 
   Doc->viewport()->update();
   drawn = false;
@@ -1075,7 +1077,7 @@ void MouseActions::MPressLabel(Schematic *Doc, QMouseEvent *, float fX, float fY
             pn->setName(Name, Value, xl, yl);
     }
 
-    Doc->sizeOfAll(Doc->UsedX1, Doc->UsedY1, Doc->UsedX2, Doc->UsedY2);
+    Doc->updateAllBoundingRect();
     Doc->viewport()->update();
     drawn = false;
     Doc->setChanged(true, true);
@@ -1246,7 +1248,7 @@ void MouseActions::MPressDelete(Schematic *Doc, QMouseEvent *, float fX, float f
         pe->isSelected = true;
         Doc->deleteElements();
 
-        Doc->sizeOfAll(Doc->UsedX1, Doc->UsedY1, Doc->UsedX2, Doc->UsedY2);
+        Doc->updateAllBoundingRect();
         Doc->viewport()->update();
         drawn = false;
     }
@@ -1674,7 +1676,7 @@ void MouseActions::MPressOnGrid(Schematic *Doc, QMouseEvent *, float fX, float f
         pe->isSelected = true;
         Doc->elementsOnGrid();
 
-        Doc->sizeOfAll(Doc->UsedX1, Doc->UsedY1, Doc->UsedX2, Doc->UsedY2);
+        Doc->updateAllBoundingRect();
         // Update matching wire label highlighting
         Doc->highlightWireLabels();
         Doc->viewport()->update();

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -679,13 +679,8 @@ void QucsApp::slotSelectAll()
     ((TextDoc*)Doc)->selectAll();
   }
   else {
-    int xmin, ymin, xmax, ymax;
-    ((Schematic*)Doc)->sizeOfAll(xmin, ymin, xmax, ymax);
-    xmin--;
-    ymin--;
-    xmax++;
-    ymax++;
-    ((Schematic*)Doc)->selectElements(xmin, ymin, xmax, ymax, true, false);
+    auto selectionRect = ((Schematic*)Doc)->allBoundingRect().marginsAdded(QMargins{1, 1, 1, 1});
+    ((Schematic*)Doc)->selectElements(selectionRect.left(), selectionRect.top(), selectionRect.right(), selectionRect.bottom(), true, false);
     ((Schematic*)Doc)->viewport()->update();
     view->drawn = false;
   }

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -214,7 +214,7 @@ void Schematic::becomeCurrent(bool update)
 
         // if no symbol yet exists -> create one
         if (createSubcircuitSymbol()) {
-            sizeOfAll(UsedX1, UsedY1, UsedX2, UsedY2);
+            updateAllBoundingRect();
             setChanged(true, true);
         }
 
@@ -682,7 +682,7 @@ void Schematic::print(QPrinter *, QPainter *Painter, bool printAll, bool fitToPa
     float screenDpiX = (float) pa.device()->logicalDpiX();
     float screenDpiY = (float) pa.device()->logicalDpiY();
     float PrintScale = 0.5;
-    sizeOfAll(UsedX1, UsedY1, UsedX2, UsedY2);
+    updateAllBoundingRect();
     int marginX = (int) (40 * printerDpiX / screenDpiX);
     int marginY = (int) (40 * printerDpiY / screenDpiY);
 

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1162,6 +1162,15 @@ float Schematic::textCorr()
     return (Scale / float(metrics.lineSpacing()));
 }
 
+void Schematic::updateAllBoundingRect() {
+    sizeOfAll(UsedX1, UsedY1, UsedX2, UsedY2);
+}
+
+QRect Schematic::allBoundingRect() {
+    updateAllBoundingRect();
+    return QRect{UsedX1, UsedY1, (UsedX2 - UsedX1), (UsedY2 - UsedY1)};
+}
+
 // ---------------------------------------------------
 void Schematic::sizeOfAll(int &xmin, int &ymin, int &xmax, int &ymax)
 {

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -93,6 +93,18 @@ public:
   float textCorr();
   bool sizeOfFrame(int&, int&);
   void  sizeOfAll(int&, int&, int&, int&);
+  /**
+    Iterates over all elements of schematic to find the size of the smallest
+    rectangle able to fit all elements. The bounds are then stored in members
+    @c UsedX1, @c UsedY1, @c UsedX2, @c UsedY2 , i.e. the internal state
+    of schematic is updated.
+  */
+  void updateAllBoundingRect();
+
+  /**
+    Returns the smallest rectangle enclosing all elements of schematic
+  */
+  QRect allBoundingRect();
   QRect  sizeOfSelection() const;
   bool  rotateElements();
   bool  mirrorXComponents();

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -92,7 +92,7 @@ public:
 
   float textCorr();
   bool sizeOfFrame(int&, int&);
-  void  sizeOfAll(int&, int&, int&, int&);
+
   /**
     Iterates over all elements of schematic to find the size of the smallest
     rectangle able to fit all elements. The bounds are then stored in members
@@ -218,11 +218,6 @@ public:
   // these variables ("model") is used to draw the scematic.
   int ViewX1, ViewY1, ViewX2, ViewY2;
 
-  // Variables Used* hold the coordinates of top-left and bottom-right corners
-  // of a smallest rectangle which can fit all elements of the schematic.
-  // This rectangle exists in the same coordinate system as View*-rectangle
-  int UsedX1, UsedY1, UsedX2, UsedY2;
-
   int showFrame;
   QString Frame_Text0, Frame_Text1, Frame_Text2, Frame_Text3;
 
@@ -271,6 +266,13 @@ protected slots:
   void slotScrollRight();
 
 private:
+  // Variables Used* hold the coordinates of top-left and bottom-right corners
+  // of a smallest rectangle which can fit all elements of the schematic.
+  // This rectangle exists in the same coordinate system as View*-rectangle
+  int UsedX1, UsedY1, UsedX2, UsedY2;
+
+  void  sizeOfAll(int&, int&, int&, int&);
+
   // Viewport-realative coordinates of the cursor between mouse movements.
   // Used in "pan with mouse" feature.
   QPoint previousCursorPosition;

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -2089,7 +2089,7 @@ bool Schematic::deleteElements()
 
     if(sel)
     {
-        sizeOfAll(UsedX1, UsedY1, UsedX2, UsedY2);   // set new document size
+        updateAllBoundingRect();   // set new document size
         setChanged(sel, true);
     }
     return sel;


### PR DESCRIPTION
Hi! Yet another bit of refactoring is here.

`Schematic` object has `UsedX1`, `UsedY1`, `UsedX2`, `UsedY2` members which describe the bounds of the smallest rectangle which is able to fit all elements of schematic. In other words they describe the size and location of occupied area. Despite their seemingly "inner state" nature these variables are public and accessible from anywhere. I believe it's better to keep such things private.

`Schematic` also has a public member function `sizeOfAll`. It takes integer references, calculates the size and location of the area used by all elements of schematic and writes them back to given int references.  Sometimes this function is used
with `Used…` variables which results in quite clumsy lines like:
```
Doc->sizeOfAll(Doc->UsedX1, Doc->UsedY1, Doc->UsedX2, Doc->UsedY2);
```
Without inspecting the `sizeOfAll` or `Used…` it may be hard to see that this line just updates occupied area bounds.

The whole PR is about eliminating external usages of  `Schematic::Used…` variables and then making them private. I do this by introducing new API in 2be5fd216b757e93ab187d6dec5caac2d35f4eb4 and then using it instead of the old one, rewriting where it's needed, so in the end  `Schematic::Used…` and  `Schematic::sizeOfAll` become able to be made private.
