### PR TITLE
Fix #682 - Warnings during run-time

### DIFF
--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -69,7 +69,7 @@ AbstractSpiceKernel::AbstractSpiceKernel(Schematic *sch_, QObject *parent) :
     SimProcess->setProcessChannelMode(QProcess::MergedChannels);
     connect(SimProcess,SIGNAL(finished(int)),this,SLOT(slotFinished()));
     connect(SimProcess,SIGNAL(readyRead()),this,SLOT(slotProcessOutput()));
-    connect(SimProcess,SIGNAL(error(QProcess::ProcessError)),this,SLOT(slotErrors(QProcess::ProcessError)));
+    connect(SimProcess,SIGNAL(errorOccurred(QProcess::ProcessError)),this,SLOT(slotErrors(QProcess::ProcessError)));
     connect(this,SIGNAL(destroyed()),this,SLOT(killThemAll()));
 
 }


### PR DESCRIPTION
This PR fixes #682 .
The signal is errorOccurred(QProcess::ProcessError error) since qt-5.6
[Qt5 doc](https://doc.qt.io/qt-5/qprocess.html#errorOccurred)
[Qt6 doc](https://doc.qt.io/qt-6/qprocess.html#errorOccurredl)
