### PR TITLE
Fix Windows build by replacing absent "QucsHomeDir" settings member

### DIFF
--- a/qucs/dialogs/simmessage.cpp
+++ b/qucs/dialogs/simmessage.cpp
@@ -567,7 +567,7 @@ void SimMessage::startSimulator()
 /// \todo \bug error: unrecognized command line option '-Wl'
 #ifdef __MINGW32__
     Program = QDir::toNativeSeparators(pathName(QucsSettings.BinDir + QucsDigi));
-    Arguments << QDir::toNativeSeparators(QucsSettings.QucsHomeDir.filePath("netlist.txt"))
+    Arguments << QDir::toNativeSeparators(QucsSettings.tempFilesDir.filePath("netlist.txt"))
               << DataSet
               << SimTime
               << QDir::toNativeSeparators(SimPath)


### PR DESCRIPTION
In 72f9e461 all temporary files were moved to a dedicated temp files dir. To store the name of this dir, a new property named "tempFilesDir" was introduced and all occurences of "QucsHomeDir" in "temporary file" contexts were replaced by new property. But in one branch of "ifdef" preprocessor condition the replacement somehow failed, leaving the old property name. This commit replaces it with correct one.

Fixes ra3xdh#686