### PR TITLE
Refactor drawing of elements: hide logic behind common interface

### DIFF
--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -193,13 +193,14 @@ void Component::paint(ViewPainter *p) {
     int x, y, a, b, xb, yb;
     QFont f = p->Painter->font();   // save current font
     QFont newFont = f;
+    const bool correctSimulator = (Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator;
     if (Model.at(0) == '.') {   // is simulation component (dc, ac, ...)
         newFont.setPointSizeF(p->Scale * Texts.first()->Size);
         newFont.setWeight(QFont::DemiBold);
         p->Painter->setFont(newFont);
         p->map(cx, cy, x, y);
 
-        if ((Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator) {
+        if (correctSimulator) {
             if ((Model == ".CUSTOMSIM") || (Model == ".DISTO")
                 || (Model == ".NOISE") || (Model == ".PZ") ||
                 (Model == ".SENS") || (Model == ".SENS_AC") ||
@@ -240,7 +241,7 @@ void Component::paint(ViewPainter *p) {
 
         // paint all lines
         for (qucs::DrawingPrimitive *line: Lines) {
-            if ((Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator) {
+            if (correctSimulator) {
                 p->Painter->setPen(line->penHint());
             } else {
                 p->Painter->setPen(WrongSimulatorPen);
@@ -250,7 +251,7 @@ void Component::paint(ViewPainter *p) {
 
         // paint all arcs
         for (qucs::DrawingPrimitive *arc: Arcs) {
-            if ((Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator) {
+            if (correctSimulator) {
                 p->Painter->setPen(arc->penHint());
             } else {
                 p->Painter->setPen(WrongSimulatorPen);
@@ -260,7 +261,7 @@ void Component::paint(ViewPainter *p) {
 
         // paint all rectangles
         for (qucs::DrawingPrimitive *rect: Rects) {
-            if ((Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator) {
+            if (correctSimulator) {
                 p->Painter->setPen(rect->penHint());
             } else {
                 p->Painter->setPen(WrongSimulatorPen);
@@ -271,7 +272,7 @@ void Component::paint(ViewPainter *p) {
 
         // paint all ellipses
         for (qucs::DrawingPrimitive *ellips: Ellipses) {
-            if ((Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator) {
+            if (correctSimulator) {
                 p->Painter->setPen(ellips->penHint());
             } else {
                 p->Painter->setPen(WrongSimulatorPen);
@@ -297,7 +298,7 @@ void Component::paint(ViewPainter *p) {
             newFont.setOverline(pt->over);
             newFont.setUnderline(pt->under);
             p->Painter->setFont(newFont);
-            if ((Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator) {
+            if (correctSimulator) {
                 p->Painter->setPen(pt->Color);
             } else {
                 p->Painter->setPen(WrongSimulatorPen);

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -239,45 +239,45 @@ void Component::paint(ViewPainter *p) {
     } else {    // normal components go here
 
         // paint all lines
-        for (qucs::Line *p1: Lines) {
+        for (qucs::DrawingPrimitive *line: Lines) {
             if ((Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator) {
-                p->Painter->setPen(p1->style);
+                p->Painter->setPen(line->penHint());
             } else {
                 p->Painter->setPen(WrongSimulatorPen);
             }
-            p->drawLine(cx + p1->x1, cy + p1->y1, cx + p1->x2, cy + p1->y2);
+            line->draw(p, cx, cy);
         }
 
         // paint all arcs
-        for (qucs::Arc *p3: Arcs) {
+        for (qucs::DrawingPrimitive *arc: Arcs) {
             if ((Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator) {
-                p->Painter->setPen(p3->style);
+                p->Painter->setPen(arc->penHint());
             } else {
                 p->Painter->setPen(WrongSimulatorPen);
             }
-            p->drawArc(cx + p3->x, cy + p3->y, p3->w, p3->h, p3->angle, p3->arclen);
+            arc->draw(p, cx, cy);
         }
 
         // paint all rectangles
-        for (qucs::Rect *pa: Rects) {
+        for (qucs::DrawingPrimitive *rect: Rects) {
             if ((Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator) {
-                p->Painter->setPen(pa->Pen);
+                p->Painter->setPen(rect->penHint());
             } else {
                 p->Painter->setPen(WrongSimulatorPen);
             }
-            p->Painter->setBrush(pa->Brush);
-            p->drawRect(cx + pa->x, cy + pa->y, pa->w, pa->h);
+            p->Painter->setBrush(rect->brushHint());
+            rect->draw(p, cx, cy);
         }
 
         // paint all ellipses
-        for (qucs::Ellips *pa: Ellipses) {
+        for (qucs::DrawingPrimitive *ellips: Ellipses) {
             if ((Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator) {
-                p->Painter->setPen(pa->Pen);
+                p->Painter->setPen(ellips->penHint());
             } else {
                 p->Painter->setPen(WrongSimulatorPen);
             }
-            p->Painter->setBrush(pa->Brush);
-            p->drawEllipse(cx + pa->x, cy + pa->y, pa->w, pa->h);
+            p->Painter->setBrush(ellips->brushHint());
+            ellips->draw(p, cx, cy);
         }
         p->Painter->setBrush(Qt::NoBrush);
 
@@ -373,32 +373,35 @@ void Component::paintIcon(QPixmap *pixmap)
             p->drawEllipse(cx+pp->x-2,cy+pp->y-2,4,4);
         }
 
-        for (qucs::Line *p1: Lines) {
-            p1->style.setWidth(3);
-            p->Painter->setPen(p1->style);
-            p->drawLine(cx + p1->x1, cy + p1->y1, cx + p1->x2, cy + p1->y2);
+        for (qucs::DrawingPrimitive *line: Lines) {
+            auto pen = line->penHint();
+            pen.setWidth(3);
+            p->Painter->setPen(pen);
+            line->draw(p, cx, cy);
         }
 
         // paint all arcs
-        for (qucs::Arc *p3: Arcs) {
-            p3->style.setWidth(3);
-            p->Painter->setPen(p3->style);
-            p->drawArc(cx + p3->x, cy + p3->y, p3->w, p3->h, p3->angle, p3->arclen);
+        for (qucs::DrawingPrimitive *arc: Arcs) {
+            auto pen = arc->penHint();
+            pen.setWidth(3);
+            p->Painter->setPen(pen);
+            arc->draw(p, cx, cy);
         }
 
         // paint all rectangles
-        for (qucs::Rect *pa: Rects) {
-            pa->Pen.setWidth(3);
-            p->Painter->setPen(pa->Pen);
-            p->Painter->setBrush(pa->Brush);
-            p->drawRect(cx + pa->x, cy + pa->y, pa->w, pa->h);
+        for (qucs::DrawingPrimitive *rect: Rects) {
+            auto pen = rect->penHint();
+            pen.setWidth(3);
+            p->Painter->setPen(pen);
+            p->Painter->setBrush(rect->brushHint());
+            rect->draw(p, cx, cy);
         }
 
         // paint all ellipses
-        for (qucs::Ellips *pa: Ellipses) {
-            p->Painter->setPen(pa->Pen);
-            p->Painter->setBrush(pa->Brush);
-            p->drawEllipse(cx + pa->x, cy + pa->y, pa->w, pa->h);
+        for (qucs::DrawingPrimitive *ellipse: Ellipses) {
+            p->Painter->setPen(ellipse->penHint());
+            p->Painter->setBrush(ellipse->brushHint());
+            ellipse->draw(p, cx, cy);
         }
         p->Painter->setBrush(Qt::NoBrush);
 

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -241,42 +241,34 @@ void Component::paint(ViewPainter *p) {
 
         // paint all lines
         for (qucs::DrawingPrimitive *line: Lines) {
-            if (correctSimulator) {
-                p->Painter->setPen(line->penHint());
-            } else {
-                p->Painter->setPen(WrongSimulatorPen);
-            }
+            p->Painter->setPen(
+                correctSimulator ? line->penHint() : WrongSimulatorPen
+            );
             line->draw(p, cx, cy);
         }
 
         // paint all arcs
         for (qucs::DrawingPrimitive *arc: Arcs) {
-            if (correctSimulator) {
-                p->Painter->setPen(arc->penHint());
-            } else {
-                p->Painter->setPen(WrongSimulatorPen);
-            }
+            p->Painter->setPen(
+                correctSimulator ? arc->penHint() : WrongSimulatorPen
+            );
             arc->draw(p, cx, cy);
         }
 
         // paint all rectangles
         for (qucs::DrawingPrimitive *rect: Rects) {
-            if (correctSimulator) {
-                p->Painter->setPen(rect->penHint());
-            } else {
-                p->Painter->setPen(WrongSimulatorPen);
-            }
+            p->Painter->setPen(
+                correctSimulator ? rect->penHint() : WrongSimulatorPen
+            );
             p->Painter->setBrush(rect->brushHint());
             rect->draw(p, cx, cy);
         }
 
         // paint all ellipses
         for (qucs::DrawingPrimitive *ellips: Ellipses) {
-            if (correctSimulator) {
-                p->Painter->setPen(ellips->penHint());
-            } else {
-                p->Painter->setPen(WrongSimulatorPen);
-            }
+            p->Painter->setPen(
+                correctSimulator ? ellips->penHint() : WrongSimulatorPen
+            );
             p->Painter->setBrush(ellips->brushHint());
             ellips->draw(p, cx, cy);
         }
@@ -298,11 +290,7 @@ void Component::paint(ViewPainter *p) {
             newFont.setOverline(pt->over);
             newFont.setUnderline(pt->under);
             p->Painter->setFont(newFont);
-            if (correctSimulator) {
-                p->Painter->setPen(pt->Color);
-            } else {
-                p->Painter->setPen(WrongSimulatorPen);
-            }
+            p->Painter->setPen(correctSimulator ? pt->Color : WrongSimulatorPen);
             int w, h;
             w = p->drawTextMapped(pt->s, 0, 0, &h);
             Q_UNUSED(w)

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -239,38 +239,26 @@ void Component::paint(ViewPainter *p) {
         p->Painter->drawLine(x + xb - 1, y, a + xb, b);
     } else {    // normal components go here
 
-        // paint all lines
+        auto draw_primitive = [&](qucs::DrawingPrimitive* prim, ViewPainter* p) {
+            p->Painter->setPen(correctSimulator ? prim->penHint() : WrongSimulatorPen);
+            p->Painter->setBrush(prim->brushHint());
+            prim->draw(p, cx, cy);
+        };
+
         for (qucs::DrawingPrimitive *line: Lines) {
-            p->Painter->setPen(
-                correctSimulator ? line->penHint() : WrongSimulatorPen
-            );
-            line->draw(p, cx, cy);
+            draw_primitive(line, p);
         }
 
-        // paint all arcs
         for (qucs::DrawingPrimitive *arc: Arcs) {
-            p->Painter->setPen(
-                correctSimulator ? arc->penHint() : WrongSimulatorPen
-            );
-            arc->draw(p, cx, cy);
+            draw_primitive(arc, p);
         }
 
-        // paint all rectangles
         for (qucs::DrawingPrimitive *rect: Rects) {
-            p->Painter->setPen(
-                correctSimulator ? rect->penHint() : WrongSimulatorPen
-            );
-            p->Painter->setBrush(rect->brushHint());
-            rect->draw(p, cx, cy);
+            draw_primitive(rect, p);
         }
 
-        // paint all ellipses
         for (qucs::DrawingPrimitive *ellips: Ellipses) {
-            p->Painter->setPen(
-                correctSimulator ? ellips->penHint() : WrongSimulatorPen
-            );
-            p->Painter->setBrush(ellips->brushHint());
-            ellips->draw(p, cx, cy);
+            draw_primitive(ellips, p);
         }
         p->Painter->setBrush(Qt::NoBrush);
 

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -262,28 +262,15 @@ void Component::paint(ViewPainter *p) {
         }
         p->Painter->setBrush(Qt::NoBrush);
 
-        newFont.setWeight(QFont::Light);
-
         // keep track of painter state
         p->Painter->save();
 
         QTransform wm = p->Painter->worldTransform();
-        // write all text
-        for (Text *pt: Texts) {
-            p->Painter->setWorldTransform(
-                    QTransform(pt->mCos, -pt->mSin, pt->mSin, pt->mCos,
-                               p->DX + float(cx + pt->x) * p->Scale,
-                               p->DY + float(cy + pt->y) * p->Scale));
-            newFont.setPointSizeF(p->Scale * pt->Size);
-            newFont.setOverline(pt->over);
-            newFont.setUnderline(pt->under);
-            p->Painter->setFont(newFont);
-            p->Painter->setPen(correctSimulator ? pt->Color : WrongSimulatorPen);
-            int w, h;
-            w = p->drawTextMapped(pt->s, 0, 0, &h);
-            Q_UNUSED(w)
-            Q_UNUSED(h)
+
+        for (qucs::DrawingPrimitive *text: Texts) {
+            draw_primitive(text, p);
         }
+
         p->Painter->setWorldTransform(wm);
         p->Painter->setWorldMatrixEnabled(false);
 
@@ -380,23 +367,11 @@ void Component::paintIcon(QPixmap *pixmap)
             p->Painter->setBrush(ellipse->brushHint());
             ellipse->draw(p, cx, cy);
         }
-        p->Painter->setBrush(Qt::NoBrush);
 
-        newFont.setWeight(QFont::Light);
-
-        for (Text *pt: Texts) {
-            p->Painter->setWorldTransform(
-                    QTransform(pt->mCos, -pt->mSin, pt->mSin, pt->mCos,
-                               p->DX + float(cx + pt->x) * p->Scale,
-                               p->DY + float(cy + pt->y) * p->Scale));
-            newFont.setPointSizeF(p->Scale * pt->Size);
-            newFont.setOverline(pt->over);
-            newFont.setUnderline(pt->under);
-            p->Painter->setFont(newFont);
-            p->Painter->setPen(pt->Color);
-            w = p->drawTextMapped(pt->s, 0, 0, &h);
-            Q_UNUSED(w)
-            Q_UNUSED(h)
+        for (qucs::DrawingPrimitive *text: Texts) {
+            p->Painter->setPen(text->penHint());
+            p->Painter->setBrush(text->brushHint());
+            text->draw(p, cx, cy);
         }
     }
 }

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -259,7 +259,7 @@ void Component::paint(ViewPainter *p) {
         }
 
         // paint all rectangles
-        for (qucs::Area *pa: Rects) {
+        for (qucs::Rect *pa: Rects) {
             if ((Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator) {
                 p->Painter->setPen(pa->Pen);
             } else {
@@ -387,7 +387,7 @@ void Component::paintIcon(QPixmap *pixmap)
         }
 
         // paint all rectangles
-        for (qucs::Area *pa: Rects) {
+        for (qucs::Rect *pa: Rects) {
             pa->Pen.setWidth(3);
             p->Painter->setPen(pa->Pen);
             p->Painter->setBrush(pa->Brush);
@@ -482,7 +482,7 @@ void Component::paintScheme(Schematic *p) {
         p->PostPaintEvent(_Arc, cx + p3->x, cy + p3->y, p3->w, p3->h, p3->angle, p3->arclen);
 
 
-    for (qucs::Area *pa: Rects) // paint all rectangles
+    for (qucs::Rect *pa: Rects) // paint all rectangles
         p->PostPaintEvent(_Rect, cx + pa->x, cy + pa->y, pa->w, pa->h);
 
     for (qucs::Ellips *pa: Ellipses) // paint all ellipses
@@ -540,7 +540,7 @@ void Component::rotate() {
     }
 
     // rotate all rectangles
-    for (qucs::Area *pa: Rects) {
+    for (qucs::Rect *pa: Rects) {
         tmp = -pa->x;
         pa->x = pa->y;
         pa->y = tmp - pa->w;
@@ -638,7 +638,7 @@ void Component::mirrorX() {
     }
 
     // mirror all rectangles
-    for (qucs::Area *pa: Rects)
+    for (qucs::Rect *pa: Rects)
         pa->y = -pa->y - pa->h;
 
     // mirror all ellipses
@@ -699,7 +699,7 @@ void Component::mirrorY() {
     }
 
     // mirror all rectangles
-    for (qucs::Area *pa: Rects)
+    for (qucs::Rect *pa: Rects)
         pa->x = -pa->x - pa->w;
 
     // mirror all ellipses
@@ -1293,7 +1293,7 @@ int Component::analyseLine(const QString &Row, int numProps) {
         if (!getIntegers(Row, &i1, &i2, &i3, &i4)) return -1;
         if (!getPen(Row, Pen, 5)) return -1;
         if (!getBrush(Row, Brush, 8)) return -1;
-        Rects.append(new qucs::Area(i1, i2, i3, i4, Pen, Brush));
+        Rects.append(new qucs::Rect(i1, i2, i3, i4, Pen, Brush));
 
         if (i1 < x1) x1 = i1;  // keep track of component boundings
         if (i1 > x2) x2 = i1;

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -270,7 +270,7 @@ void Component::paint(ViewPainter *p) {
         }
 
         // paint all ellipses
-        for (qucs::Ellips *pa: Ellips) {
+        for (qucs::Ellips *pa: Ellipses) {
             if ((Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator) {
                 p->Painter->setPen(pa->Pen);
             } else {
@@ -395,7 +395,7 @@ void Component::paintIcon(QPixmap *pixmap)
         }
 
         // paint all ellipses
-        for (qucs::Ellips *pa: Ellips) {
+        for (qucs::Ellips *pa: Ellipses) {
             p->Painter->setPen(pa->Pen);
             p->Painter->setBrush(pa->Brush);
             p->drawEllipse(cx + pa->x, cy + pa->y, pa->w, pa->h);
@@ -485,7 +485,7 @@ void Component::paintScheme(Schematic *p) {
     for (qucs::Area *pa: Rects) // paint all rectangles
         p->PostPaintEvent(_Rect, cx + pa->x, cy + pa->y, pa->w, pa->h);
 
-    for (qucs::Ellips *pa: Ellips) // paint all ellipses
+    for (qucs::Ellips *pa: Ellipses) // paint all ellipses
         p->PostPaintEvent(_Ellipse, cx + pa->x, cy + pa->y, pa->w, pa->h);
 }
 
@@ -550,7 +550,7 @@ void Component::rotate() {
     }
 
     // rotate all ellipses
-    for (qucs::Ellips *pa: Ellips) {
+    for (qucs::Ellips *pa: Ellipses) {
         tmp = -pa->x;
         pa->x = pa->y;
         pa->y = tmp - pa->w;
@@ -642,7 +642,7 @@ void Component::mirrorX() {
         pa->y = -pa->y - pa->h;
 
     // mirror all ellipses
-    for (qucs::Ellips *pa: Ellips)
+    for (qucs::Ellips *pa: Ellipses)
         pa->y = -pa->y - pa->h;
 
     QFont f = QucsSettings.font;
@@ -703,7 +703,7 @@ void Component::mirrorY() {
         pa->x = -pa->x - pa->w;
 
     // mirror all ellipses
-    for (qucs::Ellips *pa: Ellips)
+    for (qucs::Ellips *pa: Ellipses)
         pa->x = -pa->x - pa->w;
 
     int tmp;
@@ -1278,7 +1278,7 @@ int Component::analyseLine(const QString &Row, int numProps) {
         if (!getIntegers(Row, &i1, &i2, &i3, &i4)) return -1;
         if (!getPen(Row, Pen, 5)) return -1;
         if (!getBrush(Row, Brush, 8)) return -1;
-        Ellips.append(new qucs::Ellips(i1, i2, i3, i4, Pen, Brush));
+        Ellipses.append(new qucs::Ellips(i1, i2, i3, i4, Pen, Brush));
 
         if (i1 < x1) x1 = i1;  // keep track of component boundings
         if (i1 > x2) x2 = i1;
@@ -1461,7 +1461,7 @@ void Component::copyComponent(Component *pc) {
     Lines = pc->Lines;
     Arcs = pc->Arcs;
     Rects = pc->Rects;
-    Ellips = pc->Ellips;
+    Ellipses = pc->Ellipses;
     Texts = pc->Texts;
 }
 
@@ -1477,7 +1477,7 @@ void MultiViewComponent::recreate(Schematic *Doc) {
         Doc->deleteComp(this);
     }
 
-    Ellips.clear();
+    Ellipses.clear();
     Texts.clear();
     Ports.clear();
     Lines.clear();
@@ -1717,7 +1717,7 @@ void GateComponent::createSymbol() {
             Texts.append(new Text(-10, 3 - y, "&", Qt::darkBlue, 15.0));
         else if (Model.at(0) == 'X') {
             if (Model.at(1) == 'N') {
-                Ellips.append(new qucs::Ellips(xr, -4, 8, 8,
+                Ellipses.append(new qucs::Ellips(xr, -4, 8, 8,
                                              QPen(Qt::darkBlue, 0), QBrush(Qt::darkBlue)));
                 Texts.append(new Text(-11, 3 - y, "=1", Qt::darkBlue, 15.0));
             } else
@@ -1747,7 +1747,7 @@ void GateComponent::createSymbol() {
     }
 
     if (Model.at(0) == 'N')
-        Ellips.append(new qucs::Ellips(xr, -4, 8, 8,
+        Ellipses.append(new qucs::Ellips(xr, -4, 8, 8,
                                      QPen(Qt::darkBlue, 0), QBrush(Qt::darkBlue)));
 
     Ports.append(new Port(30, 0));

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -270,7 +270,7 @@ void Component::paint(ViewPainter *p) {
         }
 
         // paint all ellipses
-        for (qucs::Area *pa: Ellips) {
+        for (qucs::Ellips *pa: Ellips) {
             if ((Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator) {
                 p->Painter->setPen(pa->Pen);
             } else {
@@ -395,7 +395,7 @@ void Component::paintIcon(QPixmap *pixmap)
         }
 
         // paint all ellipses
-        for (qucs::Area *pa: Ellips) {
+        for (qucs::Ellips *pa: Ellips) {
             p->Painter->setPen(pa->Pen);
             p->Painter->setBrush(pa->Brush);
             p->drawEllipse(cx + pa->x, cy + pa->y, pa->w, pa->h);
@@ -485,7 +485,7 @@ void Component::paintScheme(Schematic *p) {
     for (qucs::Area *pa: Rects) // paint all rectangles
         p->PostPaintEvent(_Rect, cx + pa->x, cy + pa->y, pa->w, pa->h);
 
-    for (qucs::Area *pa: Ellips) // paint all ellipses
+    for (qucs::Ellips *pa: Ellips) // paint all ellipses
         p->PostPaintEvent(_Ellipse, cx + pa->x, cy + pa->y, pa->w, pa->h);
 }
 
@@ -550,7 +550,7 @@ void Component::rotate() {
     }
 
     // rotate all ellipses
-    for (qucs::Area *pa: Ellips) {
+    for (qucs::Ellips *pa: Ellips) {
         tmp = -pa->x;
         pa->x = pa->y;
         pa->y = tmp - pa->w;
@@ -642,7 +642,7 @@ void Component::mirrorX() {
         pa->y = -pa->y - pa->h;
 
     // mirror all ellipses
-    for (qucs::Area *pa: Ellips)
+    for (qucs::Ellips *pa: Ellips)
         pa->y = -pa->y - pa->h;
 
     QFont f = QucsSettings.font;
@@ -703,7 +703,7 @@ void Component::mirrorY() {
         pa->x = -pa->x - pa->w;
 
     // mirror all ellipses
-    for (qucs::Area *pa: Ellips)
+    for (qucs::Ellips *pa: Ellips)
         pa->x = -pa->x - pa->w;
 
     int tmp;
@@ -1278,7 +1278,7 @@ int Component::analyseLine(const QString &Row, int numProps) {
         if (!getIntegers(Row, &i1, &i2, &i3, &i4)) return -1;
         if (!getPen(Row, Pen, 5)) return -1;
         if (!getBrush(Row, Brush, 8)) return -1;
-        Ellips.append(new qucs::Area(i1, i2, i3, i4, Pen, Brush));
+        Ellips.append(new qucs::Ellips(i1, i2, i3, i4, Pen, Brush));
 
         if (i1 < x1) x1 = i1;  // keep track of component boundings
         if (i1 > x2) x2 = i1;
@@ -1717,7 +1717,7 @@ void GateComponent::createSymbol() {
             Texts.append(new Text(-10, 3 - y, "&", Qt::darkBlue, 15.0));
         else if (Model.at(0) == 'X') {
             if (Model.at(1) == 'N') {
-                Ellips.append(new qucs::Area(xr, -4, 8, 8,
+                Ellips.append(new qucs::Ellips(xr, -4, 8, 8,
                                              QPen(Qt::darkBlue, 0), QBrush(Qt::darkBlue)));
                 Texts.append(new Text(-11, 3 - y, "=1", Qt::darkBlue, 15.0));
             } else
@@ -1747,7 +1747,7 @@ void GateComponent::createSymbol() {
     }
 
     if (Model.at(0) == 'N')
-        Ellips.append(new qucs::Area(xr, -4, 8, 8,
+        Ellips.append(new qucs::Ellips(xr, -4, 8, 8,
                                      QPen(Qt::darkBlue, 0), QBrush(Qt::darkBlue)));
 
     Ports.append(new Port(30, 0));

--- a/qucs/components/component.h
+++ b/qucs/components/component.h
@@ -83,7 +83,7 @@ public:
 
   QList<qucs::Line *>     Lines;
   QList<struct qucs::Arc *>      Arcs;
-  QList<qucs::Area *>     Rects;
+  QList<qucs::Rect *>     Rects;
   QList<qucs::Ellips *>     Ellipses;
   QList<Port *>     Ports;
   QList<Text *>     Texts;

--- a/qucs/components/component.h
+++ b/qucs/components/component.h
@@ -84,7 +84,7 @@ public:
   QList<qucs::Line *>     Lines;
   QList<struct qucs::Arc *>      Arcs;
   QList<qucs::Area *>     Rects;
-  QList<qucs::Area *>     Ellips;
+  QList<qucs::Ellips *>     Ellips;
   QList<Port *>     Ports;
   QList<Text *>     Texts;
   Q3PtrList<Property> Props;

--- a/qucs/components/component.h
+++ b/qucs/components/component.h
@@ -84,7 +84,7 @@ public:
   QList<qucs::Line *>     Lines;
   QList<struct qucs::Arc *>      Arcs;
   QList<qucs::Area *>     Rects;
-  QList<qucs::Ellips *>     Ellips;
+  QList<qucs::Ellips *>     Ellipses;
   QList<Port *>     Ports;
   QList<Text *>     Texts;
   Q3PtrList<Property> Props;

--- a/qucs/components/logical_inv.cpp
+++ b/qucs/components/logical_inv.cpp
@@ -122,7 +122,7 @@ void Logical_Inv::createSymbol()
     xr =  10;
   }
 
-  Ellips.append(new qucs::Ellips(xr,-4, 8, 8,
+  Ellipses.append(new qucs::Ellips(xr,-4, 8, 8,
                 QPen(Qt::darkBlue,0), QBrush(Qt::darkBlue)));
 
   Lines.append(new qucs::Line( xr, 0, 30, 0, QPen(Qt::darkBlue,2)));

--- a/qucs/components/logical_inv.cpp
+++ b/qucs/components/logical_inv.cpp
@@ -122,7 +122,7 @@ void Logical_Inv::createSymbol()
     xr =  10;
   }
 
-  Ellips.append(new qucs::Area(xr,-4, 8, 8,
+  Ellips.append(new qucs::Ellips(xr,-4, 8, 8,
                 QPen(Qt::darkBlue,0), QBrush(Qt::darkBlue)));
 
   Lines.append(new qucs::Line( xr, 0, 30, 0, QPen(Qt::darkBlue,2)));

--- a/qucs/components/relais.cpp
+++ b/qucs/components/relais.cpp
@@ -43,7 +43,7 @@ Relais::Relais()
   Lines.append(new qucs::Line( 30, 15, 30, 30,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30, 15, 45,-15,QPen(Qt::darkBlue,2)));
   Arcs.append(new qucs::Arc( 27,-18, 5, 5, 0, 16*360,QPen(Qt::darkBlue,2)));
-  Ellips.append(new qucs::Area( 27, 12, 6, 6, QPen(Qt::darkBlue,2),
+  Ellips.append(new qucs::Ellips( 27, 12, 6, 6, QPen(Qt::darkBlue,2),
                          QBrush(Qt::darkBlue, Qt::SolidPattern)));
 
   Ports.append(new Port(-30,-30));

--- a/qucs/components/relais.cpp
+++ b/qucs/components/relais.cpp
@@ -43,7 +43,7 @@ Relais::Relais()
   Lines.append(new qucs::Line( 30, 15, 30, 30,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30, 15, 45,-15,QPen(Qt::darkBlue,2)));
   Arcs.append(new qucs::Arc( 27,-18, 5, 5, 0, 16*360,QPen(Qt::darkBlue,2)));
-  Ellips.append(new qucs::Ellips( 27, 12, 6, 6, QPen(Qt::darkBlue,2),
+  Ellipses.append(new qucs::Ellips( 27, 12, 6, 6, QPen(Qt::darkBlue,2),
                          QBrush(Qt::darkBlue, Qt::SolidPattern)));
 
   Ports.append(new Port(-30,-30));

--- a/qucs/components/switch.cpp
+++ b/qucs/components/switch.cpp
@@ -176,7 +176,7 @@ void Switch::createSymbol()
   Lines.append(new qucs::Line(-30,  0,-15,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 17,  0, 30,  0,QPen(Qt::darkBlue,2)));
   Arcs.append(new qucs::Arc( 12, -3, 5, 5, 0, 16*360,QPen(Qt::darkBlue,2)));
-  Ellips.append(new qucs::Area(-18, -3, 6, 6, QPen(Qt::darkBlue,2),
+  Ellips.append(new qucs::Ellips(-18, -3, 6, 6, QPen(Qt::darkBlue,2),
                 QBrush(Qt::darkBlue, Qt::SolidPattern)));
 
   Ports.append(new Port(-30,  0));

--- a/qucs/components/switch.cpp
+++ b/qucs/components/switch.cpp
@@ -176,7 +176,7 @@ void Switch::createSymbol()
   Lines.append(new qucs::Line(-30,  0,-15,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 17,  0, 30,  0,QPen(Qt::darkBlue,2)));
   Arcs.append(new qucs::Arc( 12, -3, 5, 5, 0, 16*360,QPen(Qt::darkBlue,2)));
-  Ellips.append(new qucs::Ellips(-18, -3, 6, 6, QPen(Qt::darkBlue,2),
+  Ellipses.append(new qucs::Ellips(-18, -3, 6, 6, QPen(Qt::darkBlue,2),
                 QBrush(Qt::darkBlue, Qt::SolidPattern)));
 
   Ports.append(new Port(-30,  0));

--- a/qucs/components/vacomponent.cpp
+++ b/qucs/components/vacomponent.cpp
@@ -236,7 +236,7 @@ void vacomponent::createSymbol(QJsonObject json)
             colorfill = getString(paint, "colorfill");
             stylefill = getString(paint, "stylefill");
 
-            Ellips.append (new qucs::Ellips (x, y, w, h,
+            Ellipses.append (new qucs::Ellips (x, y, w, h,
                                          QPen (QColor (color), thick, penMap.value(style)),
                                          QBrush(QColor (colorfill), brushMap.value(stylefill))
                                          ));

--- a/qucs/components/vacomponent.cpp
+++ b/qucs/components/vacomponent.cpp
@@ -236,7 +236,7 @@ void vacomponent::createSymbol(QJsonObject json)
             colorfill = getString(paint, "colorfill");
             stylefill = getString(paint, "stylefill");
 
-            Ellips.append (new qucs::Area (x, y, w, h,
+            Ellips.append (new qucs::Ellips (x, y, w, h,
                                          QPen (QColor (color), thick, penMap.value(style)),
                                          QBrush(QColor (colorfill), brushMap.value(stylefill))
                                          ));

--- a/qucs/components/vacomponent.cpp
+++ b/qucs/components/vacomponent.cpp
@@ -219,7 +219,7 @@ void vacomponent::createSymbol(QJsonObject json)
             colorfill = getString(paint, "colorfill");
             stylefill = getString(paint, "stylefill");
 
-            Rects.append (new qucs::Area (x, y, w, h,
+            Rects.append (new qucs::Rect (x, y, w, h,
                                         QPen (QColor (color), thick, penMap.value(style)),
                                         QBrush(QColor (colorfill), brushMap.value(stylefill))
                                         ));

--- a/qucs/diagrams/diagram.cpp
+++ b/qucs/diagrams/diagram.cpp
@@ -104,16 +104,22 @@ void Diagram::paint(ViewPainter *p) {
 }
 
 void Diagram::paintDiagram(ViewPainter *p) {
+    // Drawing primitives in Diagram have their coordinates
+    // as if they exist in space where Y-axis oriented upwards
+    // in contrast to downwards-oriented Y-axis of ViewPainter.
+    // We need to pass this flag to draw primitives correctly.
+    const bool y_directed_upwards = true;
+
     // paint all lines
-    for (qucs::Line *pl: Lines) {
-        p->Painter->setPen(pl->style);
-        p->drawLine(cx + pl->x1, cy - pl->y1, cx + pl->x2, cy - pl->y2);
+    for (qucs::DrawingPrimitive* line : Lines) {
+        p->Painter->setPen(line->penHint());
+        line->draw(p, cx, cy, y_directed_upwards);
     }
 
     // paint all arcs (1 pixel larger to compensate for strange circle method)
-    for (qucs::Arc *pa: Arcs) {
-        p->Painter->setPen(pa->style);
-        p->drawArc(cx + pa->x, cy - pa->y, pa->w, pa->h, pa->angle, pa->arclen);
+    for (qucs::DrawingPrimitive* arc : Arcs) {
+        p->Painter->setPen(arc->penHint());
+        arc->draw(p, cx, cy, y_directed_upwards);
     }
 
     // draw all graphs

--- a/qucs/diagrams/tabdiagram.cpp
+++ b/qucs/diagrams/tabdiagram.cpp
@@ -55,9 +55,9 @@ void TabDiagram::paint(ViewPainter *p)
 void TabDiagram::paintDiagram(ViewPainter *p)
 {
   // paint all lines
-  for (qucs::Line *pl : Lines) {
-    p->Painter->setPen(pl->style);
-    p->drawLine(cx+pl->x1, cy-pl->y1, cx+pl->x2, cy-pl->y2);
+  for (qucs::DrawingPrimitive* line : Lines) {
+    p->Painter->setPen(line->penHint());
+    line->draw(p, cx, cy, true);
   }
 
   if(x1 > 0) {  // paint scroll bar ?

--- a/qucs/diagrams/timingdiagram.cpp
+++ b/qucs/diagrams/timingdiagram.cpp
@@ -54,9 +54,9 @@ void TimingDiagram::paint(ViewPainter *p)
 void TimingDiagram::paintDiagram(ViewPainter *p)
 {
   // paint all lines
-  for(qucs::Line *pl : Lines) {
-    p->Painter->setPen(pl->style);
-    p->drawLine(cx+pl->x1, cy-pl->y1, cx+pl->x2, cy-pl->y2);
+  for(qucs::DrawingPrimitive* line : Lines) {
+    p->Painter->setPen(line->penHint());
+    line->draw(p, cx, cy, true);
   }
 
   p->Painter->setPen(Qt::black);

--- a/qucs/element.cpp
+++ b/qucs/element.cpp
@@ -93,6 +93,27 @@ void Ellips::draw(QPainter* painter, int cx, int cy, bool y_grows_up) const {
 
 } // namespace qucs
 
+void Text::draw(ViewPainter *painter, int cx, int cy, bool) const {
+  painter->Painter->save();
+
+  QFont newFont = painter->Painter->font();
+  newFont.setWeight(QFont::Light);
+  newFont.setPointSizeF(painter->Scale * Size);
+  newFont.setOverline(over);
+  newFont.setUnderline(under);
+  painter->Painter->setFont(newFont);
+
+  painter->Painter->setWorldTransform(
+        QTransform(mCos, -mSin, mSin, mCos,
+                    painter->DX + float(cx + x) * painter->Scale,
+                    painter->DY + float(cy + y) * painter->Scale));
+
+  painter->drawTextMapped(s, 0, 0);
+
+  painter->Painter->restore();
+}
+
+
 Element::Element()
 {
   Type = isDummyElement;

--- a/qucs/element.cpp
+++ b/qucs/element.cpp
@@ -17,6 +17,82 @@
 
 #include "element.h"
 
+namespace qucs {
+
+void Line::draw(ViewPainter* painter, int cx, int cy, bool y_grows_up) const {
+  // For explanation please refer to parent class doc
+  if (y_grows_up) {
+    painter->drawLine(cx + x1, cy - y1, cx + x2, cy - y2);
+  } else {
+    painter->drawLine(cx + x1, cy + y1, cx + x2, cy + y2);
+  }
+}
+
+void Line::draw(QPainter* painter, int cx, int cy, bool y_grows_up) const {
+  // For explanation please refer to parent class doc
+  if (y_grows_up) {
+    painter->drawLine(cx + x1, cy - y1, cx + x2, cy - y2);
+  } else {
+    painter->drawLine(cx + x1, cy + y1, cx + x2, cy + y2);
+  }
+}
+
+void Arc::draw(ViewPainter* painter, int cx, int cy, bool y_grows_up) const {
+  // For explanation please refer to parent class doc
+  if (y_grows_up) {
+    painter->drawArc(cx + x, cy - y, w, h, angle, arclen);
+  } else {
+    painter->drawArc(cx + x, cy + y, w, h, angle, arclen);
+  }
+}
+
+void Arc::draw(QPainter* painter, int cx, int cy, bool y_grows_up) const {
+  // For explanation please refer to parent class doc
+  if (y_grows_up) {
+    painter->drawArc(cx + x, cy - y, w, h, angle, arclen);
+  } else {
+    painter->drawArc(cx + x, cy + y, w, h, angle, arclen);
+  }
+}
+
+void Rect::draw(ViewPainter* painter, int cx, int cy, bool y_grows_up) const {
+  // For explanation please refer to parent class doc
+  if (y_grows_up) {
+    painter->drawRect(cx + x, cy - y, w, h);
+  } else {
+    painter->drawRect(cx + x, cy + y, w, h);
+  }
+}
+
+void Rect::draw(QPainter* painter, int cx, int cy, bool y_grows_up) const {
+  // For explanation please refer to parent class doc
+  if (y_grows_up) {
+    painter->drawRect(cx + x, cy - y, w, h);
+  } else {
+    painter->drawRect(cx + x, cy + y, w, h);
+  }
+}
+
+void Ellips::draw(ViewPainter* painter, int cx, int cy, bool y_grows_up) const {
+  // For explanation please refer to parent class doc
+  if (y_grows_up) {
+    painter->drawEllipse(cx + x, cy - y, w, h);
+  } else {
+    painter->drawEllipse(cx + x, cy + y, w, h);
+  }
+}
+
+void Ellips::draw(QPainter* painter, int cx, int cy, bool y_grows_up) const {
+  // For explanation please refer to parent class doc
+  if (y_grows_up) {
+    painter->drawEllipse(cx + x, cy - y, w, h);
+  } else {
+    painter->drawEllipse(cx + x, cy + y, w, h);
+  }
+}
+
+} // namespace qucs
+
 Element::Element()
 {
   Type = isDummyElement;

--- a/qucs/element.h
+++ b/qucs/element.h
@@ -147,7 +147,7 @@ struct Port {
   Node *Connection;
 };
 
-struct Text {
+struct Text : qucs::DrawingPrimitive {
   Text(int _x, int _y, const QString& _s, QColor _Color = QColor(0,0,0),
 	float _Size = 10.0, float _mCos=1.0, float _mSin=0.0)
 	: x(_x), y(_y), s(_s), Color(_Color), Size(_Size),
@@ -157,6 +157,8 @@ struct Text {
   QColor  Color;
   float	  Size, mSin, mCos; // font size and rotation coefficients
   bool	  over, under;      // text attributes
+  void draw(ViewPainter* painter, int cx, int cy, bool y_grows_up=false) const override;
+  QPen penHint() const override { return Color; }
 };
 
 struct Property {

--- a/qucs/element.h
+++ b/qucs/element.h
@@ -72,6 +72,16 @@ struct Area {
   QBrush Brush;    // filling style/color
 };
 
+// 'ellipse' conflicts 'ellipse' defined in paintings.h in the same namespace
+struct Ellips {
+  Ellips(int _x, int _y, int _w, int _h, QPen _Pen,
+	QBrush _Brush = QBrush(Qt::NoBrush))
+	: x(_x), y(_y), w(_w), h(_h), Pen(_Pen), Brush(_Brush) {};
+  int    x, y, w, h;
+  QPen   Pen;
+  QBrush Brush;    // filling style/color
+};
+
 }
 
 struct Port {

--- a/qucs/element.h
+++ b/qucs/element.h
@@ -63,8 +63,8 @@ struct Arc {
   QPen  style;
 };
 
-struct Area {
-  Area(int _x, int _y, int _w, int _h, QPen _Pen,
+struct Rect {
+  Rect(int _x, int _y, int _w, int _h, QPen _Pen,
 	QBrush _Brush = QBrush(Qt::NoBrush))
 	: x(_x), y(_y), w(_w), h(_h), Pen(_Pen), Brush(_Brush) {};
   int    x, y, w, h;

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -579,7 +579,7 @@ void createIcons() {
         QList<qucs::Line *> Lines      = c->Lines;
         QList<struct qucs::Arc *> Arcs = c-> Arcs;
         QList<qucs::Area *> Rects      = c-> Rects;
-        QList<qucs::Area *> Ellips     = c-> Ellips;
+        QList<qucs::Ellips *> Ellips     = c-> Ellips;
         QList<Port *> Ports      = c->Ports;
         QList<Text*> Texts       = c->Texts;
 
@@ -602,7 +602,7 @@ void createIcons() {
           scene->addRect(a->x, a->y, a->w, a->h, a->Pen, a->Brush);
         }
 
-        for(qucs::Area *a: Ellips) {
+        for(qucs::Ellips *a: Ellips) {
           scene->addEllipse(a->x, a->y, a->w, a->h, a->Pen, a->Brush);
         }
 

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -578,7 +578,7 @@ void createIcons() {
 
         QList<qucs::Line *> Lines      = c->Lines;
         QList<struct qucs::Arc *> Arcs = c-> Arcs;
-        QList<qucs::Area *> Rects      = c-> Rects;
+        QList<qucs::Rect *> Rects      = c-> Rects;
         QList<qucs::Ellips *> Ellips     = c-> Ellipses;
         QList<Port *> Ports      = c->Ports;
         QList<Text*> Texts       = c->Texts;
@@ -598,7 +598,7 @@ void createIcons() {
           scene->addPath(*path);
         }
 
-        for(qucs::Area *a: Rects) {
+        for(qucs::Rect *a: Rects) {
           scene->addRect(a->x, a->y, a->w, a->h, a->Pen, a->Brush);
         }
 

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -579,7 +579,7 @@ void createIcons() {
         QList<qucs::Line *> Lines      = c->Lines;
         QList<struct qucs::Arc *> Arcs = c-> Arcs;
         QList<qucs::Area *> Rects      = c-> Rects;
-        QList<qucs::Ellips *> Ellips     = c-> Ellips;
+        QList<qucs::Ellips *> Ellips     = c-> Ellipses;
         QList<Port *> Ports      = c->Ports;
         QList<Text*> Texts       = c->Texts;
 

--- a/qucs/symbolwidget.cpp
+++ b/qucs/symbolwidget.cpp
@@ -152,8 +152,8 @@ void SymbolWidget::paintEvent(QPaintEvent*)
   }
 
   // paint all ellipses
-  for(int i=0; i<Ellips.size(); i++) {
-    qucs::Ellips *pa = Ellips.at(i);
+  for(int i=0; i<Ellipses.size(); i++) {
+    qucs::Ellips *pa = Ellipses.at(i);
     Painter.setPen(pa->Pen);
     Painter.setBrush(pa->Brush);
     Painter.drawEllipse(cx+pa->x, cy+pa->y, pa->w, pa->h);
@@ -183,7 +183,7 @@ int SymbolWidget::createStandardSymbol(const QString& Lib_, const QString& Comp_
   Arcs.clear();
   Lines.clear();
   Rects.clear();
-  Ellips.clear();
+  Ellipses.clear();
   Texts.clear();
   LibraryPath = Lib_;
   ComponentName = Comp_;
@@ -415,7 +415,7 @@ int SymbolWidget::setSymbol( QString& SymbolString,
   Arcs.clear();
   Lines.clear();
   Rects.clear();
-  Ellips.clear();
+  Ellipses.clear();
   Texts.clear();
   LibraryPath = Lib_;
   ComponentName = Comp_;
@@ -562,7 +562,7 @@ int SymbolWidget::analyseLine(const QString& Row)
     if(!getCompLineIntegers(Row, &i1, &i2, &i3, &i4))  return -1;
     if(!getPen(Row, Pen, 5))  return -1;
     if(!getBrush(Row, Brush, 8))  return -1;
-    Ellips.append(new qucs::Ellips(i1, i2, i3, i4, Pen, Brush));
+    Ellipses.append(new qucs::Ellips(i1, i2, i3, i4, Pen, Brush));
 
     if(i1 < x1)  x1 = i1;  // keep track of component boundings
     if(i1 > x2)  x2 = i1;

--- a/qucs/symbolwidget.cpp
+++ b/qucs/symbolwidget.cpp
@@ -153,7 +153,7 @@ void SymbolWidget::paintEvent(QPaintEvent*)
 
   // paint all ellipses
   for(int i=0; i<Ellips.size(); i++) {
-    qucs::Area *pa = Ellips.at(i);
+    qucs::Ellips *pa = Ellips.at(i);
     Painter.setPen(pa->Pen);
     Painter.setBrush(pa->Brush);
     Painter.drawEllipse(cx+pa->x, cy+pa->y, pa->w, pa->h);
@@ -562,7 +562,7 @@ int SymbolWidget::analyseLine(const QString& Row)
     if(!getCompLineIntegers(Row, &i1, &i2, &i3, &i4))  return -1;
     if(!getPen(Row, Pen, 5))  return -1;
     if(!getBrush(Row, Brush, 8))  return -1;
-    Ellips.append(new qucs::Area(i1, i2, i3, i4, Pen, Brush));
+    Ellips.append(new qucs::Ellips(i1, i2, i3, i4, Pen, Brush));
 
     if(i1 < x1)  x1 = i1;  // keep track of component boundings
     if(i1 > x2)  x2 = i1;

--- a/qucs/symbolwidget.cpp
+++ b/qucs/symbolwidget.cpp
@@ -145,7 +145,7 @@ void SymbolWidget::paintEvent(QPaintEvent*)
 
   // paint all rectangles
   for(int i=0; i<Rects.size(); i++) {
-    qucs::Area *pa = Rects.at(i);
+    qucs::Rect *pa = Rects.at(i);
     Painter.setPen(pa->Pen);
     Painter.setBrush(pa->Brush);
     Painter.drawRect(cx+pa->x, cy+pa->y, pa->w, pa->h);
@@ -578,7 +578,7 @@ int SymbolWidget::analyseLine(const QString& Row)
     if(!getCompLineIntegers(Row, &i1, &i2, &i3, &i4))  return -1;
     if(!getPen(Row, Pen, 5))  return -1;
     if(!getBrush(Row, Brush, 8))  return -1;
-    Rects.append(new qucs::Area(i1, i2, i3, i4, Pen, Brush));
+    Rects.append(new qucs::Rect(i1, i2, i3, i4, Pen, Brush));
 
     if(i1 < x1)  x1 = i1;  // keep track of component boundings
     if(i1 > x2)  x2 = i1;

--- a/qucs/symbolwidget.cpp
+++ b/qucs/symbolwidget.cpp
@@ -130,33 +130,29 @@ void SymbolWidget::paintEvent(QPaintEvent*)
   Painter.drawText(dx, y2-y1+2, 0, 0, Qt::AlignLeft | Qt::TextDontClip, DragNDropText);
 
   // paint all lines
-  for(int i=0; i<Lines.size(); i++) {
-    qucs::Line *pl = Lines.at(i);
-    Painter.setPen(pl->style);
-    Painter.drawLine(cx+pl->x1, cy+pl->y1, cx+pl->x2, cy+pl->y2);
+  for (auto* line : Lines) {
+    Painter.setPen(line->penHint());
+    line->draw(&Painter, cx, cy);
   }
 
   // paint all arcs
-  for(int i=0; i<Arcs.size(); i++) {
-    qucs::Arc *pc = Arcs.at(i);
-    Painter.setPen(pc->style);
-    Painter.drawArc(cx+pc->x, cy+pc->y, pc->w, pc->h, pc->angle, pc->arclen);
+  for (auto* arc : Arcs) {
+    Painter.setPen(arc->penHint());
+    arc->draw(&Painter, cx, cy);
   }
 
   // paint all rectangles
-  for(int i=0; i<Rects.size(); i++) {
-    qucs::Rect *pa = Rects.at(i);
-    Painter.setPen(pa->Pen);
-    Painter.setBrush(pa->Brush);
-    Painter.drawRect(cx+pa->x, cy+pa->y, pa->w, pa->h);
+  for (auto* rect : Rects) {
+    Painter.setPen(rect->penHint());
+    Painter.setBrush(rect->brushHint());
+    rect->draw(&Painter, cx, cy);
   }
 
   // paint all ellipses
-  for(int i=0; i<Ellipses.size(); i++) {
-    qucs::Ellips *pa = Ellipses.at(i);
-    Painter.setPen(pa->Pen);
-    Painter.setBrush(pa->Brush);
-    Painter.drawEllipse(cx+pa->x, cy+pa->y, pa->w, pa->h);
+  for (auto* ellipse : Ellipses) {
+    Painter.setPen(ellipse->penHint());
+    Painter.setBrush(ellipse->brushHint());
+    ellipse->draw(&Painter, cx, cy);
   }
 
   Painter.setPen(QPen(Qt::black,1));

--- a/qucs/symbolwidget.h
+++ b/qucs/symbolwidget.h
@@ -78,7 +78,7 @@ private:
   QList<qucs::Line *> Lines;
   QList<qucs::Arc *> Arcs;
   QList<qucs::Area *> Rects;
-  QList<qucs::Ellips *> Ellips;
+  QList<qucs::Ellips *> Ellipses;
   QList<Text *>  Texts;
 };
 

--- a/qucs/symbolwidget.h
+++ b/qucs/symbolwidget.h
@@ -77,7 +77,8 @@ private:
   int cx, cy, x1, x2, y1, y2;
   QList<qucs::Line *> Lines;
   QList<qucs::Arc *> Arcs;
-  QList<qucs::Area *> Rects, Ellips;
+  QList<qucs::Area *> Rects;
+  QList<qucs::Ellips *> Ellips;
   QList<Text *>  Texts;
 };
 

--- a/qucs/symbolwidget.h
+++ b/qucs/symbolwidget.h
@@ -77,7 +77,7 @@ private:
   int cx, cy, x1, x2, y1, y2;
   QList<qucs::Line *> Lines;
   QList<qucs::Arc *> Arcs;
-  QList<qucs::Area *> Rects;
+  QList<qucs::Rect *> Rects;
   QList<qucs::Ellips *> Ellipses;
   QList<Text *>  Texts;
 };


### PR DESCRIPTION
Hi!

This is yet another bit of refactoring. The core idea is to create a common interface for such primitives like `qucs::Line`, `qucs::Arc`, `qucs::Area` and to hide drawing logic behind the interface.

Look at this, where client has to select a proper method of `QPainter` and deal with its arguments not its own:
```
        for (qucs::Area *pa: Rects) {
            p->setBrush(pa->Brush);
            p->drawRect(cx + pa->x, cy + pa->y, pa->w, pa->h);
        } 
```
— next time when rect is drawn everything has to be done again, and most likely will be just copied and pasted, making duplicate.

And compare with this:
```
        for (qucs::DrawingPrimitive* rect : Rects) {
            p->setBrush(rect->brushHint());
            rect-draw(p, cx, cy);
        } 
```
— where
- drawing logic (`drawRect(cx + pa->x, cy + pa->y, pa->w, pa->h)`) is hidden and defined only once in member function body
- it's cleaner
- you can drawn different kinds of primitives all in one loop, because they have the same interface

To achieve this I did the following steps:
1. Created a new type for ellipses. Previously ellipses and rectangles were defined by the same type `Area` and client had to decide somehow what this area is — an ellipse or a rectangle
2. Created a common interface `qucs::DrawingPrimitive` for `qucs::Line`, `qucs::Arc`, `qucs::Rect`, `qucs::Ellips`
3. Replaced all approach to drawing of primitives with invocations of new API.

<hr>

Everything should look the same, I haven't found any issues using the changed build on my machine.  