### PR TITLE
Fix tabdiagram headers with Qucsator data

### DIFF
--- a/qucs/diagrams/tabdiagram.cpp
+++ b/qucs/diagrams/tabdiagram.cpp
@@ -247,7 +247,9 @@ int TabDiagram::calcDiagram()
     y = y2-tHeight-5;
     colWidth = 0;
 
-    Str = g->Var.section('/', 1);
+    Str = g->Var;
+    if (Str.contains('/')) Str = g->Var.section('/', 1);
+
     colWidth = checkColumnWidth(Str, metrics, colWidth, x, y2);
     if(colWidth < 0)  goto funcEnd;
     Texts.append(new Text(x, y2-2, Str));  // dependent variable


### PR DESCRIPTION
It has been noticed that the data headers are missing from the Tab Diagram when the simulation data comes from Qucsator instead of Ngspice.

### Data from Qucsator [NOT OK]
![imagen](https://github.com/ra3xdh/qucs_s/assets/13180689/b8d59208-f318-480e-b938-da72ae4f8ff9)

### Data from Ngspice [OK]
![imagen](https://github.com/ra3xdh/qucs_s/assets/13180689/f2d64bcd-2d8a-41c5-8944-5d2e3704e6f1)

By inspecting the code in "tabdiagram.cpp", It was found that line [250](https://github.com/ra3xdh/qucs_s/blob/current/qucs/diagrams/tabdiagram.cpp#L250C1-L250C34) filters the name of the dependent variable by removing all characters before the "/". 

The data coming from a Ngspice simulation has names like "ngspice/variable_name", but in the case of Qucsator, the "/" is missing, so the table headers are empty.

### Dataset from the Ngspice simulation
![imagen](https://github.com/ra3xdh/qucs_s/assets/13180689/64bbbcb6-bb9f-4d83-8791-03bd679f5fff)

### Dataset from the Qucsator simulation
![imagen](https://github.com/ra3xdh/qucs_s/assets/13180689/100a20a4-7092-44cc-82e7-aca04bd51bd7)


This PR fixes the above problem by first checking that the string contains "/":

### After this fix
![imagen](https://github.com/ra3xdh/qucs_s/assets/13180689/72f179da-83f7-48c3-8358-d8cef5b85f2b)

A workspace is provided to verify this:
[TESTBENCH_TABLES_wo_headers_if_qucsator_prj.zip](https://github.com/ra3xdh/qucs_s/files/15048786/TESTBENCH_TABLES_wo_headers_if_qucsator_prj.zip)

