### PR TITLE
Turned off the output of component parameters in the schemes by default

### DIFF
--- a/qucs/components/ac_sim.cpp
+++ b/qucs/components/ac_sim.cpp
@@ -50,13 +50,13 @@ AC_Sim::AC_Sim()
   Name  = "AC";
 
   // The index of the first 4 properties must not changed. Used in recreate().
-  Props.append(new Property("Type", "lin", true,
+  Props.append(new Property("Type", "lin", false,
 			QObject::tr("sweep type")+" [lin, log, list, const]"));
-  Props.append(new Property("Start", "1 Hz", true,
+  Props.append(new Property("Start", "1 Hz", false,
 			QObject::tr("start frequency in Hertz")));
-  Props.append(new Property("Stop", "10 kHz", true,
+  Props.append(new Property("Stop", "10 kHz", false,
 			QObject::tr("stop frequency in Hertz")));
-  Props.append(new Property("Points", "200", true,
+  Props.append(new Property("Points", "200", false,
 			QObject::tr("number of simulation steps")));
   Props.append(new Property("Noise", "no", false,
 			QObject::tr("calculate noise voltages")+

--- a/qucs/components/am_modulator.cpp
+++ b/qucs/components/am_modulator.cpp
@@ -50,7 +50,7 @@ AM_Modulator::AM_Modulator()
   Model = "AM_Mod";
   Name  = "V";
 
-  Props.append(new Property("U", "1 V", true,
+  Props.append(new Property("U", "1 V", false,
 		QObject::tr("peak voltage in Volts")));
   Props.append(new Property("f", "1 GHz", false,
 		QObject::tr("frequency in Hertz")));

--- a/qucs/components/ampere_ac.cpp
+++ b/qucs/components/ampere_ac.cpp
@@ -46,7 +46,7 @@ Ampere_ac::Ampere_ac()
   Name  = "I";
   SpiceModel = "I";
 
-  Props.append(new Property("I", "1 mA", true,
+  Props.append(new Property("I", "1 mA", false,
 		QObject::tr("peak current in Ampere")));
   Props.append(new Property("f", "1 GHz", false,
 		QObject::tr("frequency in Hertz")));

--- a/qucs/components/ampere_dc.cpp
+++ b/qucs/components/ampere_dc.cpp
@@ -44,7 +44,7 @@ Ampere_dc::Ampere_dc()
   Name  = "I";
   SpiceModel = "I";
 
-  Props.append(new Property("I", "1 mA", true,
+  Props.append(new Property("I", "1 mA", false,
 		QObject::tr("current in Ampere")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/ampere_noise.cpp
+++ b/qucs/components/ampere_noise.cpp
@@ -51,7 +51,7 @@ Ampere_noise::Ampere_noise()
   Model = "Inoise";
   Name  = "I";
 
-  Props.append(new Property("i", "1e-6", true,
+  Props.append(new Property("i", "1e-6", false,
 		QObject::tr("current power spectral density in A^2/Hz")));
   Props.append(new Property("e", "0", false,
 		QObject::tr("frequency exponent")));

--- a/qucs/components/amplifier.cpp
+++ b/qucs/components/amplifier.cpp
@@ -42,7 +42,7 @@ Amplifier::Amplifier()
   Model = "Amp";
   Name  = "X";
 
-  Props.append(new Property("G", "10", true,
+  Props.append(new Property("G", "10", false,
 		QObject::tr("voltage gain")));
   Props.append(new Property("Z1", "50 Ohm", false,
 		QObject::tr("reference impedance of input port")));

--- a/qucs/components/attenuator.cpp
+++ b/qucs/components/attenuator.cpp
@@ -50,7 +50,7 @@ Attenuator::Attenuator()
   Model = "Attenuator";
   Name  = "X";
 
-  Props.append(new Property("L", "10 dB", true,
+  Props.append(new Property("L", "10 dB", false,
 		QObject::tr("power attenuation")));
   Props.append(new Property("Zref", "50 Ohm", false,
 		QObject::tr("reference impedance")));

--- a/qucs/components/bjtsub.cpp
+++ b/qucs/components/bjtsub.cpp
@@ -23,11 +23,11 @@
 Basic_BJT::Basic_BJT()
 {
   // this must be the first property in the list  !!!
-  Props.append(new Property("Type", "npn", true,
+  Props.append(new Property("Type", "npn", false,
 	QObject::tr("polarity")+" [npn, pnp]"));
-  Props.append(new Property("Is", "1e-16", true,
+  Props.append(new Property("Is", "1e-16", false,
 	QObject::tr("saturation current")));
-  Props.append(new Property("Nf", "1", true,
+  Props.append(new Property("Nf", "1", false,
 	QObject::tr("forward emission coefficient")));
   Props.append(new Property("Nr", "1", false,
 	QObject::tr("reverse emission coefficient")));
@@ -35,7 +35,7 @@ Basic_BJT::Basic_BJT()
 	QObject::tr("high current corner for forward beta")));
   Props.append(new Property("Ikr", "0", false,
 	QObject::tr("high current corner for reverse beta")));
-  Props.append(new Property("Vaf", "0", true,
+  Props.append(new Property("Vaf", "0", false,
 	QObject::tr("forward early voltage")));
   Props.append(new Property("Var", "0", false,
 	QObject::tr("reverse early voltage")));
@@ -47,7 +47,7 @@ Basic_BJT::Basic_BJT()
 	QObject::tr("base-collector leakage saturation current")));
   Props.append(new Property("Nc", "2", false,
 	QObject::tr("base-collector leakage emission coefficient")));
-  Props.append(new Property("Bf", "100", true,
+  Props.append(new Property("Bf", "100", false,
 	QObject::tr("forward beta")));
   Props.append(new Property("Br", "1", false,
 	QObject::tr("reverse beta")));

--- a/qucs/components/bondwire.cpp
+++ b/qucs/components/bondwire.cpp
@@ -42,11 +42,11 @@ BondWire::BondWire()
   Model = "BOND";
   Name  = "Line";
 
-  Props.append(new Property("L", "3 mm", true,
+  Props.append(new Property("L", "3 mm", false,
 		QObject::tr("length of the wire")));
-  Props.append(new Property("D", "50 um", true,
+  Props.append(new Property("D", "50 um", false,
 		QObject::tr("diameter of the wire")));
-  Props.append(new Property("H", "2 mm", true,
+  Props.append(new Property("H", "2 mm", false,
 		QObject::tr("height above ground plane")));
   Props.append(new Property("rho", "0.022e-6", false,
 		QObject::tr("specific resistance of the metal")));
@@ -54,7 +54,7 @@ BondWire::BondWire()
 		QObject::tr("relative permeability of the metal")));
   Props.append(new Property("Model", "FREESPACE", false,
 	QObject::tr("bond wire model")+" [FREESPACE, MIRROR, DESCHARLES]"));
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 		QObject::tr("substrate")));
   Props.append(new Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));

--- a/qucs/components/capacitor.cpp
+++ b/qucs/components/capacitor.cpp
@@ -26,7 +26,7 @@ Capacitor::Capacitor()
 {
   Description = QObject::tr("capacitor");
 
-  Props.append(new Property("C", "1 nF", true,
+  Props.append(new Property("C", "1 nF", false,
 		QObject::tr("capacitance in Farad")));
   Props.append(new Property("V", "", false,
 		QObject::tr("initial voltage for transient simulation")));

--- a/qucs/components/capq.cpp
+++ b/qucs/components/capq.cpp
@@ -61,9 +61,9 @@ CapQ::CapQ()
   SpiceModel = "C";
   Name  = "CQ";
 
-  Props.append(new Property("C", "1 pF", true,
+  Props.append(new Property("C", "1 pF", false,
 		QObject::tr("Capacitance")));
-  Props.append(new Property("Q", "100", true,
+  Props.append(new Property("Q", "100", false,
 		QObject::tr("Quality factor")));
   Props.append(new Property("f", "100 MHz", false,
 		QObject::tr("Frequency at which Q is measured")));

--- a/qucs/components/cccs.cpp
+++ b/qucs/components/cccs.cpp
@@ -62,7 +62,7 @@ CCCS::CCCS()
   Name  = "SRC";
   SpiceModel = "F";
 
-  Props.append(new Property("G", "1", true,
+  Props.append(new Property("G", "1", false,
 		QObject::tr("forward transfer factor")));
   Props.append(new Property("T", "0", false, QObject::tr("delay time (Qucsator only)")));
 }

--- a/qucs/components/ccvs.cpp
+++ b/qucs/components/ccvs.cpp
@@ -62,7 +62,7 @@ CCVS::CCVS()
   Name  = "SRC";
   SpiceModel = "H";
 
-  Props.append(new Property("G", "1 Ohm", true,
+  Props.append(new Property("G", "1 Ohm", false,
 		QObject::tr("forward transfer factor")));
   Props.append(new Property("T", "0", false, QObject::tr("delay time (Qucsator only)")));
 }

--- a/qucs/components/circline.cpp
+++ b/qucs/components/circline.cpp
@@ -50,9 +50,9 @@ CircLine::CircLine()
   Model = "CIRCLINE";
   Name  = "Line";
 
-  Props.append(new Property("a", "2.95 mm", true,
+  Props.append(new Property("a", "2.95 mm", false,
 		QObject::tr("Radius")));
-  Props.append(new Property("L", "1500 mm", true,
+  Props.append(new Property("L", "1500 mm", false,
 		QObject::tr("Mechanical length of the line")));
   Props.append(new Property("er", "1", false,
 		QObject::tr("Relative permittivity of dielectric")));

--- a/qucs/components/circularloop.cpp
+++ b/qucs/components/circularloop.cpp
@@ -47,7 +47,7 @@ circularloop::circularloop()
   Name  = "CIRCULARLOOP";
   Simulator = spicecompat::simQucsator;
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 		QObject::tr("Substrate")));
   Props.append(new Property("W", "25 um", false,
 		QObject::tr("Width of line")));

--- a/qucs/components/coaxialline.cpp
+++ b/qucs/components/coaxialline.cpp
@@ -43,7 +43,7 @@ CoaxialLine::CoaxialLine()
   Model = "COAX";
   Name  = "Line";
 
-  Props.append(new Property("er", "2.29", true,
+  Props.append(new Property("er", "2.29", false,
 		QObject::tr("relative permittivity of dielectric")));
   Props.append(new Property("rho", "0.022e-6", false,
 		QObject::tr("specific resistance of conductor")));
@@ -53,7 +53,7 @@ CoaxialLine::CoaxialLine()
 		QObject::tr("inner diameter of shield")));
   Props.append(new Property("d", "0.9 mm", false,
 		QObject::tr("diameter of inner conductor")));
-  Props.append(new Property("L", "1500 mm", true,
+  Props.append(new Property("L", "1500 mm", false,
 		QObject::tr("mechanical length of the line")));
   Props.append(new Property("tand", "4e-4", false,
 		QObject::tr("loss tangent")));

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -1057,7 +1057,7 @@ bool Component::load(const QString &_s) {
     else tmp = counts + 1;    // "+1" because "counts" could be zero
 
     for (; tmp <= (int) counts / 2; tmp++)
-        Props.append(new Property("p", "", true, " "));
+        Props.append(new Property("p", "", false, " "));
 
     // load all properties
     Property *p1;
@@ -1127,7 +1127,7 @@ bool Component::load(const QString &_s) {
                 n = n.section('=', 1);
                 // allocate memory for a new property (e.g. for equations)
                 if (Props.count() < (counts >> 1)) {
-                    Props.insert(z >> 1, new Property("y", "1", true));
+                    Props.insert(z >> 1, new Property("y", "1", false));
                     Props.prev();
                 }
             }

--- a/qucs/components/coplanar.cpp
+++ b/qucs/components/coplanar.cpp
@@ -58,13 +58,13 @@ Coplanar::Coplanar()
   Model = "CLIN";
   Name  = "CL";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 		QObject::tr("name of substrate definition")));
-  Props.append(new Property("W", "1 mm", true,
+  Props.append(new Property("W", "1 mm", false,
 		QObject::tr("width of the line")));
-  Props.append(new Property("S", "1 mm", true,
+  Props.append(new Property("S", "1 mm", false,
 		QObject::tr("width of a gap")));
-  Props.append(new Property("L", "10 mm", true,
+  Props.append(new Property("L", "10 mm", false,
 		QObject::tr("length of the line")));
   Props.append(new Property("Backside", "Air", false,
 		QObject::tr("material at the backside of the substrate")+

--- a/qucs/components/coupler.cpp
+++ b/qucs/components/coupler.cpp
@@ -62,9 +62,9 @@ Coupler::Coupler()
   Model = "Coupler";
   Name  = "X";
 
-  Props.append(new Property("k", "0.7071", true,
+  Props.append(new Property("k", "0.7071", false,
 		QObject::tr("coupling factor")));
-  Props.append(new Property("phi", "180", true,
+  Props.append(new Property("phi", "180", false,
 		QObject::tr("phase shift of coupling path in degree")));
   Props.append(new Property("Z", "50 Ohm", false,
 		QObject::tr("reference impedance")));

--- a/qucs/components/cpwgap.cpp
+++ b/qucs/components/cpwgap.cpp
@@ -62,13 +62,13 @@ CPWgap::CPWgap()
   Model = "CGAP";
   Name  = "CL";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 		QObject::tr("name of substrate definition")));
-  Props.append(new Property("W", "1 mm", true,
+  Props.append(new Property("W", "1 mm", false,
 		QObject::tr("width of the line")));
-  Props.append(new Property("S", "1 mm", true,
+  Props.append(new Property("S", "1 mm", false,
 		QObject::tr("width of a gap")));
-  Props.append(new Property("G", "0.5 mm", true,
+  Props.append(new Property("G", "0.5 mm", false,
 		QObject::tr("width of gap between the two lines")));
 }
 

--- a/qucs/components/cpwopen.cpp
+++ b/qucs/components/cpwopen.cpp
@@ -61,13 +61,13 @@ CPWopen::CPWopen()
   Model = "COPEN";
   Name  = "CL";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 		QObject::tr("name of substrate definition")));
-  Props.append(new Property("W", "1 mm", true,
+  Props.append(new Property("W", "1 mm", false,
 		QObject::tr("width of the line")));
-  Props.append(new Property("S", "1 mm", true,
+  Props.append(new Property("S", "1 mm", false,
 		QObject::tr("width of a gap")));
-  Props.append(new Property("G", "5 mm", true,
+  Props.append(new Property("G", "5 mm", false,
 		QObject::tr("width of gap at end of line")));
   Props.append(new Property("Backside", "Air", false,
 		QObject::tr("material at the backside of the substrate")+

--- a/qucs/components/cpwshort.cpp
+++ b/qucs/components/cpwshort.cpp
@@ -60,11 +60,11 @@ CPWshort::CPWshort()
   Model = "CSHORT";
   Name  = "CL";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 		QObject::tr("name of substrate definition")));
-  Props.append(new Property("W", "1 mm", true,
+  Props.append(new Property("W", "1 mm", false,
 		QObject::tr("width of the line")));
-  Props.append(new Property("S", "1 mm", true,
+  Props.append(new Property("S", "1 mm", false,
 		QObject::tr("width of a gap")));
   Props.append(new Property("Backside", "Air", false,
 		QObject::tr("material at the backside of the substrate")+

--- a/qucs/components/cpwstep.cpp
+++ b/qucs/components/cpwstep.cpp
@@ -64,13 +64,13 @@ CPWstep::CPWstep()
   Model = "CSTEP";
   Name  = "CL";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 		QObject::tr("name of substrate definition")));
-  Props.append(new Property("W1", "1 mm", true,
+  Props.append(new Property("W1", "1 mm", false,
 		QObject::tr("width of line 1")));
-  Props.append(new Property("W2", "2 mm", true,
+  Props.append(new Property("W2", "2 mm", false,
 		QObject::tr("width of line 2")));
-  Props.append(new Property("S", "3 mm", true,
+  Props.append(new Property("S", "3 mm", false,
 		QObject::tr("distance between ground planes")));
   Props.append(new Property("Backside", "Air", false,
 		QObject::tr("material at the backside of the substrate")+

--- a/qucs/components/ctline.cpp
+++ b/qucs/components/ctline.cpp
@@ -53,11 +53,11 @@ CoupledTLine::CoupledTLine()
   Model = "CTLIN";
   Name  = "Line";
 
-  Props.append(new Property("Ze", "50 Ohm", true,
+  Props.append(new Property("Ze", "50 Ohm", false,
 		QObject::tr("characteristic impedance of even mode")));
-  Props.append(new Property("Zo", "50 Ohm", true,
+  Props.append(new Property("Zo", "50 Ohm", false,
 		QObject::tr("characteristic impedance of odd mode")));
-  Props.append(new Property("L", "1 mm", true,
+  Props.append(new Property("L", "1 mm", false,
 		QObject::tr("electrical length of the line")));
   Props.append(new Property("Ere", "1", false,
 		QObject::tr("relative dielectric constant of even mode")));

--- a/qucs/components/diac.cpp
+++ b/qucs/components/diac.cpp
@@ -45,7 +45,7 @@ Diac::Diac()
   Model = "Diac";
   Name  = "D";
 
-  Props.append(new Property("Vbo", "30 V", true,
+  Props.append(new Property("Vbo", "30 V", false,
 	QObject::tr("(bidirectional) breakover voltage")));
   Props.append(new Property("Ibo", "50 uA", false,
 	QObject::tr("(bidirectional) breakover current")));

--- a/qucs/components/digi_sim.cpp
+++ b/qucs/components/digi_sim.cpp
@@ -40,7 +40,7 @@ Digi_Sim::Digi_Sim()
   Name  = "Digi";
 
   // Property list must keeps its order !
-  Props.append(new Property("Type", "TruthTable", true,
+  Props.append(new Property("Type", "TruthTable", false,
 	QObject::tr("type of simulation")+" [TruthTable, TimeList]"));
   Props.append(new Property("time", "10 ns", false,
 	QObject::tr("duration of TimeList simulation")));

--- a/qucs/components/digi_source.cpp
+++ b/qucs/components/digi_source.cpp
@@ -52,7 +52,7 @@ Digi_Source::Digi_Source()
   icon_dx = 6;
 
   // This property must stay in this order !
-  Props.append(new Property("Num", "1", true,
+  Props.append(new Property("Num", "1", false,
 		QObject::tr("number of the port")));
   Props.append(new Property("init", "low", false,
 		QObject::tr("initial output value")+" [low, high]"));

--- a/qucs/components/diode.cpp
+++ b/qucs/components/diode.cpp
@@ -25,11 +25,11 @@ Diode::Diode()
 {
   Description = QObject::tr("diode");
 
-  Props.append(new Property("Is", "1e-15 A", true,
+  Props.append(new Property("Is", "1e-15 A", false,
 	QObject::tr("saturation current")));
-  Props.append(new Property("N", "1", true,
+  Props.append(new Property("N", "1", false,
 	QObject::tr("emission coefficient")));
-  Props.append(new Property("Cj0", "10 fF", true,
+  Props.append(new Property("Cj0", "10 fF", false,
 	QObject::tr("zero-bias junction capacitance")));
   Props.append(new Property("M", "0.5", false,
 	QObject::tr("grading coefficient")));

--- a/qucs/components/ecvs.cpp
+++ b/qucs/components/ecvs.cpp
@@ -63,7 +63,7 @@ ecvs::ecvs()
   Model = "ECVS";
   Name  = "ECVS";
 
-  Props.append(new Property("U", "0 V", true,
+  Props.append(new Property("U", "0 V", false,
 		QObject::tr("voltage in Volts")));
 //  Props.append(new Property("Interpolator", "linear", false,
 //		QObject::tr("interpolation type")+" [hold, linear, cubic]"));

--- a/qucs/components/eqndefined.cpp
+++ b/qucs/components/eqndefined.cpp
@@ -43,7 +43,7 @@ EqnDefined::EqnDefined()
 		QObject::tr("number of branches")));
 
   // last properties
-  Props.append(new Property("I1", "0", true,
+  Props.append(new Property("I1", "0", false,
 		QObject::tr("current equation") + " 1"));
   Props.append(new Property("Q1", "0", false,
 		QObject::tr("charge equation") + " 1"));

--- a/qucs/components/equation.cpp
+++ b/qucs/components/equation.cpp
@@ -48,7 +48,7 @@ Equation::Equation()
   Model = "Eqn";
   Name  = "Eqn";
 
-  Props.append(new Property("y", "1", true));
+  Props.append(new Property("y", "1", false));
   Props.append(new Property("Export", "yes", false,
   		QObject::tr("put result into dataset")+" [yes, no]"));
 }

--- a/qucs/components/gyrator.cpp
+++ b/qucs/components/gyrator.cpp
@@ -55,7 +55,7 @@ Gyrator::Gyrator()
   Name  = "X";
   SpiceModel = "*";
 
-  Props.append(new Property("R", "50 Ohm", true,
+  Props.append(new Property("R", "50 Ohm", false,
 		QObject::tr("gyrator ratio")));
   Props.append(new Property("Zref", "50 Ohm", false,
 		QObject::tr("reference impedance")));

--- a/qucs/components/hb_sim.cpp
+++ b/qucs/components/hb_sim.cpp
@@ -46,7 +46,7 @@ HB_Sim::HB_Sim()
 
   Props.append(new Property("f", "1 GHz", false,
 		QObject::tr("frequency in Hertz")));
-  Props.append(new Property("n", "4", true,
+  Props.append(new Property("n", "4", false,
 		QObject::tr("number of harmonics")));
   Props.append(new Property("iabstol", "1 pA", false,
 		QObject::tr("absolute tolerance for currents")));

--- a/qucs/components/hybrid.cpp
+++ b/qucs/components/hybrid.cpp
@@ -54,7 +54,7 @@ Hybrid::Hybrid()
   Model = "Hybrid";
   Name  = "X";
 
-  Props.append(new Property("phi", "90", true,
+  Props.append(new Property("phi", "90", false,
 		QObject::tr("phase shift in degree")));
   Props.append(new Property("Zref", "50 Ohm", false,
 		QObject::tr("reference impedance")));

--- a/qucs/components/iexp.cpp
+++ b/qucs/components/iexp.cpp
@@ -60,13 +60,13 @@ iExp::iExp()
   SpiceModel = "I";
   Name  = "I";
 
-  Props.append(new Property("I1", "0", true,
+  Props.append(new Property("I1", "0", false,
 		QObject::tr("current before rising edge")));
-  Props.append(new Property("I2", "1 A", true,
+  Props.append(new Property("I2", "1 A", false,
 		QObject::tr("maximum current of the pulse")));
-  Props.append(new Property("T1", "0", true,
+  Props.append(new Property("T1", "0", false,
 		QObject::tr("start time of the exponentially rising edge")));
-  Props.append(new Property("T2", "1 ms", true,
+  Props.append(new Property("T2", "1 ms", false,
 		QObject::tr("start of exponential decay")));
   Props.append(new Property("Tr", "1 ns", false,
 		QObject::tr("time constant of the rising edge")));

--- a/qucs/components/ifile.cpp
+++ b/qucs/components/ifile.cpp
@@ -52,7 +52,7 @@ iFile::iFile()
   Name  = "I";
   SpiceModel = "A";
 
-  Props.append(new Property("File", "ifile.dat", true,
+  Props.append(new Property("File", "ifile.dat", false,
 		QObject::tr("name of the sample file")));
   Props.append(new Property("Interpolator", "linear", false,
         QObject::tr("interpolation type")+" [hold, linear]"));

--- a/qucs/components/indq.cpp
+++ b/qucs/components/indq.cpp
@@ -62,9 +62,9 @@ IndQ::IndQ()
   SpiceModel = "L";
   Name  = "LQ";
 
-  Props.append(new Property("L", "1 nH", true,
+  Props.append(new Property("L", "1 nH", false,
 		QObject::tr("Inductance")));
-  Props.append(new Property("Q", "100", true,
+  Props.append(new Property("Q", "100", false,
 		QObject::tr("Quality factor")));
   Props.append(new Property("f", "100 MHz", false,
 		QObject::tr("Frequency at which Q is measured")));

--- a/qucs/components/inductor.cpp
+++ b/qucs/components/inductor.cpp
@@ -44,7 +44,7 @@ Inductor::Inductor()
   Name  = "L";
   SpiceModel = "L";
 
-  Props.append(new Property("L", "1 mH", true,
+  Props.append(new Property("L", "1 mH", false,
 		QObject::tr("inductance in Henry")));
   Props.append(new Property("I", "", false,
 		QObject::tr("initial current for transient simulation")));

--- a/qucs/components/ipulse.cpp
+++ b/qucs/components/ipulse.cpp
@@ -53,13 +53,13 @@ iPulse::iPulse()
   Name  = "I";
   SpiceModel = "I";
 
-  Props.append(new Property("I1", "0", true,
+  Props.append(new Property("I1", "0", false,
 		QObject::tr("current before and after the pulse")));
-  Props.append(new Property("I2", "1 A", true,
+  Props.append(new Property("I2", "1 A", false,
 		QObject::tr("current of the pulse")));
-  Props.append(new Property("T1", "0", true,
+  Props.append(new Property("T1", "0", false,
 		QObject::tr("start time of the pulse")));
-  Props.append(new Property("T2", "1 ms", true,
+  Props.append(new Property("T2", "1 ms", false,
 		QObject::tr("ending time of the pulse")));
   Props.append(new Property("Tr", "1 ns", false,
 		QObject::tr("rise time of the leading edge")));

--- a/qucs/components/irect.cpp
+++ b/qucs/components/irect.cpp
@@ -57,11 +57,11 @@ iRect::iRect()
   Name  = "I";
   SpiceModel = "I";
 
-  Props.append(new Property("U", "1 mA", true,
+  Props.append(new Property("U", "1 mA", false,
 		QObject::tr("current at high pulse")));
-  Props.append(new Property("TH", "1 ms", true,
+  Props.append(new Property("TH", "1 ms", false,
 		QObject::tr("duration of high pulses")));
-  Props.append(new Property("TL", "1 ms", true,
+  Props.append(new Property("TL", "1 ms", false,
 		QObject::tr("duration of low pulses")));
   Props.append(new Property("Tr", "1 ns", false,
 		QObject::tr("rise time of the leading edge")));

--- a/qucs/components/jfet.cpp
+++ b/qucs/components/jfet.cpp
@@ -24,13 +24,13 @@ JFET::JFET() {
     Description = QObject::tr("junction field-effect transistor");
 
     // this must be the first property in the list !!!
-    Props.append(new Property("Type", "nfet", true,
+    Props.append(new Property("Type", "nfet", false,
                               QObject::tr("polarity") + " [nfet, pfet]"));
-    Props.append(new Property("Vt0", "-2.0 V", true,
+    Props.append(new Property("Vt0", "-2.0 V", false,
                               QObject::tr("threshold voltage")));
-    Props.append(new Property("Beta", "1e-4", true,
+    Props.append(new Property("Beta", "1e-4", false,
                               QObject::tr("transconductance parameter")));
-    Props.append(new Property("Lambda", "0.0", true,
+    Props.append(new Property("Lambda", "0.0", false,
                               QObject::tr("channel-length modulation parameter")));
     Props.append(new Property("Rd", "0.0", false,
                               QObject::tr("parasitic drain resistance")));

--- a/qucs/components/libcomp.cpp
+++ b/qucs/components/libcomp.cpp
@@ -41,9 +41,9 @@ LibComp::LibComp()
   Name  = "X";
   SpiceModel = "X";
 
-  Props.append(new Property("Lib", "", true,
+  Props.append(new Property("Lib", "", false,
 		QObject::tr("name of qucs library file")));
-  Props.append(new Property("Comp", "", true,
+  Props.append(new Property("Comp", "", false,
 		QObject::tr("name of component in library")));
 }
 

--- a/qucs/components/mosfet_sub.cpp
+++ b/qucs/components/mosfet_sub.cpp
@@ -25,16 +25,16 @@ Basic_MOSFET::Basic_MOSFET()
   // these must be the first properties in the list !!!
   Props.append(new Property("Type", "nfet", false,
 	QObject::tr("polarity")+" [nfet, pfet]"));
-  Props.append(new Property("Vt0", "1.0 V", true,
+  Props.append(new Property("Vt0", "1.0 V", false,
 	QObject::tr("zero-bias threshold voltage")));
 
-  Props.append(new Property("Kp", "2e-5", true,
+  Props.append(new Property("Kp", "2e-5", false,
 	QObject::tr("transconductance coefficient in A/V^2")));
   Props.append(new Property("Gamma", "0.0", false,
 	QObject::tr("bulk threshold in sqrt(V)")));
   Props.append(new Property("Phi", "0.6 V", false,
 	QObject::tr("surface potential")));
-  Props.append(new Property("Lambda", "0.0", true,
+  Props.append(new Property("Lambda", "0.0", false,
 	QObject::tr("channel-length modulation parameter in 1/V")));
   Props.append(new Property("Rd", "0.0 Ohm", false,
 	QObject::tr("drain ohmic resistance")));

--- a/qucs/components/mscorner.cpp
+++ b/qucs/components/mscorner.cpp
@@ -46,9 +46,9 @@ MScorner::MScorner()
   Model = "MCORN";
   Name  = "MS";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 		QObject::tr("substrate")));
-  Props.append(new Property("W", "1 mm", true,
+  Props.append(new Property("W", "1 mm", false,
 		QObject::tr("width of line")));
 }
 

--- a/qucs/components/mscoupled.cpp
+++ b/qucs/components/mscoupled.cpp
@@ -55,13 +55,13 @@ MScoupled::MScoupled()
   Model = "MCOUPLED";
   Name  = "MS";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 	QObject::tr("name of substrate definition")));
-  Props.append(new Property("W", "1 mm", true,
+  Props.append(new Property("W", "1 mm", false,
 	QObject::tr("width of the line")));
-  Props.append(new Property("L", "10 mm", true,
+  Props.append(new Property("L", "10 mm", false,
 	QObject::tr("length of the line")));
-  Props.append(new Property("S", "1 mm", true,
+  Props.append(new Property("S", "1 mm", false,
 	QObject::tr("spacing between the lines")));
   Props.append(new Property("Model", "Kirschning", false,
 	QObject::tr("microstrip model")+" [Kirschning, Hammerstad]"));

--- a/qucs/components/mscross.cpp
+++ b/qucs/components/mscross.cpp
@@ -27,15 +27,15 @@ MScross::MScross()
   Model = "MCROSS";
   Name  = "MS";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 		QObject::tr("substrate")));
-  Props.append(new Property("W1", "1 mm", true,
+  Props.append(new Property("W1", "1 mm", false,
 		QObject::tr("width of line 1")));
-  Props.append(new Property("W2", "2 mm", true,
+  Props.append(new Property("W2", "2 mm", false,
 		QObject::tr("width of line 2")));
-  Props.append(new Property("W3", "1 mm", true,
+  Props.append(new Property("W3", "1 mm", false,
 		QObject::tr("width of line 3")));
-  Props.append(new Property("W4", "2 mm", true,
+  Props.append(new Property("W4", "2 mm", false,
 		QObject::tr("width of line 4")));
   Props.append(new Property("MSModel", "Hammerstad", false,
 	QObject::tr("quasi-static microstrip model")+

--- a/qucs/components/msgap.cpp
+++ b/qucs/components/msgap.cpp
@@ -49,13 +49,13 @@ MSgap::MSgap()
   Model = "MGAP";
   Name  = "MS";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 	QObject::tr("name of substrate definition")));
-  Props.append(new Property("W1", "1 mm", true,
+  Props.append(new Property("W1", "1 mm", false,
 	QObject::tr("width of the line 1")));
-  Props.append(new Property("W2", "1 mm", true,
+  Props.append(new Property("W2", "1 mm", false,
 	QObject::tr("width of the line 2")));
-  Props.append(new Property("S", "1 mm", true,
+  Props.append(new Property("S", "1 mm", false,
 	QObject::tr("spacing between the microstrip ends")));
   Props.append(new Property("MSModel", "Hammerstad", false,
 	QObject::tr("quasi-static microstrip model")+

--- a/qucs/components/mslange.cpp
+++ b/qucs/components/mslange.cpp
@@ -47,13 +47,13 @@ MSlange::MSlange()
   Model = "MLANGE";
   Name  = "MS";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 	QObject::tr("name of substrate definition")));
-  Props.append(new Property("W", "1 mm", true,
+  Props.append(new Property("W", "1 mm", false,
 	QObject::tr("width of the line")));
-  Props.append(new Property("L", "10 mm", true,
+  Props.append(new Property("L", "10 mm", false,
 	QObject::tr("length of the line")));
-  Props.append(new Property("S", "1 mm", true,
+  Props.append(new Property("S", "1 mm", false,
 	QObject::tr("spacing between the lines")));
   Props.append(new Property("Model", "Kirschning", false,
 	QObject::tr("microstrip model")+" [Kirschning, Hammerstad]"));

--- a/qucs/components/msline.cpp
+++ b/qucs/components/msline.cpp
@@ -42,11 +42,11 @@ MSline::MSline()
   Model = "MLIN";
   Name  = "MS";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 	QObject::tr("name of substrate definition")));
-  Props.append(new Property("W", "1 mm", true,
+  Props.append(new Property("W", "1 mm", false,
 	QObject::tr("width of the line")));
-  Props.append(new Property("L", "10 mm", true,
+  Props.append(new Property("L", "10 mm", false,
 	QObject::tr("length of the line")));
   Props.append(new Property("Model", "Hammerstad", false,
 	QObject::tr("quasi-static microstrip model")+

--- a/qucs/components/msmbend.cpp
+++ b/qucs/components/msmbend.cpp
@@ -47,9 +47,9 @@ MSmbend::MSmbend()
   Model = "MMBEND";
   Name  = "MS";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 		QObject::tr("substrate")));
-  Props.append(new Property("W", "1 mm", true,
+  Props.append(new Property("W", "1 mm", false,
 		QObject::tr("width of line")));
 }
 

--- a/qucs/components/msopen.cpp
+++ b/qucs/components/msopen.cpp
@@ -41,9 +41,9 @@ MSopen::MSopen()
   Model = "MOPEN";
   Name  = "MS";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 	QObject::tr("name of substrate definition")));
-  Props.append(new Property("W", "1 mm", true,
+  Props.append(new Property("W", "1 mm", false,
 	QObject::tr("width of the line")));
   Props.append(new Property("MSModel", "Hammerstad", false,
 	QObject::tr("quasi-static microstrip model")+

--- a/qucs/components/msrstub.cpp
+++ b/qucs/components/msrstub.cpp
@@ -40,15 +40,15 @@ MSrstub::MSrstub()
   Model = "MRSTUB";
   Name  = "MS";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 	QObject::tr("name of substrate definition")));
   Props.append(new Property("ri", "1 mm", false,
 	QObject::tr("inner radius")));
-  Props.append(new Property("ro", "10 mm", true,
+  Props.append(new Property("ro", "10 mm", false,
 	QObject::tr("outer radius")));
-  Props.append(new Property("Wf", "1 mm", true,
+  Props.append(new Property("Wf", "1 mm", false,
     QObject::tr("feeding line width")));
-  Props.append(new Property("alpha", "90", true,
+  Props.append(new Property("alpha", "90", false,
 	QObject::tr("stub angle")+" ("+QObject::tr ("degrees")+")"));
   Props.append(new Property("EffDimens", "OldQucsNoCorrection", false,
     QObject::tr("Effective dimension")+" [Chew_Kong,Giannini,OldQucsNoCorrection]"));

--- a/qucs/components/msstep.cpp
+++ b/qucs/components/msstep.cpp
@@ -48,11 +48,11 @@ MSstep::MSstep()
   Model = "MSTEP";
   Name  = "MS";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 	QObject::tr("substrate")));
-  Props.append(new Property("W1", "2 mm", true,
+  Props.append(new Property("W1", "2 mm", false,
 	QObject::tr("width 1 of the line")));
-  Props.append(new Property("W2", "1 mm", true,
+  Props.append(new Property("W2", "1 mm", false,
 	QObject::tr("width 2 of the line")));
   Props.append(new Property("MSModel", "Hammerstad", false,
 	QObject::tr("quasi-static microstrip model")+

--- a/qucs/components/mstee.cpp
+++ b/qucs/components/mstee.cpp
@@ -35,13 +35,13 @@ MStee::MStee()
   Model = "MTEE";
   Name  = "MS";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 		QObject::tr("substrate")));
-  Props.append(new Property("W1", "1 mm", true,
+  Props.append(new Property("W1", "1 mm", false,
 		QObject::tr("width of line 1")));
-  Props.append(new Property("W2", "1 mm", true,
+  Props.append(new Property("W2", "1 mm", false,
 		QObject::tr("width of line 2")));
-  Props.append(new Property("W3", "2 mm", true,
+  Props.append(new Property("W3", "2 mm", false,
 		QObject::tr("width of line 3")));
   Props.append(new Property("MSModel", "Hammerstad", false,
 	QObject::tr("quasi-static microstrip model")+

--- a/qucs/components/msvia.cpp
+++ b/qucs/components/msvia.cpp
@@ -43,9 +43,9 @@ MSvia::MSvia()
   Model = "MVIA";
   Name  = "MS";
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 		QObject::tr("substrate")));
-  Props.append(new Property("D", "1 mm", true,
+  Props.append(new Property("D", "1 mm", false,
 		QObject::tr("diameter of round via conductor")));
   Props.append(new Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature in degree Celsius")));

--- a/qucs/components/noise_ii.cpp
+++ b/qucs/components/noise_ii.cpp
@@ -69,11 +69,11 @@ Noise_ii::Noise_ii()
   Model = "IInoise";
   Name  = "SRC";
 
-  Props.append(new Property("i1", "1e-6", true,
+  Props.append(new Property("i1", "1e-6", false,
 		QObject::tr("current power spectral density of source 1")));
-  Props.append(new Property("i2", "1e-6", true,
+  Props.append(new Property("i2", "1e-6", false,
 		QObject::tr("current power spectral density of source 2")));
-  Props.append(new Property("C", "0.5", true,
+  Props.append(new Property("C", "0.5", false,
 		QObject::tr("normalized correlation coefficient")));
   Props.append(new Property("e", "0", false,
 		QObject::tr("frequency exponent")));

--- a/qucs/components/noise_iv.cpp
+++ b/qucs/components/noise_iv.cpp
@@ -64,11 +64,11 @@ Noise_iv::Noise_iv()
   Model = "IVnoise";
   Name  = "SRC";
 
-  Props.append(new Property("i1", "1e-6", true,
+  Props.append(new Property("i1", "1e-6", false,
 		QObject::tr("current power spectral density of source 1")));
-  Props.append(new Property("v2", "1e-6", true,
+  Props.append(new Property("v2", "1e-6", false,
 		QObject::tr("voltage power spectral density of source 2")));
-  Props.append(new Property("C", "0.5", true,
+  Props.append(new Property("C", "0.5", false,
 		QObject::tr("normalized correlation coefficient")));
   Props.append(new Property("e", "0", false,
 		QObject::tr("frequency exponent")));

--- a/qucs/components/noise_vv.cpp
+++ b/qucs/components/noise_vv.cpp
@@ -59,11 +59,11 @@ Noise_vv::Noise_vv()
   Model = "VVnoise";
   Name  = "SRC";
 
-  Props.append(new Property("v1", "1e-6", true,
+  Props.append(new Property("v1", "1e-6", false,
 		QObject::tr("voltage power spectral density of source 1")));
-  Props.append(new Property("v2", "1e-6", true,
+  Props.append(new Property("v2", "1e-6", false,
 		QObject::tr("voltage power spectral density of source 2")));
-  Props.append(new Property("C", "0.5", true,
+  Props.append(new Property("C", "0.5", false,
 		QObject::tr("normalized correlation coefficient")));
   Props.append(new Property("e", "0", false,
 		QObject::tr("frequency exponent")));

--- a/qucs/components/opamp.cpp
+++ b/qucs/components/opamp.cpp
@@ -50,7 +50,7 @@ OpAmp::OpAmp()
   Name  = "OP";
   SpiceModel = "B";
 
-  Props.append(new Property("G", "1e6", true,
+  Props.append(new Property("G", "1e6", false,
 		QObject::tr("voltage gain")));
   Props.append(new Property("Umax", "15 V", false,
 	QObject::tr("absolute value of maximum and minimum output voltage")));

--- a/qucs/components/param_sweep.cpp
+++ b/qucs/components/param_sweep.cpp
@@ -43,17 +43,17 @@ Param_Sweep::Param_Sweep()
   isSimulation = true;
 
   // The index of the first 6 properties must not changed. Used in recreate().
-  Props.append(new Property("Sim", "", true,
+  Props.append(new Property("Sim", "", false,
 		QObject::tr("simulation to perform parameter sweep on")));
-  Props.append(new Property("Type", "lin", true,
+  Props.append(new Property("Type", "lin", false,
 		QObject::tr("sweep type")+" [lin, log, list, const]"));
-  Props.append(new Property("Param", "R1", true,
+  Props.append(new Property("Param", "R1", false,
 		QObject::tr("parameter to sweep")));
-  Props.append(new Property("Start", "5 Ohm", true,
+  Props.append(new Property("Start", "5 Ohm", false,
 		QObject::tr("start value for sweep")));
-  Props.append(new Property("Stop", "50 Ohm", true,
+  Props.append(new Property("Stop", "50 Ohm", false,
 		QObject::tr("stop value for sweep")));
-  Props.append(new Property("Points", "20", true,
+  Props.append(new Property("Points", "20", false,
 		QObject::tr("number of simulation steps")));
   Props.append(new Property("SweepModel","false",false,
                             "[true,false]"));

--- a/qucs/components/phaseshifter.cpp
+++ b/qucs/components/phaseshifter.cpp
@@ -45,7 +45,7 @@ Phaseshifter::Phaseshifter()
   Model = "PShift";
   Name  = "X";
 
-  Props.append(new Property("phi", "90", true,
+  Props.append(new Property("phi", "90", false,
 		QObject::tr("phase shift in degree")));
   Props.append(new Property("Zref", "50 Ohm", false,
 		QObject::tr("reference impedance")));

--- a/qucs/components/pm_modulator.cpp
+++ b/qucs/components/pm_modulator.cpp
@@ -50,7 +50,7 @@ PM_Modulator::PM_Modulator()
   Model = "PM_Mod";
   Name  = "V";
 
-  Props.append(new Property("U", "1 V", true,
+  Props.append(new Property("U", "1 V", false,
 		QObject::tr("peak voltage in Volts")));
   Props.append(new Property("f", "1 GHz", false,
 		QObject::tr("frequency in Hertz")));

--- a/qucs/components/rectline.cpp
+++ b/qucs/components/rectline.cpp
@@ -48,11 +48,11 @@ RectLine::RectLine()
   Model = "RECTLINE";
   Name  = "Line";
 
-  Props.append(new Property("a", "2.95 mm", true,
+  Props.append(new Property("a", "2.95 mm", false,
 		QObject::tr("widest side")));
-  Props.append(new Property("b", "0.9 mm", true,
+  Props.append(new Property("b", "0.9 mm", false,
 		QObject::tr("shortest side")));
-  Props.append(new Property("L", "1500 mm", true,
+  Props.append(new Property("L", "1500 mm", false,
 		QObject::tr("mechanical length of the line")));
   Props.append(new Property("er", "1", false,
 		QObject::tr("relative permittivity of dielectric")));

--- a/qucs/components/resistor.cpp
+++ b/qucs/components/resistor.cpp
@@ -25,7 +25,7 @@ Resistor::Resistor(bool european)
 {
   Description = QObject::tr("resistor");
 
-  Props.append(new Property("R", "1 kOhm", true,
+  Props.append(new Property("R", "1 kOhm", false,
     QObject::tr("ohmic resistance in Ohms")));
   Props.append(new Property("Temp", "26.85", false,
     QObject::tr("simulation temperature in degree Celsius (Qucsator only)")));

--- a/qucs/components/rlcg.cpp
+++ b/qucs/components/rlcg.cpp
@@ -63,13 +63,13 @@ RLCG::RLCG()
 
   Props.append(new Property("R", "0.0", false,
 		QObject::tr("resistive load")+" ("+QObject::tr ("Ohm/m")+")"));
-  Props.append(new Property("L", "0.6e-6", true,
+  Props.append(new Property("L", "0.6e-6", false,
 		QObject::tr("inductive load")+" ("+QObject::tr ("H/m")+")"));
-  Props.append(new Property("C", "240e-12", true,
+  Props.append(new Property("C", "240e-12", false,
 		QObject::tr("capacitive load")+" ("+QObject::tr ("F/m")+")"));
   Props.append(new Property("G", "0.0", false,
 		QObject::tr("conductive load")+" ("+QObject::tr ("S/m")+")"));
-  Props.append(new Property("Length", "1 mm", true,
+  Props.append(new Property("Length", "1 mm", false,
 		QObject::tr("electrical length of the line")));
   Props.append(new Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -59,9 +59,9 @@ Source_ac::Source_ac()
   Name  = "P";
 
   // This property must be the first one !
-  Props.append(new Property("Num", "1", true,
+  Props.append(new Property("Num", "1", false,
 		QObject::tr("number of the port")));
-  Props.append(new Property("Z", "50 Ohm", true,
+  Props.append(new Property("Z", "50 Ohm", false,
 		QObject::tr("port impedance")));
   Props.append(new Property("P", "0 dBm", false,
 		QObject::tr("(available) ac power in Watts")));

--- a/qucs/components/sp_sim.cpp
+++ b/qucs/components/sp_sim.cpp
@@ -47,13 +47,13 @@ SP_Sim::SP_Sim()
   SpiceModel = ".SP";
 
   // The index of the first 4 properties must not changed. Used in recreate().
-  Props.append(new Property("Type", "lin", true,
+  Props.append(new Property("Type", "lin", false,
 	QObject::tr("sweep type")+" [lin, log, list, const]"));
-  Props.append(new Property("Start", "1 MHz", true,
+  Props.append(new Property("Start", "1 MHz", false,
 	QObject::tr("start frequency in Hertz")));
-  Props.append(new Property("Stop", "100 MHz", true,
+  Props.append(new Property("Stop", "100 MHz", false,
 	QObject::tr("stop frequency in Hertz")));
-  Props.append(new Property("Points", "200", true,
+  Props.append(new Property("Points", "200", false,
 	QObject::tr("number of simulation steps")));
   Props.append(new Property("Noise", "no", false,
 	QObject::tr("calculate noise parameters")+

--- a/qucs/components/sparamfile.cpp
+++ b/qucs/components/sparamfile.cpp
@@ -32,7 +32,7 @@ SParamFile::SParamFile()
   SpiceModel = "X";
 
   // must be the first property !!!
-  Props.append(new Property("File", "test.s1p", true,
+  Props.append(new Property("File", "test.s1p", false,
 		QObject::tr("name of the s parameter file")));
   Props.append(new Property("Data", "rectangular", false,
 		QObject::tr("data type")+" [rectangular, polar]"));

--- a/qucs/components/spicefile.cpp
+++ b/qucs/components/spicefile.cpp
@@ -43,7 +43,7 @@ SpiceFile::SpiceFile()
 {
   Description = QObject::tr("SPICE netlist file");
   // Property descriptions not needed, but must not be empty !
-  Props.append(new Property("File", "", true, QString("x")));
+  Props.append(new Property("File", "", false, QString("x")));
   Props.append(new Property("Ports", "", false, QString("x")));
   Props.append(new Property("Sim", "yes", false, QString("x")));
   Props.append(new Property("Preprocessor", "none", false, QString("x")));

--- a/qucs/components/spiralinductor.cpp
+++ b/qucs/components/spiralinductor.cpp
@@ -51,9 +51,9 @@ spiralinductor::spiralinductor()
   Name  = "SPIRALIND";
   Simulator = spicecompat::simQucsator;
 
-  Props.append(new Property("Subst", "Subst1", true,
+  Props.append(new Property("Subst", "Subst1", false,
 		QObject::tr("Substrate")));
-  Props.append(new Property("Geometry", "Circular", true,
+  Props.append(new Property("Geometry", "Circular", false,
 		QObject::tr("Spiral type")+
 +		"[Circular, Square, Hexagonal, Octogonal]"));
   Props.append(new Property("W", "25 um", false,

--- a/qucs/components/subcirport.cpp
+++ b/qucs/components/subcirport.cpp
@@ -25,7 +25,7 @@ SubCirPort::SubCirPort()
   Description = QObject::tr("port of a subcircuit");
 
   // This property must be the first one !
-  Props.append(new Property("Num", "1", true,
+  Props.append(new Property("Num", "1", false,
 		QObject::tr("number of the port within the subcircuit")));
   // This property must be the second one !
   Props.append(new Property("Type", "analog", false,

--- a/qucs/components/substrate.cpp
+++ b/qucs/components/substrate.cpp
@@ -58,17 +58,17 @@ Substrate::Substrate()
   Model = "SUBST";
   Name  = "Subst";
 
-  Props.append(new Property("er", "9.8", true,
+  Props.append(new Property("er", "9.8", false,
 		QObject::tr("relative permittivity")));
-  Props.append(new Property("h", "1 mm", true,
+  Props.append(new Property("h", "1 mm", false,
 		QObject::tr("thickness in meters")));
-  Props.append(new Property("t", "35 um", true,
+  Props.append(new Property("t", "35 um", false,
 		QObject::tr("thickness of metalization")));
-  Props.append(new Property("tand", "2e-4", true,
+  Props.append(new Property("tand", "2e-4", false,
 		QObject::tr("loss tangent")));
-  Props.append(new Property("rho", "0.022e-6", true,
+  Props.append(new Property("rho", "0.022e-6", false,
 		QObject::tr("specific resistance of metal")));
-  Props.append(new Property("D", "0.15e-6", true,
+  Props.append(new Property("D", "0.15e-6", false,
 		QObject::tr("rms substrate roughness")));
 }
 

--- a/qucs/components/symtrafo.cpp
+++ b/qucs/components/symtrafo.cpp
@@ -87,9 +87,9 @@ symTrafo::symTrafo()
   Model = "sTr";
   Name  = "Tr";
 
-  Props.append(new Property("T1", "1", true,
+  Props.append(new Property("T1", "1", false,
 		QObject::tr("voltage transformation ratio of coil 1")));
-  Props.append(new Property("T2", "1", true,
+  Props.append(new Property("T2", "1", false,
 		QObject::tr("voltage transformation ratio of coil 2")));
 }
 

--- a/qucs/components/taperedline.cpp
+++ b/qucs/components/taperedline.cpp
@@ -50,13 +50,13 @@ taperedline::taperedline()
   Model = "TAPEREDLINE";
   Name  = "Line";
 
-  Props.append(new Property("Z1", "50 Ohm", true,
+  Props.append(new Property("Z1", "50 Ohm", false,
 		QObject::tr("Characteristic impedance at port 1")));
-  Props.append(new Property("Z2", "100 Ohm", true,
+  Props.append(new Property("Z2", "100 Ohm", false,
 		QObject::tr("Characteristic impedance at port 2")));
-  Props.append(new Property("L", "75 mm", true,
+  Props.append(new Property("L", "75 mm", false,
 		QObject::tr("Line length")));
-  Props.append(new Property("Weighting", "Exponential", true,
+  Props.append(new Property("Weighting", "Exponential", false,
 		QObject::tr("Taper weighting")+
 		" [Exponential, Linear, Triangular, Klopfenstein]"));
   Props.append(new Property("Gamma_max", "0.1", false,

--- a/qucs/components/thyristor.cpp
+++ b/qucs/components/thyristor.cpp
@@ -47,7 +47,7 @@ Thyristor::Thyristor()
 
   Props.append(new Property("Vbo", "400 V", false,
 	QObject::tr("breakover voltage")));
-  Props.append(new Property("Igt", "50 uA", true,
+  Props.append(new Property("Igt", "50 uA", false,
 	QObject::tr("gate trigger current")));
   Props.append(new Property("Cj0", "10 pF", false,
 	QObject::tr("parasitic capacitance")));

--- a/qucs/components/tline.cpp
+++ b/qucs/components/tline.cpp
@@ -47,9 +47,9 @@ TLine::TLine()
   Model = "TLIN";
   Name  = "Line";
 
-  Props.append(new Property("Z", "50 Ohm", true,
+  Props.append(new Property("Z", "50 Ohm", false,
 		QObject::tr("characteristic impedance")));
-  Props.append(new Property("L", "1 mm", true,
+  Props.append(new Property("L", "1 mm", false,
 		QObject::tr("electrical length of the line")));
   Props.append(new Property("Alpha", "0 dB", false,
 		QObject::tr("attenuation factor per length in 1/m")));

--- a/qucs/components/tline_4port.cpp
+++ b/qucs/components/tline_4port.cpp
@@ -51,9 +51,9 @@ TLine_4Port::TLine_4Port()
   Model = "TLIN4P";
   Name  = "Line";
 
-  Props.append(new Property("Z", "50 Ohm", true,
+  Props.append(new Property("Z", "50 Ohm", false,
 		QObject::tr("characteristic impedance")));
-  Props.append(new Property("L", "1 mm", true,
+  Props.append(new Property("L", "1 mm", false,
 		QObject::tr("electrical length of the line")));
   Props.append(new Property("Alpha", "0 dB", false,
 		QObject::tr("attenuation factor per length in 1/m")));

--- a/qucs/components/tr_sim.cpp
+++ b/qucs/components/tr_sim.cpp
@@ -43,11 +43,11 @@ TR_Sim::TR_Sim()
   SpiceModel = ".TRAN";
 
   // The index of the first 4 properties must not changed. Used in recreate().
-  Props.append(new Property("Type", "lin", true,
+  Props.append(new Property("Type", "lin", false,
 	QObject::tr("sweep type")+" [lin, log, list, const]"));
-  Props.append(new Property("Start", "0", true,
+  Props.append(new Property("Start", "0", false,
 	QObject::tr("start time in seconds")));
-  Props.append(new Property("Stop", "1 ms", true,
+  Props.append(new Property("Stop", "1 ms", false,
 	QObject::tr("stop time in seconds")));
   Props.append(new Property("Points", "200", false,
 	QObject::tr("number of simulation time steps")));

--- a/qucs/components/transformer.cpp
+++ b/qucs/components/transformer.cpp
@@ -59,7 +59,7 @@ Transformer::Transformer()
   Model = "Tr";
   Name  = "Tr";
 
-  Props.append(new Property("T", "1", true,
+  Props.append(new Property("T", "1", false,
 		QObject::tr("voltage transformation ratio")));
 }
 

--- a/qucs/components/triac.cpp
+++ b/qucs/components/triac.cpp
@@ -51,7 +51,7 @@ Triac::Triac()
 
   Props.append(new Property("Vbo", "400 V", false,
 	QObject::tr("(bidirectional) breakover voltage")));
-  Props.append(new Property("Igt", "50 uA", true,
+  Props.append(new Property("Igt", "50 uA", false,
 	QObject::tr("(bidirectional) gate trigger current")));
   Props.append(new Property("Cj0", "10 pF", false,
 	QObject::tr("parasitic capacitance")));

--- a/qucs/components/tunneldiode.cpp
+++ b/qucs/components/tunneldiode.cpp
@@ -20,11 +20,11 @@ TunnelDiode::TunnelDiode()
   Description = QObject::tr("resonance tunnel diode");
   Simulator = spicecompat::simQucsator;
 
-  Props.append(new Property("Ip", "4 mA", true,
+  Props.append(new Property("Ip", "4 mA", false,
 	QObject::tr("peak current")));
-  Props.append(new Property("Iv", "0.6 mA", true,
+  Props.append(new Property("Iv", "0.6 mA", false,
 	QObject::tr("valley current")));
-  Props.append(new Property("Vv", "0.8 V", true,
+  Props.append(new Property("Vv", "0.8 V", false,
 	QObject::tr("valley voltage")));
   Props.append(new Property("Wr", "2.7e-20", false,
 	QObject::tr("resonance energy in Ws")));

--- a/qucs/components/twistedpair.cpp
+++ b/qucs/components/twistedpair.cpp
@@ -55,11 +55,11 @@ TwistedPair::TwistedPair()
   Model = "TWIST";
   Name  = "Line";
 
-  Props.append(new Property("d", "0.5 mm", true,
+  Props.append(new Property("d", "0.5 mm", false,
 		QObject::tr("diameter of conductor")));
-  Props.append(new Property("D", "0.8 mm", true,
+  Props.append(new Property("D", "0.8 mm", false,
 		QObject::tr("diameter of wire (conductor and insulator)")));
-  Props.append(new Property("L", "1.5", true,
+  Props.append(new Property("L", "1.5", false,
 		QObject::tr("physical length of the line")));
   Props.append(new Property("T", "100", false,
 		QObject::tr("twists per length in 1/m")));

--- a/qucs/components/vccs.cpp
+++ b/qucs/components/vccs.cpp
@@ -63,7 +63,7 @@ VCCS::VCCS()
   SpiceModel = "G";
   Name  = "SRC";
 
-  Props.append(new Property("G", "1 S", true,
+  Props.append(new Property("G", "1 S", false,
 		QObject::tr("forward transconductance")));
   Props.append(new Property("T", "0", false, QObject::tr("delay time (Qucsator only)")));
 }

--- a/qucs/components/vcresistor.cpp
+++ b/qucs/components/vcresistor.cpp
@@ -68,7 +68,7 @@ vcresistor::vcresistor()
   Model = "vcresistor";
   Name  = "VCR";
 
-  Props.append(new Property("gain", "1", true,
+  Props.append(new Property("gain", "1", false,
 		QObject::tr("resistance gain")));
 }
 

--- a/qucs/components/vcvs.cpp
+++ b/qucs/components/vcvs.cpp
@@ -65,7 +65,7 @@ VCVS::VCVS()
   Name  = "SRC";
   SpiceModel = "E";
 
-  Props.append(new Property("G", "1", true,
+  Props.append(new Property("G", "1", false,
 		QObject::tr("forward transfer factor")));
   Props.append(new Property("T", "0", false, QObject::tr("delay time (Qucsator only)")));
 }

--- a/qucs/components/vexp.cpp
+++ b/qucs/components/vexp.cpp
@@ -61,13 +61,13 @@ vExp::vExp()
   SpiceModel = "V";
   Name  = "V";
 
-  Props.append(new Property("U1", "0 V", true,
+  Props.append(new Property("U1", "0 V", false,
 		QObject::tr("voltage before rising edge")));
-  Props.append(new Property("U2", "1 V", true,
+  Props.append(new Property("U2", "1 V", false,
 		QObject::tr("maximum voltage of the pulse")));
-  Props.append(new Property("T1", "0", true,
+  Props.append(new Property("T1", "0", false,
 		QObject::tr("start time of the exponentially rising edge")));
-  Props.append(new Property("T2", "1 ms", true,
+  Props.append(new Property("T2", "1 ms", false,
 		QObject::tr("start of exponential decay")));
   Props.append(new Property("Tr", "1 ns", false,
 		QObject::tr("rise time of the rising edge")));

--- a/qucs/components/vfile.cpp
+++ b/qucs/components/vfile.cpp
@@ -54,7 +54,7 @@ vFile::vFile()
   Name  = "V";
   SpiceModel = "A";
 
-  Props.append(new Property("File", "vfile.dat", true,
+  Props.append(new Property("File", "vfile.dat", false,
 		QObject::tr("name of the sample file")));
   Props.append(new Property("Interpolator", "linear", false,
         QObject::tr("interpolation type")+" [hold, linear]"));

--- a/qucs/components/volt_ac.cpp
+++ b/qucs/components/volt_ac.cpp
@@ -46,7 +46,7 @@ Volt_ac::Volt_ac()
   SpiceModel = "V";
   Name  = "V";
 
-  Props.append(new Property("U", "1 V", true,
+  Props.append(new Property("U", "1 V", false,
 		QObject::tr("peak voltage in Volts")));
   Props.append(new Property("f", "1 kHz", false,
 		QObject::tr("frequency in Hertz")));

--- a/qucs/components/volt_dc.cpp
+++ b/qucs/components/volt_dc.cpp
@@ -45,7 +45,7 @@ Volt_dc::Volt_dc()
   Name  = "V";
   SpiceModel = "V";
 
-  Props.append(new Property("U", "1 V", true,
+  Props.append(new Property("U", "1 V", false,
 		QObject::tr("voltage in Volts")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/volt_noise.cpp
+++ b/qucs/components/volt_noise.cpp
@@ -44,7 +44,7 @@ Volt_noise::Volt_noise()
   Model = "Vnoise";
   Name  = "V";
 
-  Props.append(new Property("u", "1e-6", true,
+  Props.append(new Property("u", "1e-6", false,
 		QObject::tr("voltage power spectral density in V^2/Hz")));
   Props.append(new Property("e", "0", false,
 		QObject::tr("frequency exponent")));

--- a/qucs/components/vpulse.cpp
+++ b/qucs/components/vpulse.cpp
@@ -53,13 +53,13 @@ vPulse::vPulse()
   Name  = "V";
   SpiceModel = "V";
 
-  Props.append(new Property("U1", "0 V", true,
+  Props.append(new Property("U1", "0 V", false,
 		QObject::tr("voltage before and after the pulse")));
-  Props.append(new Property("U2", "1 V", true,
+  Props.append(new Property("U2", "1 V", false,
 		QObject::tr("voltage of the pulse")));
-  Props.append(new Property("T1", "0", true,
+  Props.append(new Property("T1", "0", false,
 		QObject::tr("start time of the pulse")));
-  Props.append(new Property("T2", "1 ms", true,
+  Props.append(new Property("T2", "1 ms", false,
 		QObject::tr("ending time of the pulse")));
   Props.append(new Property("Tr", "1 ns", false,
 		QObject::tr("rise time of the leading edge")));

--- a/qucs/components/vrect.cpp
+++ b/qucs/components/vrect.cpp
@@ -52,11 +52,11 @@ vRect::vRect()
   Name  = "V";
   SpiceModel = "V";
 
-  Props.append(new Property("U", "1 V", true,
+  Props.append(new Property("U", "1 V", false,
 		QObject::tr("voltage of high signal")));
-  Props.append(new Property("TH", "1 ms", true,
+  Props.append(new Property("TH", "1 ms", false,
 		QObject::tr("duration of high pulses")));
-  Props.append(new Property("TL", "1 ms", true,
+  Props.append(new Property("TL", "1 ms", false,
 		QObject::tr("duration of low pulses")));
   Props.append(new Property("Tr", "1 ns", false,
 		QObject::tr("rise time of the leading edge")));
@@ -64,7 +64,7 @@ vRect::vRect()
 		QObject::tr("fall time of the trailing edge")));
   Props.append(new Property("Td", "0 ns", false,
 		QObject::tr("initial delay time")));
-  Props.append(new Property("U0", "0 V", true,
+  Props.append(new Property("U0", "0 V", false,
         QObject::tr("voltage of low signal (SPICE only)")));
 
   rotate();  // fix historical flaw


### PR DESCRIPTION
By default, when adding components to the diagram, most of their parameters are output, which greatly clutters the diagram. This can be disabled in the settings of each component, but it is extremely inconvenient. I made it so that all text parameters are not output by default.
![image](https://github.com/ra3xdh/qucs_s/assets/130451001/456b3789-45de-4238-8883-e7176ecb6d0a)
![image](https://github.com/ra3xdh/qucs_s/assets/130451001/fa726123-f68e-430e-afde-572aa956da64)
