### PR TITLE
Fix rendering quirks of some lumped components

### DIFF
--- a/qucs/components/inductor.cpp
+++ b/qucs/components/inductor.cpp
@@ -26,9 +26,9 @@ Inductor::Inductor()
 {
   Description = QObject::tr("inductor");
 
-  Arcs.append(new qucs::Arc(-18, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,4)));
-  Arcs.append(new qucs::Arc( -6, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,4)));
-  Arcs.append(new qucs::Arc(  6, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,4)));
+  Arcs.append(new qucs::Arc(-18, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.append(new qucs::Arc( -6, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.append(new qucs::Arc(  6, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
 

--- a/qucs/components/iprobe.cpp
+++ b/qucs/components/iprobe.cpp
@@ -23,22 +23,28 @@ iProbe::iProbe()
 {
   Description = QObject::tr("current probe");
 
+  // "contacts"
   Lines.append(new qucs::Line(-30,  0,-20,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 20,  0,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-20,  0, 20,  0,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  4,  0, -4, -4,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  4,  0, -4,  4,QPen(Qt::darkBlue,3)));
 
+  // arrow
+  Lines.append(new qucs::Line(-20,  0, 20,  0,QPen(Qt::darkBlue,2)));
+  Lines.append(new qucs::Line( -4, -4,  4,  0,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(  4,  0, -4,  4,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+
+  // outer frame
   Lines.append(new qucs::Line(-20,-31, 20,-31,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-20,  9, 20,  9,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-20,-31,-20,  9,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 20,-31, 20,  9,QPen(Qt::darkBlue,2)));
 
+  // gauge frame
   Lines.append(new qucs::Line(-16,-27, 16,-27,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-16, -9, 16, -9,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-16,-27,-16, -9,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 16,-27, 16, -9,QPen(Qt::darkBlue,2)));
 
+  // gauge
   Arcs.append(new qucs::Arc(-20,-23, 39, 39, 16*50, 16*80,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-11,-24, -2, -9,QPen(Qt::darkBlue,2)));
 

--- a/qucs/components/potentiometer.cpp
+++ b/qucs/components/potentiometer.cpp
@@ -82,8 +82,8 @@ void potentiometer::createSymbol()
   Lines.append(new qucs::Line( 30,-13,-30,-13,QPen(Qt::darkBlue,2)));
 
   // resistor
-  Lines.append(new qucs::Line(-40,  0, -25, 0,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-25,  0, -20,-5,QPen(Qt::darkBlue,2)));
+  Lines.append(new qucs::Line(-40,  0, -25, 0,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-25,  0, -20,-5,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::RoundCap)));
   Lines.append(new qucs::Line(-20, -5, -15, 0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-15,  0, -10,-5,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-10, -5, -5,  0,QPen(Qt::darkBlue,2)));
@@ -92,8 +92,8 @@ void potentiometer::createSymbol()
   Lines.append(new qucs::Line(  5,  0, 10, -5,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 10, -5, 15,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 15,  0, 20, -5,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 20, -5, 25,  0,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 25,  0, 40,  0,QPen(Qt::darkBlue,2)));
+  Lines.append(new qucs::Line( 20, -5, 25,  0,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::RoundCap)));
+  Lines.append(new qucs::Line( 25,  0, 40,  0,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
 
   // arrow
   Lines.append(new qucs::Line( -4, -9,  0, -5,QPen(Qt::darkBlue,2)));

--- a/qucs/components/relais.cpp
+++ b/qucs/components/relais.cpp
@@ -25,17 +25,21 @@ Relais::Relais()
 {
   Description = QObject::tr("relay");
 
+  // driver contacts
   Lines.append(new qucs::Line(-30,-30,-30, -8,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-30,  8,-30, 30,QPen(Qt::darkBlue,2)));
+  // driver rect
   Lines.append(new qucs::Line(-45, -8,-15, -8,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-45,  8,-15,  8,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-45, -8,-45,  8,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-15, -8,-15,  8,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-45,  8,-15, -8,QPen(Qt::darkBlue,2)));
-
+  // diagonal
+  Lines.append(new qucs::Line(-45,  8,-15, -8,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  // plus
   Lines.append(new qucs::Line(-43, -3,-37, -3,QPen(Qt::red,1)));
   Lines.append(new qucs::Line(-40, -6,-40,  0,QPen(Qt::red,1)));
-  Lines.append(new qucs::Line(-23,  3,-17,  3,QPen(Qt::black,1)));  
+  // minus
+  Lines.append(new qucs::Line(-23,  3,-17,  3,QPen(Qt::black,1)));
 
   Lines.append(new qucs::Line(-15,  0, 35,  0,QPen(Qt::darkBlue,1,Qt::DotLine)));
 

--- a/qucs/components/resistor.cpp
+++ b/qucs/components/resistor.cpp
@@ -112,13 +112,13 @@ void Resistor::createSymbol()
   }
   else {
     Lines.append(new qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-    Lines.append(new qucs::Line(-18,  0,-15, -7,QPen(Qt::darkBlue,2)));
-    Lines.append(new qucs::Line(-15, -7, -9,  7,QPen(Qt::darkBlue,2)));
-    Lines.append(new qucs::Line( -9,  7, -3, -7,QPen(Qt::darkBlue,2)));
-    Lines.append(new qucs::Line( -3, -7,  3,  7,QPen(Qt::darkBlue,2)));
-    Lines.append(new qucs::Line(  3,  7,  9, -7,QPen(Qt::darkBlue,2)));
-    Lines.append(new qucs::Line(  9, -7, 15,  7,QPen(Qt::darkBlue,2)));
-    Lines.append(new qucs::Line( 15,  7, 18,  0,QPen(Qt::darkBlue,2)));
+    Lines.append(new qucs::Line(-18,  0,-15, -7,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::RoundCap)));
+    Lines.append(new qucs::Line(-15, -7, -9,  7,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::RoundCap)));
+    Lines.append(new qucs::Line( -9,  7, -3, -7,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::RoundCap)));
+    Lines.append(new qucs::Line( -3, -7,  3,  7,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::RoundCap)));
+    Lines.append(new qucs::Line(  3,  7,  9, -7,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::RoundCap)));
+    Lines.append(new qucs::Line(  9, -7, 15,  7,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::RoundCap)));
+    Lines.append(new qucs::Line( 15,  7, 18,  0,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::RoundCap)));
     Lines.append(new qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
   }
 

--- a/qucs/spicecomponents/K_SPICE.cpp
+++ b/qucs/spicecomponents/K_SPICE.cpp
@@ -29,13 +29,13 @@ K_SPICE::K_SPICE()
     Description = QObject::tr("SPICE K:\nEnter the names of the coupled inductances and their coupling factor.");
     Simulator = spicecompat::simSpice;
 
-    Lines.append(new qucs::Line(-10,  0, 10,  0,QPen(Qt::darkRed,3)));
-    Lines.append(new qucs::Line(-10,  0, -6,   4,QPen(Qt::darkRed,3)));
-    Lines.append(new qucs::Line(-10,  0, -6,  -4,QPen(Qt::darkRed,3)));
-    Lines.append(new qucs::Line( 10,  0,   6,  4,QPen(Qt::darkRed,3)));
-    Lines.append(new qucs::Line( 10,  0,   6,  -4,QPen(Qt::darkRed,3)));
-   
- 
+    Lines.append(new qucs::Line(-10,  0, 10,  0,QPen(Qt::darkRed,3, Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin)));
+    Lines.append(new qucs::Line(-10,  0, -6,   4,QPen(Qt::darkRed,3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
+    Lines.append(new qucs::Line(-10,  0, -6,  -4,QPen(Qt::darkRed,3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
+    Lines.append(new qucs::Line( 10,  0,   6,  4,QPen(Qt::darkRed,3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
+    Lines.append(new qucs::Line( 10,  0,   6,  -4,QPen(Qt::darkRed,3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
+
+
     x1 = -15; y1 = -13;
     x2 =  15; y2 =  13;
 

--- a/qucs/spicecomponents/S4Q_S.cpp
+++ b/qucs/spicecomponents/S4Q_S.cpp
@@ -37,7 +37,7 @@ S4Q_S::S4Q_S()
     Lines.append(new qucs::Line(-15,  0,   -5,  0,QPen(Qt::darkRed,3)));
     Lines.append(new qucs::Line( 30,  0,   15,  0,QPen(Qt::darkBlue,2)));
     Lines.append(new qucs::Line( 15,  0,    5,  0,QPen(Qt::darkRed,3)));
-    Lines.append(new qucs::Line(  5,  0,    0,  8,QPen(Qt::darkRed,3)));
+    Lines.append(new qucs::Line(  5,  0,    0,  8,QPen(Qt::darkRed,3, Qt::SolidLine, Qt::FlatCap)));
     Lines.append(new qucs::Line(-10, -30, -10,  -15,QPen(Qt::darkBlue,2)));
     Lines.append(new qucs::Line( 10, -30,  10,  -15,QPen(Qt::darkBlue,2)));
     

--- a/qucs/spicecomponents/S4Q_W.cpp
+++ b/qucs/spicecomponents/S4Q_W.cpp
@@ -35,9 +35,9 @@ S4Q_W::S4Q_W()
     Lines.append(new qucs::Line( 15, -15, -15, -15,QPen(Qt::darkRed,3)));
     Lines.append(new qucs::Line(-30,  0,  -15,  0,QPen(Qt::darkBlue,2)));
     Lines.append(new qucs::Line(-15,  0,   -5,  0,QPen(Qt::darkRed,3)));
-    Lines.append(new qucs::Line( 30,  0,   15,  0,QPen(Qt::darkBlue,3)));
+    Lines.append(new qucs::Line( 30,  0,   15,  0,QPen(Qt::darkBlue,2)));
     Lines.append(new qucs::Line( 15,  0,    5,  0,QPen(Qt::darkRed,3)));
-    Lines.append(new qucs::Line(  5,  0,    0,  8,QPen(Qt::darkRed,3)));
+    Lines.append(new qucs::Line(  5,  0,    0,  8,QPen(Qt::darkRed,3, Qt::SolidLine, Qt::FlatCap)));
 
     Ports.append(new Port(-30,  0)); // Ps+
     Ports.append(new Port( 30,  0)); // Ps-


### PR DESCRIPTION
Hi! This is a set of small changes to some of lumped components to deal with rendering artifacts which became visible after switching to new schematic rendering.

<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/607e7eab-d510-490d-b688-5a3f77e0e837" width="300" />
<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/f3e16e27-9187-4c43-87e4-8088ea07a7e6" width="300" />

<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/e60e0829-4fa1-44e0-8e18-1d5b5d987857" width="300" />
<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/cc3764b5-0636-4e17-ad0f-d289d56ddc74" width="300" />

<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/0176921e-c198-44a0-ade2-feab8b8a5728" width="300" />
<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/c6c16ad6-eb1a-4295-afb3-28303d5a5998" width="300" />

<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/903c7330-c304-432e-af56-4d495e881986" width="300" />
<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/7913555f-5958-4d4c-839b-75b0915b32ed" width="300" />

<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/c4366d32-9b16-4f95-bd51-1118466910a6" width="300" />
<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/a6d1daa5-f8b6-44cd-abb0-1444eaf5eef8" width="300" />

<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/a35d5b63-7dcd-4206-a797-85e0cb4e1f73" width="300" />
<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/1900bf7c-7c54-4b68-84e5-5f0b93e00918" width="300" />

<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/e39c6472-3df0-4151-8546-4b94482cb396" width="300" />
<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/9c0fe889-e77b-49d9-8556-e21d3b446824" width="300" />

<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/3771e23a-cfee-4170-9b05-8357ee1e1a74" width="300" />
<img src="https://github.com/ra3xdh/qucs_s/assets/40355531/b90b0263-ad8a-40a7-934c-472c883e5c51" width="300" />


