### PR TITLE
Fixed Xyce simulation #701

### DIFF
--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -49,6 +49,7 @@ AbstractSpiceKernel::AbstractSpiceKernel(Schematic *sch_, QObject *parent) :
 {
     Sch = sch_;
     console = nullptr;
+    needsPrefix = false;
 
     if (Sch->showBias == 0) DC_OP_only = true;
     else DC_OP_only = false;


### PR DESCRIPTION
This PR adds fix for Xyce simulation #701. There was a missing default initializer of the `AbstractSpiceKernel::needsPrefix`.