### PR TITLE
Fix source components rendering quirks

### DIFF
--- a/qucs/components/am_modulator.cpp
+++ b/qucs/components/am_modulator.cpp
@@ -24,15 +24,19 @@ AM_Modulator::AM_Modulator()
   Description = QObject::tr("ac voltage source with amplitude modulator");
   Simulator = spicecompat::simQucsator;
 
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.append(new qucs::Arc( -7, -4,  7,  7,     0, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.append(new qucs::Arc(  0, -4,  7,  7,16*180, 16*180,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24,    QPen(Qt::darkBlue,2)));
+  // wave
+  Arcs.append(new qucs::Arc( -7, -4,  7,  7,     0, 16*180,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Arcs.append(new qucs::Arc(  0, -4,  7,  7,16*180, 16*180,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  // pins
   Lines.append(new qucs::Line(  0, 30,  0, 12,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(  0,-30,  0,-12,QPen(Qt::darkBlue,2)));
+  // plus sign
   Lines.append(new qucs::Line(  5,-18, 11,-18,QPen(Qt::red,1)));
   Lines.append(new qucs::Line(  8,-21,  8,-15,QPen(Qt::red,1)));
+  // minus sign
   Lines.append(new qucs::Line(  5, 18, 11, 18,QPen(Qt::black,1)));
-
+  // arrow
   Lines.append(new qucs::Line(-12,  0,-30,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-12,  0,-17,  5,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-12,  0,-17, -5,QPen(Qt::darkBlue,2)));

--- a/qucs/components/ampere_ac.cpp
+++ b/qucs/components/ampere_ac.cpp
@@ -27,11 +27,13 @@ Ampere_ac::Ampere_ac()
   Arcs.append(new qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
-  Arcs.append(new qucs::Arc( 12,  5,  6,  6,16*270, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.append(new qucs::Arc( 12, 11,  6,  6, 16*90, 16*180,QPen(Qt::darkBlue,2)));
+  // arrow stem
+  Lines.append(new qucs::Line( -8.5,  0,  6,  0,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  // arrow head
+  Polylines.append(new qucs::Polyline(std::vector<QPointF>{{0, -4}, {6, 0}, {0, 4}}, QPen(Qt::darkBlue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
+  // AC-wave
+  Arcs.append(new qucs::Arc( 12,  5,  6,  6,16*270, 16*180, QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Arcs.append(new qucs::Arc( 12, 11,  6,  6, 16*90, 16*180, QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
 
   Ports.append(new Port( 30,  0));
   Ports.append(new Port(-30,  0));

--- a/qucs/components/ampere_dc.cpp
+++ b/qucs/components/ampere_dc.cpp
@@ -27,9 +27,12 @@ Ampere_dc::Ampere_dc()
   Arcs.append(new qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
+
+  // arrow stem
+  Lines.append(new qucs::Line( -8.5,  0,  6,  0,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  // arrow head
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{0, -4},{6, 0}, {0, 4}}, QPen(Qt::darkBlue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
 
   Ports.append(new Port( 30,  0));
   Ports.append(new Port(-30,  0));

--- a/qucs/components/ampere_noise.cpp
+++ b/qucs/components/ampere_noise.cpp
@@ -25,19 +25,21 @@ Ampere_noise::Ampere_noise()
   Description = QObject::tr("noise current source");
   Simulator = spicecompat::simQucsator;
 
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24, QPen(Qt::darkBlue,2)));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
-
-  Lines.append(new qucs::Line(-12,  1,  1,-12,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-10,  6, -7,  3,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(  3, -7,  6,-10,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -7, 10, -2,  5,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(  7, -4, 10, -7,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -1, 12, 12, -1,QPen(Qt::darkBlue,2)));
+  // arrow
+  Lines.append(new qucs::Line( -8.5,  0,  6,  0,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{0, -4},{6, 0}, {0, 4}}, QPen(Qt::darkBlue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
+  // diagonal strokes
+  Lines.append(new qucs::Line(-12,  1,  1,-12,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-10,  6, -7,  3,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(  3, -7,  6,-10,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( -7, 10, -2,  5,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(  7, -4, 10, -7,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( -1, 12, 12, -1,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
 
   Ports.append(new Port( 30,  0));
   Ports.append(new Port(-30,  0));

--- a/qucs/components/cccs.cpp
+++ b/qucs/components/cccs.cpp
@@ -24,10 +24,11 @@ CCCS::CCCS()
 {
   Description = QObject::tr("current controlled current source");
 
-  Arcs.append(new qucs::Arc(0,-11, 22, 22,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 11, -7, 11,  7,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line( 11,  6, 15,  1,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line( 11,  6,  7,  1,QPen(Qt::darkBlue,3)));
+  Ellipses.append(new qucs::Ellips(0,-11, 22, 22, QPen(Qt::darkBlue,2)));
+  // thick arrow in circle
+  Lines.append(new qucs::Line( 11, -7, 11,  6,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{15, 1},{11, 6}, {7, 1}}, QPen(Qt::darkBlue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
 
   Lines.append(new qucs::Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
@@ -37,14 +38,11 @@ CCCS::CCCS()
   Lines.append(new qucs::Line(-12,-30,-12, 30,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 11,-30, 11,-11,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 11, 30, 11, 11,QPen(Qt::darkBlue,2)));
+  // smaller arrow "wings"
+  Lines.append(new qucs::Line(-12, 20,-17, 11,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-12, 20, -7, 11,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
 
-  Lines.append(new qucs::Line(-12, 20,-17, 11,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-12, 20, -8, 11,QPen(Qt::darkBlue,2)));
-
-  Lines.append(new qucs::Line(-25,-27, 25,-27,QPen(Qt::darkGray,1)));
-  Lines.append(new qucs::Line( 25,-27, 25, 27,QPen(Qt::darkGray,1)));
-  Lines.append(new qucs::Line( 25, 27,-25, 27,QPen(Qt::darkGray,1)));
-  Lines.append(new qucs::Line(-25, 27,-25,-27,QPen(Qt::darkGray,1)));
+  Rects.append(new qucs::Rect(-25, -27, 50, 54, QPen(Qt::darkGray,1)));
 
   Ports.append(new Port(-30,-30));
   Ports.append(new Port( 30,-30));

--- a/qucs/components/ccvs.cpp
+++ b/qucs/components/ccvs.cpp
@@ -23,7 +23,7 @@ CCVS::CCVS()
 {
   Description = QObject::tr("current controlled voltage source");
 
-  Arcs.append(new qucs::Arc(0,-11, 22, 22,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(0,-11, 22, 22, QPen(Qt::darkBlue,2)));
 
   Lines.append(new qucs::Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
@@ -33,18 +33,16 @@ CCVS::CCVS()
   Lines.append(new qucs::Line(-12,-30,-12, 30,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 11,-30, 11,-11,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 11, 30, 11, 11,QPen(Qt::darkBlue,2)));
-
-  Lines.append(new qucs::Line(-12, 20,-17, 11,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-12, 20, -8, 11,QPen(Qt::darkBlue,2)));
-
+  // arrow "wings"
+  Lines.append(new qucs::Line(-12, 20,-17, 11,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-12, 20, -7, 11,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  // plus sign
   Lines.append(new qucs::Line( 19,-21, 19,-15,QPen(Qt::red,1)));
   Lines.append(new qucs::Line( 16,-18, 22,-18,QPen(Qt::red,1)));
+  // minus sign
   Lines.append(new qucs::Line( 16, 18, 22, 18,QPen(Qt::black,1)));
 
-  Lines.append(new qucs::Line(-25,-27, 25,-27,QPen(Qt::darkGray,1)));
-  Lines.append(new qucs::Line( 25,-27, 25, 27,QPen(Qt::darkGray,1)));
-  Lines.append(new qucs::Line( 25, 27,-25, 27,QPen(Qt::darkGray,1)));
-  Lines.append(new qucs::Line(-25, 27,-25,-27,QPen(Qt::darkGray,1)));
+  Rects.append(new qucs::Rect(-25, -27, 50, 54, QPen(Qt::darkGray,1)));
 
   Ports.append(new Port(-30,-30));
   Ports.append(new Port( 30,-30));

--- a/qucs/components/component.h
+++ b/qucs/components/component.h
@@ -83,6 +83,7 @@ public:
   virtual Schematic* getSchematic () {return containingSchematic; }
 
   QList<qucs::Line *>     Lines;
+  QList<qucs::Polyline *> Polylines;
   QList<struct qucs::Arc *>      Arcs;
   QList<qucs::Rect *>     Rects;
   QList<qucs::Ellips *>     Ellipses;

--- a/qucs/components/iexp.cpp
+++ b/qucs/components/iexp.cpp
@@ -28,24 +28,16 @@ iExp::iExp()
   Description = QObject::tr("exponential current source");
 
   // normal current source symbol
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24,QPen(Qt::darkBlue,2)));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
+  // arrow
+  Lines.append(new qucs::Line( -7,  0,  6,  0,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{0, -4},{6, 0}, {0, 4}}, QPen(Qt::darkBlue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
 
-  // write 'Exp' beside current source symbol
-  Lines.append(new qucs::Line( 13,  7, 13, 10,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 13,  7, 21, 7,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 17,  7, 17, 10,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 21,  7, 21, 10,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 13,  13, 17, 17,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 17,  13, 13, 17,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 17,  20, 11, 20,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 17,  20, 17, 23,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 13,  20, 13, 23,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 17,  23, 13, 23,QPen(Qt::darkBlue,2)));
+  Texts.append(new Text(25, -30, "Exp", Qt::darkBlue, 12, 0.0, -1.0));
 
   Ports.append(new Port( 30,  0));
   Ports.append(new Port(-30,  0));

--- a/qucs/components/ifile.cpp
+++ b/qucs/components/ifile.cpp
@@ -25,20 +25,20 @@ iFile::iFile()
 {
   Description = QObject::tr("file based current source");
 
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24, QPen(Qt::darkBlue,2)));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
+  // arrow
+  Lines.append(new qucs::Line( -7,  0,  6,  0,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{0, -4},{6, 0}, {0, 4}}, QPen(Qt::darkBlue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
 
+  // small "list" pictogram
   Lines.append(new qucs::Line( -6,-17, -6,-21,QPen(Qt::darkBlue,1)));
   Lines.append(new qucs::Line( -8,-17, -8,-21,QPen(Qt::darkBlue,1)));
   Lines.append(new qucs::Line(-10,-17,-10,-21,QPen(Qt::darkBlue,1)));
-  Lines.append(new qucs::Line( -3,-15, -3,-23,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-13,-15,-13,-23,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -3,-23,-13,-23,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -3,-15,-13,-15,QPen(Qt::darkBlue,2)));
+  Rects.append(new qucs::Rect(-13, -23, 10, 8,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin)));
 
   Ports.append(new Port( 30,  0));
   Ports.append(new Port(-30,  0));

--- a/qucs/components/ipulse.cpp
+++ b/qucs/components/ipulse.cpp
@@ -27,12 +27,14 @@ iPulse::iPulse()
 {
   Description = QObject::tr("ideal current pulse source");
 
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24,QPen(Qt::darkBlue,2)));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
+  // arrow
+  Lines.append(new qucs::Line( -8,  0,  6,  0,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{0, -4},{6, 0}, {0, 4}}, QPen(Qt::darkBlue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
 
   // little pulse symbol
   Lines.append(new qucs::Line( 13,  7, 13, 10,QPen(Qt::darkBlue,2)));

--- a/qucs/components/irect.cpp
+++ b/qucs/components/irect.cpp
@@ -29,12 +29,15 @@ iRect::iRect()
 {
   Description = QObject::tr("ideal rectangle current source");
 
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24,QPen(Qt::darkBlue,2)));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
+  // arrow
+  Lines.append(new qucs::Line( -8,  0,  6,  0,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{0, -4},{6, 0}, {0, 4}}, QPen(Qt::darkBlue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
+
 
   // little rectangle symbol
   Lines.append(new qucs::Line( 19,  5, 19,  7,QPen(Qt::darkBlue,2)));

--- a/qucs/components/noise_ii.cpp
+++ b/qucs/components/noise_ii.cpp
@@ -25,36 +25,40 @@ Noise_ii::Noise_ii()
   Simulator = spicecompat::simQucsator;
 
   // left noise source
-  Arcs.append(new qucs::Arc(-42,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(-42,-12, 24, 24,QPen(Qt::darkBlue,2)));
+  // pins
   Lines.append(new qucs::Line(-30, 30,-30, 12,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-30,-30,-30,-12,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-30,  7,-30, -7,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(-30, -6,-34,  0,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(-30, -6,-26,  0,QPen(Qt::darkBlue,3)));
-
-  Lines.append(new qucs::Line(-29, 12,-42, -1,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-24, 10,-27,  7,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-37, -3,-40, -6,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-20,  7,-25,  2,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-34, -7,-37,-10,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-18,  1,-31,-12,QPen(Qt::darkBlue,2)));
+  // arrow
+  Lines.append(new qucs::Line(-30,  7,-30, -6,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{-34, 0},{-30, -6}, {-26, 0}}, QPen(Qt::darkBlue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
+  // diagonal strokes
+  Lines.append(new qucs::Line(-29, 12,-42, -1,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-24, 10,-27,  7,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-37, -3,-40, -6,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-20,  7,-25,  2,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-34, -7,-37,-10,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-18,  1,-31,-12,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
 
   // right noise source
   Arcs.append(new qucs::Arc( 18,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  //pins
   Lines.append(new qucs::Line( 30, 30, 30, 12,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,-30, 30,-12,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 30,  7, 30, -7,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line( 30, -6, 26,  0,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line( 30, -6, 34,  0,QPen(Qt::darkBlue,3)));
-
-  Lines.append(new qucs::Line( 31, 12, 18, -1,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 36, 10, 33,  7,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 23, -3, 20, -6,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 40,  7, 35,  2,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 26, -7, 23,-10,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 42,  1, 29,-12,QPen(Qt::darkBlue,2)));
-
-  Lines.append(new qucs::Line(-18,  0, 18,  0,QPen(Qt::darkBlue,3)));
+  // arrow
+  Lines.append(new qucs::Line( 30,  7, 30, -6,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{34, 0},{30, -6}, {26, 0}}, QPen(Qt::darkBlue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
+  // diagonal strokes
+  Lines.append(new qucs::Line( 31, 12, 18, -1,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( 36, 10, 33,  7,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( 23, -3, 20, -6,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( 40,  7, 35,  2,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( 26, -7, 23,-10,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( 42,  1, 29,-12,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  // Horizontal connecting bar
+  Lines.append(new qucs::Line(-18,  0, 18,  0,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
 
   Ports.append(new Port(-30,-30));
   Ports.append(new Port( 30,-30));

--- a/qucs/components/noise_iv.cpp
+++ b/qucs/components/noise_iv.cpp
@@ -25,31 +25,34 @@ Noise_iv::Noise_iv()
   Simulator = spicecompat::simQucsator;
 
   // left noise source
-  Arcs.append(new qucs::Arc(-42,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(-42,-12, 24, 24, QPen(Qt::darkBlue,2)));
+  // pins
   Lines.append(new qucs::Line(-30, 30,-30, 12,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-30,-30,-30,-12,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-30,  7,-30, -7,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(-30, -6,-34,  0,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(-30, -6,-26,  0,QPen(Qt::darkBlue,3)));
-
-  Lines.append(new qucs::Line(-29, 12,-42, -1,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-24, 10,-27,  7,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-37, -3,-40, -6,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-20,  7,-25,  2,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-34, -7,-37,-10,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-18,  1,-31,-12,QPen(Qt::darkBlue,2)));
+  // arrow
+  Lines.append(new qucs::Line( -30,  7,  -30,  -6,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{-34, 0},{-30, -6}, {-26, 0}}, QPen(Qt::darkBlue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
+  // diagonal strokes
+  Lines.append(new qucs::Line(-29, 12,-42, -1,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-24, 10,-27,  7,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-37, -3,-40, -6,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-20,  7,-25,  2,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-34, -7,-37,-10,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-18,  1,-31,-12,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
 
   // right noise source
-  Arcs.append(new qucs::Arc( 18,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips( 18,-12, 24, 24, QPen(Qt::darkBlue,2)));
+  // pins
   Lines.append(new qucs::Line( 30, 30, 30, 12,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,-30, 30,-12,QPen(Qt::darkBlue,2)));
-
-  Lines.append(new qucs::Line( 31, 12, 18, -1,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 36, 10, 20, -6,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 40,  7, 23,-10,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 42,  2, 28,-12,QPen(Qt::darkBlue,2)));
-
-  Lines.append(new qucs::Line(-18,  0, 18,  0,QPen(Qt::darkBlue,3)));
+  // diagonal strokes
+  Lines.append(new qucs::Line( 31, 12, 18, -1,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( 36, 10, 20, -6,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( 40,  7, 23,-10,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( 42,  2, 28,-12,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  // horizontal connecting bar
+  Lines.append(new qucs::Line(-18,  0, 18,  0,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
 
   Ports.append(new Port(-30,-30));
   Ports.append(new Port( 30,-30));

--- a/qucs/components/noise_vv.cpp
+++ b/qucs/components/noise_vv.cpp
@@ -26,25 +26,27 @@ Noise_vv::Noise_vv()
 
   // left noise source
   Arcs.append(new qucs::Arc(-42,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  // pins
   Lines.append(new qucs::Line(-30, 30,-30, 12,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-30,-30,-30,-12,QPen(Qt::darkBlue,2)));
-
-  Lines.append(new qucs::Line(-29, 12,-42, -1,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-24, 10,-40, -6,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-20,  7,-37,-10,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-18,  2,-32,-12,QPen(Qt::darkBlue,2)));
+  // diagonal strokes
+  Lines.append(new qucs::Line(-29, 12,-42, -1,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-24, 10,-40, -6,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-20,  7,-37,-10,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-18,  2,-32,-12,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
 
   // right noise source
   Arcs.append(new qucs::Arc( 18,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  // pins
   Lines.append(new qucs::Line( 30, 30, 30, 12,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,-30, 30,-12,QPen(Qt::darkBlue,2)));
-
-  Lines.append(new qucs::Line( 31, 12, 18, -1,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 36, 10, 20, -6,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 40,  7, 23,-10,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 42,  2, 28,-12,QPen(Qt::darkBlue,2)));
-
-  Lines.append(new qucs::Line(-18,  0, 18,  0,QPen(Qt::darkBlue,3)));
+  // diagonal strokes
+  Lines.append(new qucs::Line( 31, 12, 18, -1,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( 36, 10, 20, -6,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( 40,  7, 23,-10,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( 42,  2, 28,-12,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  // horizontal connectins bars
+  Lines.append(new qucs::Line(-18,  0, 18,  0,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
 
   Ports.append(new Port(-30,-30));
   Ports.append(new Port( 30,-30));

--- a/qucs/components/pm_modulator.cpp
+++ b/qucs/components/pm_modulator.cpp
@@ -24,15 +24,19 @@ PM_Modulator::PM_Modulator()
   Description = QObject::tr("ac voltage source with phase modulator");
   Simulator = spicecompat::simQucsator;
 
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.append(new qucs::Arc( -7, -4,  7,  7,     0, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.append(new qucs::Arc(  0, -4,  7,  7,16*180, 16*180,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24, QPen(Qt::darkBlue,2)));
+  // wave
+  Arcs.append(new qucs::Arc( -7, -4,  7,  7,     0, 16*180,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Arcs.append(new qucs::Arc(  0, -4,  7,  7,16*180, 16*180,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  // pins
   Lines.append(new qucs::Line(  0, 30,  0, 12,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(  0,-30,  0,-12,QPen(Qt::darkBlue,2)));
+  // plus sign
   Lines.append(new qucs::Line(  5,-18, 11,-18,QPen(Qt::red,1)));
   Lines.append(new qucs::Line(  8,-21,  8,-15,QPen(Qt::red,1)));
+  // minus sign
   Lines.append(new qucs::Line(  5, 18, 11, 18,QPen(Qt::black,1)));
-
+  // arrow
   Lines.append(new qucs::Line(-12,  0,-30,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-12,  0,-17,  5,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-12,  0,-17, -5,QPen(Qt::darkBlue,2)));

--- a/qucs/components/vccs.cpp
+++ b/qucs/components/vccs.cpp
@@ -23,10 +23,11 @@ VCCS::VCCS()
 {
   Description = QObject::tr("voltage controlled current source");
 
-  Arcs.append(new qucs::Arc(0,-11, 22, 22,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 11, -7, 11,  7,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line( 11,  6, 15,  1,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line( 11,  6,  7,  1,QPen(Qt::darkBlue,3)));
+  Ellipses.append(new qucs::Ellips(0,-11, 22, 22,QPen(Qt::darkBlue,2)));
+  // thick arrow in circle
+  Lines.append(new qucs::Line( 11, -7, 11,  6,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{15, 1},{11, 6}, {7, 1}}, QPen(Qt::darkBlue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
 
   Lines.append(new qucs::Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
@@ -38,14 +39,12 @@ VCCS::VCCS()
   Lines.append(new qucs::Line( 11,-30, 11,-11,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 11, 30, 11, 11,QPen(Qt::darkBlue,2)));
 
-  Lines.append(new qucs::Line(-12,-18,-12, 18,QPen(Qt::darkBlue,1)));
-  Lines.append(new qucs::Line(-12, 18,-17,  9,QPen(Qt::darkBlue,1)));
-  Lines.append(new qucs::Line(-12, 18, -7,  9,QPen(Qt::darkBlue,1)));
+  // thin arrow
+  Lines.append(new qucs::Line(-12,-18,-12, 18,QPen(Qt::darkBlue,1, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{-17, 9},{-12, 18}, {-7, 9}}, QPen(Qt::darkBlue, 1, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
 
-  Lines.append(new qucs::Line(-25,-27, 25,-27,QPen(Qt::darkGray,1)));
-  Lines.append(new qucs::Line( 25,-27, 25, 27,QPen(Qt::darkGray,1)));
-  Lines.append(new qucs::Line( 25, 27,-25, 27,QPen(Qt::darkGray,1)));
-  Lines.append(new qucs::Line(-25, 27,-25,-27,QPen(Qt::darkGray,1)));
+  Rects.append(new qucs::Rect(-25, -27, 50, 54, QPen(Qt::darkGray,1)));
 
   Ports.append(new Port(-30,-30));
   Ports.append(new Port( 30,-30));

--- a/qucs/components/vcvs.cpp
+++ b/qucs/components/vcvs.cpp
@@ -24,7 +24,7 @@ VCVS::VCVS()
 {
   Description = QObject::tr("voltage controlled voltage source");
 
-  Arcs.append(new qucs::Arc(0,-11, 22, 22,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(0,-11, 22, 22,QPen(Qt::darkBlue,2)));
 
   Lines.append(new qucs::Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
@@ -36,18 +36,18 @@ VCVS::VCVS()
   Lines.append(new qucs::Line( 11,-30, 11,-11,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 11, 30, 11, 11,QPen(Qt::darkBlue,2)));
 
-  Lines.append(new qucs::Line(-12,-18,-12, 18,QPen(Qt::darkBlue,1)));
-  Lines.append(new qucs::Line(-12, 18,-17,  9,QPen(Qt::darkBlue,1)));
-  Lines.append(new qucs::Line(-12, 18, -7,  9,QPen(Qt::darkBlue,1)));
+  // arrow
+  Lines.append(new qucs::Line(-12,-18,-12, 18,QPen(Qt::darkBlue,1, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{-17, 9},{-12, 18}, {-7, 9}}, QPen(Qt::darkBlue, 1, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
 
+  // plus sign
   Lines.append(new qucs::Line( 19,-21, 19,-15,QPen(Qt::red,1)));
   Lines.append(new qucs::Line( 16,-18, 22,-18,QPen(Qt::red,1)));
+  // minus sign
   Lines.append(new qucs::Line( 16, 18, 22, 18,QPen(Qt::black,1)));
 
-  Lines.append(new qucs::Line(-25,-27, 25,-27,QPen(Qt::darkGray,1)));
-  Lines.append(new qucs::Line( 25,-27, 25, 27,QPen(Qt::darkGray,1)));
-  Lines.append(new qucs::Line( 25, 27,-25, 27,QPen(Qt::darkGray,1)));
-  Lines.append(new qucs::Line(-25, 27,-25,-27,QPen(Qt::darkGray,1)));
+  Rects.append(new qucs::Rect(-25, -27, 50, 54, QPen(Qt::darkGray,1)));
 
   Ports.append(new Port(-30,-30));
   Ports.append(new Port( 30,-30));

--- a/qucs/components/vexp.cpp
+++ b/qucs/components/vexp.cpp
@@ -29,24 +29,16 @@ vExp::vExp()
   Description = QObject::tr("exponential voltage source");
 
   // normal voltage source symbol
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24,  QPen(Qt::darkBlue,2)));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  
+  // plus sign
   Lines.append(new qucs::Line( 21,  8, 15,  8,QPen(Qt::red,1)));
+  Lines.append(new qucs::Line( 18,  5, 18,  11,QPen(Qt::red,1)));
+  // minus sign
   Lines.append(new qucs::Line(-18,  5,-18, 11,QPen(Qt::black,1)));
-
-  // write 'Exp' inside voltage source symbol
-  Lines.append(new qucs::Line( -3,  -7, -3, -4,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -3,  -7, 5, -7,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 1,  -7, 1, -4,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 5,  -7, 5, -4,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -3,  -1, 1, 3,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 1,  -1, -3, 3,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 1,  6, -5, 6,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 1,  6, 1, 9,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -3,  6, -3, 9,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( 1,  9, -3, 9,QPen(Qt::darkBlue,2)));
+  Texts.append(new Text(8, -10, "Exp", Qt::darkBlue, 12, 0.0, -1.0));
 
   Ports.append(new Port( 30,  0));
   Ports.append(new Port(-30,  0));

--- a/qucs/components/vfile.cpp
+++ b/qucs/components/vfile.cpp
@@ -25,22 +25,23 @@ vFile::vFile()
 {
   Description = QObject::tr("file based voltage source");
 
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.append(new qucs::Arc( -3, -7,  7,  7,16*270, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.append(new qucs::Arc( -3,  0,  7,  7, 16*90, 16*180,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24, QPen(Qt::darkBlue,2)));
+  // wave
+  Arcs.append(new qucs::Arc( -3, -7,  7,  7,16*270, 16*180,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Arcs.append(new qucs::Arc( -3,  0,  7,  7, 16*90, 16*180,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  // plus sign
   Lines.append(new qucs::Line( 18,  5, 18, 11,QPen(Qt::red,1)));
   Lines.append(new qucs::Line( 21,  8, 15,  8,QPen(Qt::red,1)));
+  // minus sign
   Lines.append(new qucs::Line(-18,  5,-18, 11,QPen(Qt::black,1)));
-
+  // small "list" pictogram
   Lines.append(new qucs::Line( -6,-17, -6,-21,QPen(Qt::darkBlue,1)));
   Lines.append(new qucs::Line( -8,-17, -8,-21,QPen(Qt::darkBlue,1)));
   Lines.append(new qucs::Line(-10,-17,-10,-21,QPen(Qt::darkBlue,1)));
-  Lines.append(new qucs::Line( -3,-15, -3,-23,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-13,-15,-13,-23,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -3,-23,-13,-23,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -3,-15,-13,-15,QPen(Qt::darkBlue,2)));
+  Rects.append(new qucs::Rect(-13, -23, 10, 8,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin)));
 
   Ports.append(new Port( 30,  0));
   Ports.append(new Port(-30,  0));

--- a/qucs/components/volt_ac.cpp
+++ b/qucs/components/volt_ac.cpp
@@ -24,13 +24,17 @@ Volt_ac::Volt_ac()
 {
   Description = QObject::tr("ideal ac voltage source");
 
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.append(new qucs::Arc( -3, -7,  7,  7,16*270, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.append(new qucs::Arc( -3,  0,  7,  7, 16*90, 16*180,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24,QPen(Qt::darkBlue,2)));
+  // wave
+  Arcs.append(new qucs::Arc( -3, -7,  7,  7,16*270, 16*180,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Arcs.append(new qucs::Arc( -3,  0,  7,  7, 16*90, 16*180,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  // contacts
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  // plus sign
   Lines.append(new qucs::Line( 18,  5, 18, 11,QPen(Qt::red,1)));
   Lines.append(new qucs::Line( 21,  8, 15,  8,QPen(Qt::red,1)));
+  // minus sign
   Lines.append(new qucs::Line(-18,  5,-18, 11,QPen(Qt::black,1)));
 
   Ports.append(new Port( 30,  0));

--- a/qucs/components/volt_noise.cpp
+++ b/qucs/components/volt_noise.cpp
@@ -24,14 +24,15 @@ Volt_noise::Volt_noise()
   Description = QObject::tr("noise voltage source");
   Simulator = spicecompat::simQucsator;
 
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24,QPen(Qt::darkBlue,2)));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-
-  Lines.append(new qucs::Line(-12,  1,  1,-12,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(-10,  6,  6,-10,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -7, 10, 10, -7,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -2, 12, 12, -2,QPen(Qt::darkBlue,2)));
+  // diagonal strokes
+  Lines.append(new qucs::Line(-12,  1,  1,-12,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-10,  6,  6,-10,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( -7, 10, 10, -7,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( -2, 12, 12, -2,QPen(Qt::darkBlue,2, Qt::SolidLine, Qt::FlatCap)));
 
   Ports.append(new Port( 30,  0));
   Ports.append(new Port(-30,  0));

--- a/qucs/diagrams/diagram.cpp
+++ b/qucs/diagrams/diagram.cpp
@@ -111,12 +111,12 @@ void Diagram::paintDiagram(QPainter *painter) {
 
     for (qucs::Line* line : Lines) {
         painter->setPen(line->penHint());
-        painter->drawLine(line->x1, - line->y1, line->x2, - line->y2);
+        painter->drawLine(QLineF{line->x1, - line->y1, line->x2, - line->y2});
     }
 
     for (qucs::Arc* arc : Arcs) {
         painter->setPen(arc->penHint());
-        painter->drawArc(arc->x, - arc->y, arc->w, arc->h, arc->angle, arc->arclen);
+        painter->drawArc(QRectF{arc->x, - arc->y, arc->w, arc->h}, arc->angle, arc->arclen);
     }
 
     painter->scale(1.0, -1.0); // make Y-axis grow upwards

--- a/qucs/element.cpp
+++ b/qucs/element.cpp
@@ -23,19 +23,19 @@
 namespace qucs {
 
 void Line::draw(QPainter* painter) const {
-    painter->drawLine(x1, y1, x2, y2);
+    painter->drawLine(QPointF{x1, y1}, QPointF{x2, y2});
 }
 
 void Arc::draw(QPainter* painter) const {
-    painter->drawArc(x, y, w, h, angle, arclen);
+    painter->drawArc(QRectF{x, y, w, h}, angle, arclen);
 }
 
 void Rect::draw(QPainter* painter) const {
-    painter->drawRect(x, y, w, h);
+    painter->drawRect(QRectF{x, y, w, h});
 }
 
 void Ellips::draw(QPainter* painter) const {
-    painter->drawEllipse(x, y, w, h);
+    painter->drawEllipse(QRectF{x, y, w, h});
 }
 
 } // namespace qucs
@@ -44,7 +44,7 @@ void Text::draw(QPainter *painter) const {
   draw(painter, nullptr);
 }
 
-void Text::draw(QPainter *painter, QRect* br) const {
+void Text::draw(QPainter *painter, QRectF* br) const {
   painter->save();
 
   painter->translate(x, y);

--- a/qucs/element.cpp
+++ b/qucs/element.cpp
@@ -38,6 +38,10 @@ void Ellips::draw(QPainter* painter) const {
     painter->drawEllipse(QRectF{x, y, w, h});
 }
 
+void Polyline::draw(QPainter* painter) const {
+    painter->drawPolyline(points.data(), points.size());
+}
+
 } // namespace qucs
 
 void Text::draw(QPainter *painter) const {

--- a/qucs/element.h
+++ b/qucs/element.h
@@ -38,6 +38,7 @@
 #define ELEMENT_H
 
 #include <QPen>
+#include <vector>
 
 class Node;
 class WireLabel;
@@ -96,6 +97,19 @@ struct Ellips : DrawingPrimitive {
   void draw(QPainter* painter) const override;
   QPen penHint() const override { return Pen; }
   QBrush brushHint() const override { return Brush; }
+};
+
+struct Polyline : DrawingPrimitive {
+  std::vector<QPointF> points;
+  QPen pen;
+  QBrush brush;
+
+  Polyline(const std::vector<QPointF> &pts, QPen p = QPen{Qt::NoPen}, QBrush b = QBrush{Qt::NoBrush})
+    : points(pts), pen{p}, brush{b} {};
+
+  void draw(QPainter* painter) const override;
+  QPen penHint() const override { return pen; }
+  QBrush brushHint() const override { return brush; }
 };
 
 }

--- a/qucs/element.h
+++ b/qucs/element.h
@@ -54,29 +54,30 @@ public:
 };
 
 struct Line : DrawingPrimitive {
-  Line(int _x1, int _y1, int _x2, int _y2, QPen _style)
+  Line(double _x1, double _y1, double _x2, double _y2, QPen _style)
        : x1(_x1), y1(_y1), x2(_x2), y2(_y2), style(_style) {};
-  int   x1, y1, x2, y2;
+  double   x1, y1, x2, y2;
   QPen  style;
   void draw(QPainter* painter) const override;
   QPen penHint() const override { return style; }
 };
 
 struct Arc : DrawingPrimitive {
-  Arc(int _x, int _y, int _w, int _h, int _angle, int _arclen, QPen _style)
+  Arc(double _x, double _y, double _w, double _h, int _angle, int _arclen, QPen _style)
       : x(_x), y(_y), w(_w), h(_h), angle(_angle),
 	arclen(_arclen), style(_style) {};
-  int   x, y, w, h, angle, arclen;
+  double   x, y, w, h;
+  int angle, arclen;
   QPen  style;
   void draw(QPainter* painter) const override;
   QPen penHint() const override { return style; }
 };
 
 struct Rect : DrawingPrimitive {
-  Rect(int _x, int _y, int _w, int _h, QPen _Pen,
+  Rect(double _x, double _y, double _w, double _h, QPen _Pen,
 	QBrush _Brush = QBrush(Qt::NoBrush))
 	: x(_x), y(_y), w(_w), h(_h), Pen(_Pen), Brush(_Brush) {};
-  int    x, y, w, h;
+  double    x, y, w, h;
   QPen   Pen;
   QBrush Brush;    // filling style/color
   void draw(QPainter* painter) const override;
@@ -86,10 +87,10 @@ struct Rect : DrawingPrimitive {
 
 // 'ellipse' conflicts 'ellipse' defined in paintings.h in the same namespace
 struct Ellips : DrawingPrimitive {
-  Ellips(int _x, int _y, int _w, int _h, QPen _Pen,
+  Ellips(double _x, double _y, double _w, double _h, QPen _Pen,
 	QBrush _Brush = QBrush(Qt::NoBrush))
 	: x(_x), y(_y), w(_w), h(_h), Pen(_Pen), Brush(_Brush) {};
-  int    x, y, w, h;
+  double    x, y, w, h;
   QPen   Pen;
   QBrush Brush;    // filling style/color
   void draw(QPainter* painter) const override;
@@ -110,17 +111,17 @@ struct Port {
 };
 
 struct Text : qucs::DrawingPrimitive {
-  Text(int _x, int _y, const QString& _s, QColor _Color = QColor(0,0,0),
-	float _Size = 10.0, float _mCos=1.0, float _mSin=0.0)
+  Text(double _x, double _y, const QString& _s, QColor _Color = QColor(0,0,0),
+	double _Size = 10.0, double _mCos=1.0, double _mSin=0.0)
 	: x(_x), y(_y), s(_s), Color(_Color), Size(_Size),
 	  mSin(_mSin), mCos(_mCos) { over = under = false; };
-  int	  x, y;
+  double	  x, y;
   QString s;
   QColor  Color;
-  float	  Size, mSin, mCos; // font size and rotation coefficients
+  double	  Size, mSin, mCos; // font size and rotation coefficients
   bool	  over, under;      // text attributes
   void draw(QPainter *painter) const override;
-  void draw(QPainter* painter, QRect* br) const;
+  void draw(QPainter* painter, QRectF* br) const;
   QPen penHint() const override { return Color; }
   double angle() const;
 };

--- a/qucs/misc.cpp
+++ b/qucs/misc.cpp
@@ -788,8 +788,8 @@ QString VersionTriplet::toString() {
 //
 // The implementation is taken from ViewPainter::drawTextMapped and adapted
 // to work with QPainter and as standalone function outside of class.
-void misc::draw_richtext(QPainter* painter, int x, int y, const QString &text, QRect* br) {
-  QRect all_bounding_rect;
+void misc::draw_richtext(QPainter* painter, int x, int y, const QString &text, QRectF* br) {
+  QRectF all_bounding_rect;
   int current_text_x = x;
   int current_text_y = y;
   int i = 0;

--- a/qucs/misc.h
+++ b/qucs/misc.h
@@ -93,7 +93,7 @@ namespace misc {
   bool simulatorExists(const QString &exe_file);
   QString unwrapExePath(const QString &exe_file);
 
-  void draw_richtext(QPainter* painter, int x, int y, const QString& text, QRect* br = nullptr);
+  void draw_richtext(QPainter* painter, int x, int y, const QString& text, QRectF* br = nullptr);
   void draw_resize_handle(QPainter* painter, const QPointF& center);
 }
 

--- a/qucs/paintings/graphictext.cpp
+++ b/qucs/paintings/graphictext.cpp
@@ -53,7 +53,7 @@ void GraphicText::paint(QPainter* painter) {
     f.setPixelSize(QFontInfo{Font}.pixelSize());
     painter->setFont(f);
 
-    QRect br;
+    QRectF br;
     misc::draw_richtext(painter, 0, 0, Text, &br);
 
     if (isSelected) {

--- a/qucs/spicecomponents/S4Q_I.cpp
+++ b/qucs/spicecomponents/S4Q_I.cpp
@@ -29,13 +29,14 @@ S4Q_I::S4Q_I()
    Description = QObject::tr("SPICE I:\nMultiple line ngspice or Xyce I specifications allowed using \"+\" continuation lines.\nLeave continuation lines blank when NOT in use.  ");
    Simulator = spicecompat::simSpice;
 
-  Arcs.append(new qucs::Arc(-14,-14, 28, 28,     0, 16*360,QPen(Qt::darkRed,3)));
- 
- Lines.append(new qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
- Lines.append(new qucs::Line( 30,  0, 14,  0,QPen(Qt::darkBlue,2)));
- Lines.append(new qucs::Line( -8,  0, 8, 0,QPen(Qt::darkRed,3)));
- Lines.append(new qucs::Line( -8,  0, -4,  -4,QPen(Qt::darkRed,3)));
- Lines.append(new qucs::Line( -8,  0, -4,   4,QPen(Qt::darkRed,3)));
+  Ellipses.append(new qucs::Ellips(-14,-14, 28, 28,QPen(Qt::darkRed,3)));
+  // pins
+  Lines.append(new qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
+  Lines.append(new qucs::Line( 30,  0, 14,  0,QPen(Qt::darkBlue,2)));
+  // arrow
+  Lines.append(new qucs::Line( -8,  0, 8, 0,QPen(Qt::darkRed,3, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( -8,  0, -4,  -4,QPen(Qt::darkRed,3)));
+  Lines.append(new qucs::Line( -8,  0, -4,   4,QPen(Qt::darkRed,3)));
   
    Ports.append(new Port( 30,  0));
   Ports.append(new Port(-30,  0));

--- a/qucs/spicecomponents/S4Q_Ieqndef.cpp
+++ b/qucs/spicecomponents/S4Q_Ieqndef.cpp
@@ -25,17 +25,17 @@ S4Q_Ieqndef::S4Q_Ieqndef()
   Description = QObject::tr("SPICE B (I type):\nMultiple line ngspice or Xyce B specifications allowed using \"+\" continuation lines.\nLeave continuation lines blank when NOT in use.  ");
   Simulator = spicecompat::simSpice;
 
-  Arcs.append(new qucs::Arc(-14,-14, 28, 28,     0, 16*360,QPen(Qt::darkRed,3)));
- 
+  Ellipses.append(new qucs::Ellips(-14,-14, 28, 28,QPen(Qt::darkRed,3)));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 14,  0,QPen(Qt::darkBlue,2)));
  
-  
-  Lines.append(new qucs::Line( -8,  0, 8, 0,QPen(Qt::darkRed,3)));
+  // arrow
+  Lines.append(new qucs::Line( -8,  0, 8, 0,QPen(Qt::darkRed,3, Qt::SolidLine, Qt::FlatCap)));
   Lines.append(new qucs::Line( -8,  0, -4,  -4,QPen(Qt::darkRed,3)));
   Lines.append(new qucs::Line( -8,  0, -4,   4,QPen(Qt::darkRed,3)));
   
-  Texts.append(new Text(30,-30,"Eqn",Qt::darkRed,10.0,0.0,-1.0));
+  Texts.append(new Text(25,-30,"Eqn",Qt::darkRed,12.0,0.0,-1.0));
   
 
   Ports.append(new Port( 30,  0));

--- a/qucs/spicecomponents/eNL.cpp
+++ b/qucs/spicecomponents/eNL.cpp
@@ -27,12 +27,15 @@ eNL::eNL()
   Simulator = spicecompat::simSpice;
   // Value, Table and POLY forms are allowed.
 
-  Arcs.append(new qucs::Arc(-14,-14, 28, 28,     0, 16*360,QPen(Qt::blue,3)));
-  Texts.append(new Text(36,4,"ENL",Qt::blue,10.0,0.0,-1.0));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24, QPen(Qt::blue,3)));
+  Texts.append(new Text(26,6,"ENL",Qt::blue,12.0,0.0,-1.0));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 14,  0,QPen(Qt::darkBlue,2)));
+  // plus sign
   Lines.append(new qucs::Line( 18,  -5, 18, -11,QPen(Qt::red,2)));
   Lines.append(new qucs::Line( 21,  -8, 15,  -8,QPen(Qt::red,2)));
+  // minus sign
   Lines.append(new qucs::Line(-18,  -5,-18, -11,QPen(Qt::black,2))); 
 
   Ports.append(new Port( 30,  0));

--- a/qucs/spicecomponents/gNL.cpp
+++ b/qucs/spicecomponents/gNL.cpp
@@ -27,13 +27,15 @@ gNL::gNL()
   Simulator = spicecompat::simSpice;
   // Value, Table and POLY forms are allowed: should work with ngspice and Xyce.
 
-  Arcs.append(new qucs::Arc(-14,-14, 28, 28,     0, 16*360,QPen(Qt::blue,3)));
-  Texts.append(new Text(36, 4,"GNL",Qt::blue,10.0,0.0,-1.0));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24, QPen(Qt::blue,3)));
+  Texts.append(new Text(26, 6,"GNL",Qt::blue,12.0,0.0,-1.0));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 14,  0,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
+  // arrow
+  Lines.append(new qucs::Line( -7,  0,  6,  0,QPen(Qt::blue,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{0, -4},{6, 0}, {0, 4}}, QPen(Qt::blue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
  
   Ports.append(new Port( 30,  0));
   Ports.append(new Port(-30,  0));

--- a/qucs/spicecomponents/iAmpMod.cpp
+++ b/qucs/spicecomponents/iAmpMod.cpp
@@ -29,13 +29,16 @@ iAmpMod::iAmpMod()
   Simulator = spicecompat::simSpice;
 
   // normal current source symbol
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::blue,3)));
-  Texts.append(new Text(36, 4,"AM",Qt::blue,10.0,0.0,-1.0)); 
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24, QPen(Qt::blue,3)));
+  Texts.append(new Text(26, 6,"AM",Qt::blue,12.0,0.0,-1.0)); 
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -7,  0,  7,  0,QPen(Qt::blue,3)));
-  Lines.append(new qucs::Line(  -6,  0,  0, -4,QPen(Qt::blue,3)));
-  Lines.append(new qucs::Line(  -6,  0,  0,  4,QPen(Qt::blue,3)));
+  // arrow 
+  Lines.append(new qucs::Line( -7,  0,  6,  0,QPen(Qt::blue,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{0, -4},{6, 0}, {0, 4}}, QPen(Qt::blue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
+
   
   Ports.append(new Port( 30,  0));
   Ports.append(new Port(-30,  0));

--- a/qucs/spicecomponents/iAmpMod.cpp
+++ b/qucs/spicecomponents/iAmpMod.cpp
@@ -35,9 +35,9 @@ iAmpMod::iAmpMod()
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
   // arrow 
-  Lines.append(new qucs::Line( -7,  0,  6,  0,QPen(Qt::blue,3, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( -6,  0,  7,  0,QPen(Qt::blue,3, Qt::SolidLine, Qt::FlatCap)));
   Polylines.append(new qucs::Polyline(
-    std::vector<QPointF>{{0, -4},{6, 0}, {0, 4}}, QPen(Qt::blue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
+    std::vector<QPointF>{{0, -4},{-6, 0}, {0, 4}}, QPen(Qt::blue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
 
   
   Ports.append(new Port( 30,  0));

--- a/qucs/spicecomponents/iPWL.cpp
+++ b/qucs/spicecomponents/iPWL.cpp
@@ -29,13 +29,15 @@ iPWL::iPWL()
     Simulator = spicecompat::simSpice;
 
   // normal voltage source symbol
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24, 0, 16*360,QPen(Qt::darkRed,3)));
-  Texts.append(new Text(36, 4,"PWL",Qt::darkRed,10.0,0.0,-1.0));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24, QPen(Qt::darkRed,3)));
+  Texts.append(new Text(26, 6,"PWL",Qt::darkRed,12.0,0.0,-1.0));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-   Lines.append(new qucs::Line( -7,  0,  7,  0,QPen(Qt::darkRed,3)));
-  Lines.append(new qucs::Line(  6,  0,  0, -4,QPen(Qt::darkRed,3)));
-  Lines.append(new qucs::Line(  6,  0,  0,  4,QPen(Qt::darkRed,3)));
+  // arrow
+  Lines.append(new qucs::Line( -7,  0,  6,  0,QPen(Qt::darkRed,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{0, -4},{6, 0}, {0, 4}}, QPen(Qt::darkRed, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
   
 
   Ports.append(new Port( 30,  0));

--- a/qucs/spicecomponents/iTRNOISE.cpp
+++ b/qucs/spicecomponents/iTRNOISE.cpp
@@ -29,19 +29,20 @@ iTRNOISE::iTRNOISE()
   Simulator = spicecompat::simSpice;
 
   // normal voltage source symbol
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::blue,3)));
-   Texts.append(new Text(36, 4,"ITRN",Qt::blue,10.0,0.0,-1.0)); 
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24, QPen(Qt::blue,3)));
+  Texts.append(new Text(26, 6,"ITRN",Qt::blue,12.0,0.0,-1.0));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  
-  Lines.append(new qucs::Line(-12,  1,  1,-12,QPen(Qt::darkGray,3)));
-  Lines.append(new qucs::Line(-10,  6,  6,-10,QPen(Qt::darkGray,3)));
-  Lines.append(new qucs::Line( -7, 10, 10, -7,QPen(Qt::darkGray,3)));
-  Lines.append(new qucs::Line( -2, 12, 12, -2,QPen(Qt::darkGray,3)));
-  
-  Lines.append(new qucs::Line( -7,  0,  7,  0,QPen(Qt::blue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0, -4,QPen(Qt::blue,3)));
-  Lines.append(new qucs::Line(  6,  0,  0,  4,QPen(Qt::blue,3)));
+  // diagonal strokes
+  Lines.append(new qucs::Line(-12,  1,  1,-12,QPen(Qt::darkGray,3, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-10,  6,  6,-10,QPen(Qt::darkGray,3, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( -7, 10, 10, -7,QPen(Qt::darkGray,3, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( -2, 12, 12, -2,QPen(Qt::darkGray,3, Qt::SolidLine, Qt::FlatCap)));
+  // arrow
+  Lines.append(new qucs::Line( -7,  0,  6,  0,QPen(Qt::blue,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{0, -4},{6, 0}, {0, 4}}, QPen(Qt::blue, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
 
   
   Ports.append(new Port( 30,  0));

--- a/qucs/spicecomponents/isffm.cpp
+++ b/qucs/spicecomponents/isffm.cpp
@@ -30,13 +30,15 @@ iSffm::iSffm()
 
   // normal current source symbol
   
-   Arcs.append(new qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkRed,3)));
-   Texts.append(new Text(36, 4,"SFFM",Qt::darkRed,10.0,0.0,-1.0));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24,QPen(Qt::darkRed,3)));
+  Texts.append(new Text(26, 6,"SFFM",Qt::darkRed,12.0,0.0,-1.0));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line( -7,  0,  7,  0,QPen(Qt::darkRed,3)));
-  Lines.append(new qucs::Line(  -6,  0,  0, -4,QPen(Qt::darkRed,3)));
-  Lines.append(new qucs::Line(  -6,  0,  0,  4,QPen(Qt::darkRed,3)));
+  // arrow
+  Lines.append(new qucs::Line( -7,  0,  6,  0,QPen(Qt::darkRed,3, Qt::SolidLine, Qt::FlatCap)));
+  Polylines.append(new qucs::Polyline(
+    std::vector<QPointF>{{0, -4},{6, 0}, {0, 4}}, QPen(Qt::darkRed, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
  
   Ports.append(new Port( 30,  0));
   Ports.append(new Port(-30,  0));

--- a/qucs/spicecomponents/isffm.cpp
+++ b/qucs/spicecomponents/isffm.cpp
@@ -36,10 +36,10 @@ iSffm::iSffm()
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
   // arrow
-  Lines.append(new qucs::Line( -7,  0,  6,  0,QPen(Qt::darkRed,3, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( -6,  0,  7,  0,QPen(Qt::darkRed,3, Qt::SolidLine, Qt::FlatCap)));
   Polylines.append(new qucs::Polyline(
-    std::vector<QPointF>{{0, -4},{6, 0}, {0, 4}}, QPen(Qt::darkRed, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
  
+    std::vector<QPointF>{{0, -4},{-6, 0}, {0, 4}}, QPen(Qt::darkRed, 3, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin)));
   Ports.append(new Port( 30,  0));
   Ports.append(new Port(-30,  0));
 

--- a/qucs/spicecomponents/src_eqndef.cpp
+++ b/qucs/spicecomponents/src_eqndef.cpp
@@ -8,12 +8,15 @@ Src_eqndef::Src_eqndef()
   Description = QObject::tr("SPICE B (V type):\nMultiple line ngspice or Xyce B specifications allowed using \"+\" continuation lines.\nLeave continuation lines blank when NOT in use.  ");
   Simulator = spicecompat::simSpice;
 
-  Arcs.append(new qucs::Arc(-14,-14, 28, 28,     0, 16*360,QPen(Qt::darkRed,3)));
-  Texts.append(new Text(10,-12,"Eqn",Qt::darkRed,10.0,0.0,-1.0));
+  Ellipses.append(new qucs::Ellips(-14,-14, 28, 28, QPen(Qt::darkRed,3)));
+  Texts.append(new Text(8,-10,"Eqn",Qt::darkRed,12.0,0.0,-1.0));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 14,  0,QPen(Qt::darkBlue,2)));
+  // plus sign
   Lines.append(new qucs::Line( 18,  5, 18, 11,QPen(Qt::red,2)));
   Lines.append(new qucs::Line( 21,  8, 15,  8,QPen(Qt::red,2)));
+  // minus sign
   Lines.append(new qucs::Line(-18,  5,-18, 11,QPen(Qt::black,2)));
 
   Ports.append(new Port( 30,  0));

--- a/qucs/spicecomponents/vAmpMod.cpp
+++ b/qucs/spicecomponents/vAmpMod.cpp
@@ -29,14 +29,16 @@ vAmpMod::vAmpMod()
   Simulator = spicecompat::simSpice;
 
   // normal voltage source symbol
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::blue,3)));
-   Texts.append(new Text(36, 4,"AM",Qt::blue,10.0,0.0,-1.0)); 
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24, QPen(Qt::blue,3)));
+  Texts.append(new Text(26, 6,"AM",Qt::blue,12.0,0.0,-1.0));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  
-  Lines.append(new qucs::Line( 18,  -5, 18, -11,QPen(Qt::red,1)));
-  Lines.append(new qucs::Line( 21,  -8, 15,  -8,QPen(Qt::red,1)));
-  Lines.append(new qucs::Line(-18,  -5,-18, -11,QPen(Qt::black,1)));
+  // plus sign
+  Lines.append(new qucs::Line( 18,  -5, 18, -11,QPen(Qt::red,2)));
+  Lines.append(new qucs::Line( 21,  -8, 15,  -8,QPen(Qt::red,2)));
+  // minus sign
+  Lines.append(new qucs::Line(-18,  -5,-18, -11,QPen(Qt::black,2)));
 
  
 

--- a/qucs/spicecomponents/vPWL.cpp
+++ b/qucs/spicecomponents/vPWL.cpp
@@ -28,13 +28,16 @@ vPWL::vPWL()
   Description = QObject::tr("SPICE V(PWL):\nMultiple line ngspice or Xyce V specifications allowed using \"+\" continuation lines.\nLeave continuation lines blank when NOT in use. ");
   Simulator = spicecompat::simSpice;
 
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkRed,3)));
-  Texts.append(new Text(36, 4,"PWL",Qt::darkRed,10.0,0.0,-1.0));
-  Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line( 18,  -5, 18, -11,QPen(Qt::red,3)));
-  Lines.append(new qucs::Line( 21,  -8, 15,  -8,QPen(Qt::red,3)));
-  Lines.append(new qucs::Line(-18,  -5,-18, -11,QPen(Qt::black,3)));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24, QPen(Qt::darkRed,3)));
+  Texts.append(new Text(26, 6,"PWL",Qt::darkRed,12.0,0.0,-1.0));
+  // pins
+  Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  // plus
+  Lines.append(new qucs::Line( 18,  -5, 18, -11,QPen(Qt::red,2)));
+  Lines.append(new qucs::Line( 21,  -8, 15,  -8,QPen(Qt::red,2)));
+  // minus
+  Lines.append(new qucs::Line(-18,  -5,-18, -11,QPen(Qt::black,2)));
 
   Ports.append(new Port( 30,  0));
   Ports.append(new Port(-30,  0));

--- a/qucs/spicecomponents/vTRNOISE.cpp
+++ b/qucs/spicecomponents/vTRNOISE.cpp
@@ -29,15 +29,16 @@ vTRNOISE::vTRNOISE()
   Simulator = spicecompat::simSpice;
 
   // normal voltage source symbol
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24, 0, 16*360,QPen(Qt::blue,3)));
-   Texts.append(new Text(36, 4,"VTRN",Qt::blue,10.0,0.0,-1.0)); 
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24, QPen(Qt::blue,3)));
+  Texts.append(new Text(26, 6,"VTRN",Qt::blue,12.0,0.0,-1.0));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  
-  Lines.append(new qucs::Line(-12,  1,  1,-12,QPen(Qt::darkGray,3)));
-  Lines.append(new qucs::Line(-10,  6,  6,-10,QPen(Qt::darkGray,3)));
-  Lines.append(new qucs::Line( -7, 10, 10, -7,QPen(Qt::darkGray,3)));
-  Lines.append(new qucs::Line( -2, 12, 12, -2,QPen(Qt::darkGray,3)));
+  // diagonal strokes
+  Lines.append(new qucs::Line(-12,  1,  1,-12,QPen(Qt::darkGray,3, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-10,  6,  6,-10,QPen(Qt::darkGray,3, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( -7, 10, 10, -7,QPen(Qt::darkGray,3, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( -2, 12, 12, -2,QPen(Qt::darkGray,3, Qt::SolidLine, Qt::FlatCap)));
 
   
   Ports.append(new Port( 30,  0));

--- a/qucs/spicecomponents/vTRRANDOM.cpp
+++ b/qucs/spicecomponents/vTRRANDOM.cpp
@@ -29,18 +29,20 @@ vTRRANDOM::vTRRANDOM()
   Simulator = spicecompat::simSpice;
 
   // normal voltage source symbol
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24, 0, 16*360,QPen(Qt::blue,3)));
-   Texts.append(new Text(36, 4,"TRR",Qt::blue,10.0,0.0,-1.0)); 
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24, QPen(Qt::blue,3)));
+  Texts.append(new Text(26, 6,"TRR",Qt::blue,12.0,0.0,-1.0));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  
-  Lines.append(new qucs::Line(-12,  1,  1,-12,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line(-10,  6,  6,-10,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line( -7, 10, 10, -7,QPen(Qt::darkBlue,3)));
-  Lines.append(new qucs::Line( -2, 12, 12, -2,QPen(Qt::darkBlue,3)));
-  
+  // diagonal strokes
+  Lines.append(new qucs::Line(-12,  1,  1,-12,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line(-10,  6,  6,-10,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( -7, 10, 10, -7,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  Lines.append(new qucs::Line( -2, 12, 12, -2,QPen(Qt::darkBlue,3, Qt::SolidLine, Qt::FlatCap)));
+  // plus sign
   Lines.append(new qucs::Line( 18,  -5, 18, -11,QPen(Qt::red,2)));
   Lines.append(new qucs::Line( 21,  -8, 15,  -8,QPen(Qt::red,2)));
+  // minus sign
   Lines.append(new qucs::Line(-18,  -5,-18, -11,QPen(Qt::black,2))); 
 
 

--- a/qucs/spicecomponents/vsffm.cpp
+++ b/qucs/spicecomponents/vsffm.cpp
@@ -29,13 +29,15 @@ vSffm::vSffm()
   Simulator = spicecompat::simSpice;
 
   // normal voltage source symbol
-  Arcs.append(new qucs::Arc(-12,-12, 24, 24, 0, 16*360,QPen(Qt::darkRed,3)));
-  Texts.append(new Text(36, 4,"SFFM",Qt::darkRed,10.0,0.0,-1.0));
+  Ellipses.append(new qucs::Ellips(-12,-12, 24, 24, QPen(Qt::darkRed,3)));
+  Texts.append(new Text(26, 6,"SFFM",Qt::darkRed,12.0,0.0,-1.0));
+  // pins
   Lines.append(new qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  
+  // plus sign
   Lines.append(new qucs::Line( 18,  -5, 18, -11,QPen(Qt::red,2)));
   Lines.append(new qucs::Line( 21,  -8, 15,  -8,QPen(Qt::red,2)));
+  // minus sign
   Lines.append(new qucs::Line(-18,  -5,-18, -11,QPen(Qt::black,2)));
 
   Ports.append(new Port( 30,  0));


### PR DESCRIPTION
Hi!

This a follow-up to #723 and another portion of changes to components to make them look a bit prettier. This time components from "sources" groups were in work.

With this PR also comes a new type of drawing primitive — the so called "Polyline" which allows to draw compound lines consisting of several segments and make good-looking joining of them. I had to add be able to draw nice arrow heads without strange edges etc.

There is a lot of affected components and I was to lazy (shame on me!) to make before/after images this time, but I think a change in component's rendering is something self-describing and easy to see so lack of before/after images shouldn't be a problem.