### PR TITLE
Fix #739: Restore QPainter state after paining the id_text element

### DIFF
--- a/qucs/paintings/id_text.cpp
+++ b/qucs/paintings/id_text.cpp
@@ -63,6 +63,7 @@ void ID_Text::paint(QPainter* painter) {
     painter->setPen(QPen(Qt::darkGray,3));
     painter->drawRoundedRect(-4, -4, x2+8, y2+8, 4.0, 4.0);
   }
+  painter->restore();
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
The 'paint' function of ID_text missed the restore() call on painter, which led to carrying the changes made to painter further down the call chain. In other words, the painter state *after* painting the ID_text wasn't the same as *before* doing it, and everything painted after the ID_text was affected by this change in painter's state.

This commit add missing restore() call.

Fixes: ra3xdh/qucs_s#739