### PR TITLE
Prevent port labels from disappearing after performing "undo" in symbol mode

### DIFF
--- a/qucs/paintings/portsymbol.cpp
+++ b/qucs/paintings/portsymbol.cpp
@@ -53,7 +53,7 @@ void PortSymbol::paint(QPainter *painter) {
   painter->setPen(QPen(Qt::red,1));  // like open node
   painter->drawEllipse(circle_br);
 
-  QSize name_size = painter->fontMetrics().size(0b0, nameStr);
+  QSize name_size = painter->fontMetrics().size(0b0, nameStr.isEmpty() ? numberStr : nameStr);
   const int half_nameheight = static_cast<int>(std::round(name_size.height() / 2.0));
 
   constexpr int offset = 8;
@@ -88,7 +88,7 @@ void PortSymbol::paint(QPainter *painter) {
     }
 
     painter->setPen(Qt::black);
-    painter->drawText(0, 0, 0, 0, Qt::TextDontClip, nameStr);
+    painter->drawText(0, 0, 0, 0, Qt::TextDontClip, nameStr.isEmpty() ? numberStr : nameStr);
   }
   painter->restore();
 

--- a/qucs/paintings/portsymbol.cpp
+++ b/qucs/paintings/portsymbol.cpp
@@ -158,6 +158,11 @@ bool PortSymbol::load(const QString& s)
   Angel = n.toInt(&ok);
   if(!ok) return false;
 
+  // name string
+  n = s.section(' ', 5);
+  if (n.isEmpty()) return true;
+  nameStr = n;
+
   return true;
 }
 
@@ -165,7 +170,7 @@ bool PortSymbol::load(const QString& s)
 QString PortSymbol::save()
 {
   QString s = Name+QString::number(cx)+" "+QString::number(cy)+" ";
-  s += numberStr+" "+QString::number(Angel);
+  s += numberStr+" "+QString::number(Angel) + " " + nameStr;
   return s;
 }
 


### PR DESCRIPTION
This PR fixes the problem №2 described in #750