### PR TITLE
SpiceLibComp redesign

### DIFF
--- a/qucs/extsimkernels/CMakeLists.txt
+++ b/qucs/extsimkernels/CMakeLists.txt
@@ -17,6 +17,7 @@ customsimdialog.h
 simsettingsdialog.h
 verilogawriter.h
 s2spice.h
+spicelibcompdialog.h
 #xspice_cmbuilder.h
 #codemodelgen.h
 )
@@ -32,6 +33,7 @@ customsimdialog.cpp
 simsettingsdialog.cpp
 verilogawriter.cpp
 s2spice.cpp
+spicelibcompdialog.cpp
 #xspice_cmbuilder.cpp
 #codemodelgen.cpp
 )
@@ -43,6 +45,7 @@ ngspice.h
 xyce.h
 customsimdialog.h
 simsettingsdialog.h
+spicelibcompdialog.h
 )
 
 

--- a/qucs/extsimkernels/spicelibcompdialog.cpp
+++ b/qucs/extsimkernels/spicelibcompdialog.cpp
@@ -25,6 +25,8 @@
 SpiceLibCompDialog::SpiceLibCompDialog(Component *pc, QWidget* parent) : QDialog{parent}
 {
   comp = pc;
+  symbolPinsCount = 0;
+
   QString file = comp->Props.at(0)->Value;
   if (!file.isEmpty()) {
     file = misc::properAbsFileName(file);
@@ -52,6 +54,7 @@ SpiceLibCompDialog::SpiceLibCompDialog(Component *pc, QWidget* parent) : QDialog
 
   symbol = new SymbolWidget;
   symbol->disableDragNDrop();
+  symbol->enableShowPinNumbers();
 
   tbwPinsTable = new QTableWidget;
   tbwPinsTable->setColumnCount(2);
@@ -170,7 +173,7 @@ void SpiceLibCompDialog::slotSetSymbol()
 {
   QString dir_name = QucsSettings.BinDir + "/../share/" QUCS_NAME "/symbols/";
   QString file = dir_name + cbxSymPattern->currentText() + ".sym";
-  symbol->loadSymFile(file);
+  symbolPinsCount = symbol->loadSymFile(file);
 }
 
 void SpiceLibCompDialog::slotBtnOpenLib()

--- a/qucs/extsimkernels/spicelibcompdialog.cpp
+++ b/qucs/extsimkernels/spicelibcompdialog.cpp
@@ -48,6 +48,7 @@ SpiceLibCompDialog::SpiceLibCompDialog(Component *pc, QWidget* parent) : QDialog
   QLabel *lblPattern = new QLabel("Symbol pattern");
   cbxSymPattern = new QComboBox;
   QStringList lst_patterns;
+  lst_patterns.append("auto");
   misc::getSymbolPatternsList(lst_patterns);
   cbxSymPattern->addItems(lst_patterns);
   connect(cbxSymPattern,SIGNAL(currentIndexChanged(int)),this,SLOT(slotSetSymbol()));
@@ -171,9 +172,18 @@ bool SpiceLibCompDialog::parseLibFile(const QString &filename)
 
 void SpiceLibCompDialog::slotSetSymbol()
 {
-  QString dir_name = QucsSettings.BinDir + "/../share/" QUCS_NAME "/symbols/";
-  QString file = dir_name + cbxSymPattern->currentText() + ".sym";
-  symbolPinsCount = symbol->loadSymFile(file);
+  if (cbxSymPattern->currentText() == "auto") {
+    tbwPinsTable->setEnabled(false);
+    QString s1 = "";
+    QString s2 = "SpLib";
+    symbol->setSymbol(s1, s1, s2);
+    symbolPinsCount = 0;
+  } else {
+    tbwPinsTable->setEnabled(true);
+    QString dir_name = QucsSettings.BinDir + "/../share/" QUCS_NAME "/symbols/";
+    QString file = dir_name + cbxSymPattern->currentText() + ".sym";
+    symbolPinsCount = symbol->loadSymFile(file);
+  }
 }
 
 void SpiceLibCompDialog::slotBtnOpenLib()

--- a/qucs/extsimkernels/spicelibcompdialog.cpp
+++ b/qucs/extsimkernels/spicelibcompdialog.cpp
@@ -20,7 +20,7 @@ SpiceLibCompDialog::SpiceLibCompDialog(Component *pc, Schematic *sch) : QDialog{
 
   QString file = comp->Props.at(0)->Value;
   if (!file.isEmpty()) {
-    file = misc::properAbsFileName(file);
+    file = misc::properAbsFileName(file, Doc);
     QFileInfo inf(file);
     lastLibDir = inf.absoluteDir().path();
   } else {
@@ -76,10 +76,10 @@ SpiceLibCompDialog::SpiceLibCompDialog(Component *pc, Schematic *sch) : QDialog{
   connect(chbShowModel,SIGNAL(toggled(bool)),this,SLOT(slotChanged()));
   connect(chbShowParams,SIGNAL(toggled(bool)),this,SLOT(slotChanged()));
 
-  if (QFileInfo::exists(misc::properAbsFileName(sym))) {
-    edtSymFile->setText(sym);
+  if (QFileInfo::exists(misc::properAbsFileName(sym, Doc))) {
+    edtSymFile->setText(misc::properAbsFileName(sym, Doc));
     rbUserSym->setChecked(true);
-    QFileInfo inf(misc::properAbsFileName(sym));
+    QFileInfo inf(misc::properAbsFileName(sym, Doc));
     lastSymbolDir = inf.absoluteDir().path();
   } else {
     QFileInfo inf = Doc->getFileInfo();
@@ -407,8 +407,18 @@ bool SpiceLibCompDialog::setCompProps()
     return false;
   }
 
+  QString  sch_dir = Doc->getFileInfo().absoluteDir().path();
+  QString libpath = edtLibPath->text();
+  QString sympath = edtSymFile->text();
+  if (libpath.startsWith(sch_dir)) {
+    libpath = QDir(sch_dir).relativeFilePath(libpath);
+  }
+  if (sympath.startsWith(sch_dir)) {
+    sympath = QDir(sch_dir).relativeFilePath(sympath);
+  }
+
   Property *pp = comp->Props.first();
-  pp->Value = edtLibPath->text();
+  pp->Value = libpath;
   pp->display = chbShowLib->isChecked();
   pp = comp->Props.next();
   pp->Value = cbxSelectSubcir->currentText();
@@ -419,7 +429,7 @@ bool SpiceLibCompDialog::setCompProps()
   } else if (rbSymFromTemplate->isChecked()) {
     pp->Value = cbxSymPattern->currentText();
   } else if (rbUserSym->isChecked()) {
-    pp->Value = edtSymFile->text();
+    pp->Value = sympath;
   }
   pp = comp->Props.next();
   pp->Value = edtParams->text();

--- a/qucs/extsimkernels/spicelibcompdialog.cpp
+++ b/qucs/extsimkernels/spicelibcompdialog.cpp
@@ -21,6 +21,11 @@ SpiceLibCompDialog::SpiceLibCompDialog(Component *pc, Schematic *sch) : QDialog{
   QString file = comp->Props.at(0)->Value;
   if (!file.isEmpty()) {
     file = misc::properAbsFileName(file);
+    QFileInfo inf(file);
+    lastLibDir = inf.absoluteDir().path();
+  } else {
+    QFileInfo inf = Doc->getFileInfo();
+    lastLibDir = inf.absoluteDir().path();
   }
   bool show_lib = comp->Props.at(0)->display;
   QString device = comp->Props.at(1)->Value;
@@ -74,7 +79,11 @@ SpiceLibCompDialog::SpiceLibCompDialog(Component *pc, Schematic *sch) : QDialog{
   if (QFileInfo::exists(misc::properAbsFileName(sym))) {
     edtSymFile->setText(sym);
     rbUserSym->setChecked(true);
+    QFileInfo inf(misc::properAbsFileName(sym));
+    lastSymbolDir = inf.absoluteDir().path();
   } else {
+    QFileInfo inf = Doc->getFileInfo();
+    lastSymbolDir = inf.absoluteDir().path();
     if (sym == "auto") {
       rbAutoSymbol->setChecked(true);
     } else {
@@ -351,17 +360,25 @@ void SpiceLibCompDialog::slotSelectPin()
 void SpiceLibCompDialog::slotBtnOpenLib()
 {
   QString s = QFileDialog::getOpenFileName(this, tr("Open SPICE library"),
-                                           QDir::homePath(),
+                                           lastLibDir,
                                            tr("SPICE files (*.cir +.ckt *.sp *.lib)"));
-  if (!s.isEmpty()) edtLibPath->setText(s);
+  if (!s.isEmpty()) {
+    QFileInfo inf(s);
+    lastLibDir = inf.absoluteDir().path();
+    edtLibPath->setText(s);
+  }
 }
 
 void SpiceLibCompDialog::slotBtnOpenSym()
 {
   QString s = QFileDialog::getOpenFileName(this, tr("Open symbol file"),
-                                           QDir::homePath(),
+                                           lastSymbolDir,
                                            tr("Schematic symbol (*.sym)"));
-  if (!s.isEmpty()) edtSymFile->setText(s);
+  if (!s.isEmpty()) {
+    QFileInfo inf(s);
+    lastSymbolDir = inf.absoluteDir().path();
+    edtSymFile->setText(s);
+  }
 }
 
 bool SpiceLibCompDialog::setCompProps()

--- a/qucs/extsimkernels/spicelibcompdialog.cpp
+++ b/qucs/extsimkernels/spicelibcompdialog.cpp
@@ -1,0 +1,114 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "misc.h"
+#include "component.h"
+
+#include <QLabel>
+#include <QPushButton>
+#include <QLineEdit>
+#include <QComboBox>
+#include <QTableWidget>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QFile>
+#include <QFileInfo>
+
+#include "symbolwidget.h"
+#include "spicelibcompdialog.h"
+
+
+SpiceLibCompDialog::SpiceLibCompDialog(Component *pc, QWidget* parent) : QDialog{parent}
+{
+  comp = pc;
+  QString file = comp->Props.at(0)->Value;
+  if (!file.isEmpty()) {
+    file = misc::properAbsFileName(file);
+  }
+  QString device = comp->Props.at(1)->Value;
+  QString sym = comp->Props.at(2)->Value;
+
+  QLabel *lblLibfile = new QLabel("SPICE library:");
+  edtLibPath = new QLineEdit;
+  edtLibPath->setText(file);
+  btnOpenLib = new QPushButton(tr("Open"));
+  connect(btnOpenLib,SIGNAL(clicked(bool)),this,SLOT(slotBtnOpenLib()));
+
+  QLabel *lblDevice = new QLabel("Subcircuit:");
+  cbxSelectSubcir = new QComboBox;
+
+  QLabel *lblPattern = new QLabel("Symbol pattern");
+  cbxSymPattern = new QComboBox;
+
+  symbol = new SymbolWidget;
+  symbol->setAcceptDrops(false);
+
+  tbwPinsTable = new QTableWidget;
+  tbwPinsTable->setColumnCount(2);
+  tbwPinsTable->setRowCount(100);
+  QStringList lbl_cols;
+  lbl_cols<<"Symbol pin"<<"Subcircuit pin";
+  tbwPinsTable->setHorizontalHeaderLabels(lbl_cols);
+
+  btnOK = new QPushButton(tr("OK"));
+  connect(btnOK,SIGNAL(clicked(bool)),this,SLOT(slotBtnOK()));
+  btnApply = new QPushButton(tr("Apply"));
+  connect(btnApply,SIGNAL(clicked(bool)),this,SLOT(slotBtnApply()));
+  btnCancel = new QPushButton(tr("Cancel"));
+  connect(btnCancel,SIGNAL(clicked(bool)),this,SLOT(slotBtnCancel()));
+
+  QVBoxLayout *top = new QVBoxLayout;
+  QHBoxLayout *l2 = new QHBoxLayout;
+  l2->addWidget(lblLibfile);
+  l2->addWidget(edtLibPath,4);
+  l2->addWidget(btnOpenLib,1);
+  top->addLayout(l2);
+  QHBoxLayout *l5 = new QHBoxLayout;
+  l5->addWidget(lblDevice);
+  l5->addWidget(cbxSelectSubcir);
+  top->addLayout(l5);
+  QHBoxLayout *l6 = new QHBoxLayout;
+  l6->addWidget(lblPattern);
+  l6->addWidget(cbxSymPattern);
+  top->addLayout(l6);
+  QHBoxLayout *l3 = new QHBoxLayout;
+  l3->addWidget(tbwPinsTable);
+  l3->addWidget(symbol);
+  top->addLayout(l3,3);
+  QHBoxLayout *l4 = new QHBoxLayout;
+  l4->addWidget(btnOK);
+  l4->addWidget(btnApply);
+  l4->addWidget(btnCancel);
+  l4->addStretch();
+  top->addLayout(l4);
+
+  this->setLayout(top);
+
+}
+
+void SpiceLibCompDialog::fillSubcirComboBox()
+{
+  if (!QFileInfo::exists(edtLibPath->text())) return;
+}
+
+void SpiceLibCompDialog::slotBtnOpenLib()
+{
+
+}
+
+void SpiceLibCompDialog::slotBtnApply()
+{
+
+}
+
+void SpiceLibCompDialog::slotBtnOK()
+{
+  slotBtnApply();
+  accept();
+}
+
+void SpiceLibCompDialog::slotBtnCancel()
+{
+  reject();
+}

--- a/qucs/extsimkernels/spicelibcompdialog.h
+++ b/qucs/extsimkernels/spicelibcompdialog.h
@@ -20,6 +20,7 @@ private:
 
   SymbolWidget *symbol;
   QLineEdit *edtLibPath;
+  int symbolPinsCount;
 
   QPushButton *btnOpenLib, *btnOK, *btnApply, *btnCancel;
   QTableWidget *tbwPinsTable;

--- a/qucs/extsimkernels/spicelibcompdialog.h
+++ b/qucs/extsimkernels/spicelibcompdialog.h
@@ -14,6 +14,7 @@ class Component;
 class Schematic;
 class SymbolWidget;
 class QPlainTextEdit;
+class QRadioButton;
 
 class SpiceLibCompDialog : public QDialog {
   Q_OBJECT
@@ -23,15 +24,17 @@ private:
   Schematic *Doc;
 
   SymbolWidget *symbol;
-  QLineEdit *edtLibPath, *edtParams;
+  QLineEdit *edtLibPath, *edtParams, *edtSymFile;
   QPlainTextEdit *edtSPICE;
 
   int symbolPinsCount;
   bool isChanged;
 
-  QPushButton *btnOpenLib, *btnOK, *btnApply, *btnCancel;
+  QPushButton *btnOpenLib, *btnOK, *btnApply, *btnCancel, *btnOpenSym;
   QTableWidget *tbwPinsTable;
   QComboBox *cbxSelectSubcir, *cbxSymPattern;
+
+  QRadioButton *rbSymFromTemplate, *rbAutoSymbol, *rbUserSym;
 
   QMap<QString,QStringList> subcirPins;
   QMap<QString,QString> subcirSPICE;
@@ -41,6 +44,7 @@ private:
 
 private slots:
   void slotBtnOpenLib();
+  void slotBtnOpenSym();
   void slotSetSymbol();
   void slotFillSubcirComboBox();
   void slotFillPinsTable();

--- a/qucs/extsimkernels/spicelibcompdialog.h
+++ b/qucs/extsimkernels/spicelibcompdialog.h
@@ -12,6 +12,7 @@ class QLineEdit;
 class Component;
 class Schematic;
 class SymbolWidget;
+class QPlainTextEdit;
 
 class SpiceLibCompDialog : public QDialog {
   Q_OBJECT
@@ -22,6 +23,8 @@ private:
 
   SymbolWidget *symbol;
   QLineEdit *edtLibPath, *edtParams;
+  QPlainTextEdit *edtSPICE;
+
   int symbolPinsCount;
 
   QPushButton *btnOpenLib, *btnOK, *btnApply, *btnCancel;
@@ -29,6 +32,7 @@ private:
   QComboBox *cbxSelectSubcir, *cbxSymPattern;
 
   QMap<QString,QStringList> subcirPins;
+  QMap<QString,QString> subcirSPICE;
 
   bool parseLibFile(const QString &filename);
   bool setCompProps();

--- a/qucs/extsimkernels/spicelibcompdialog.h
+++ b/qucs/extsimkernels/spicelibcompdialog.h
@@ -10,6 +10,7 @@ class QTableWidget;
 class QComboBox;
 class QLineEdit;
 class Component;
+class Schematic;
 class SymbolWidget;
 
 class SpiceLibCompDialog : public QDialog {
@@ -17,9 +18,10 @@ class SpiceLibCompDialog : public QDialog {
 
 private:
   Component *comp;
+  Schematic *Doc;
 
   SymbolWidget *symbol;
-  QLineEdit *edtLibPath;
+  QLineEdit *edtLibPath, *edtParams;
   int symbolPinsCount;
 
   QPushButton *btnOpenLib, *btnOK, *btnApply, *btnCancel;
@@ -29,6 +31,7 @@ private:
   QMap<QString,QStringList> subcirPins;
 
   bool parseLibFile(const QString &filename);
+  bool setCompProps();
 
 private slots:
   void slotBtnOpenLib();
@@ -39,7 +42,7 @@ private slots:
   void slotSelectPin();
 
 public:
-  explicit SpiceLibCompDialog(Component *pc, QWidget* parent = nullptr);
+  explicit SpiceLibCompDialog(Component *pc, Schematic *sch);
 
 public slots:
 

--- a/qucs/extsimkernels/spicelibcompdialog.h
+++ b/qucs/extsimkernels/spicelibcompdialog.h
@@ -5,16 +5,12 @@
 #include <QWidget>
 #include <QDialog>
 #include <QMap>
+#include <QtWidgets>
 
-class QPushButton;
-class QTableWidget;
-class QComboBox;
-class QLineEdit;
 class Component;
 class Schematic;
 class SymbolWidget;
-class QPlainTextEdit;
-class QRadioButton;
+
 
 class SpiceLibCompDialog : public QDialog {
   Q_OBJECT
@@ -35,6 +31,7 @@ private:
   QComboBox *cbxSelectSubcir, *cbxSymPattern;
 
   QRadioButton *rbSymFromTemplate, *rbAutoSymbol, *rbUserSym;
+  QCheckBox *chbShowLib, *chbShowModel, *chbShowParams;
 
   QMap<QString,QStringList> subcirPins;
   QMap<QString,QString> subcirSPICE;

--- a/qucs/extsimkernels/spicelibcompdialog.h
+++ b/qucs/extsimkernels/spicelibcompdialog.h
@@ -27,6 +27,7 @@ private:
   QPlainTextEdit *edtSPICE;
 
   int symbolPinsCount;
+  bool isChanged;
 
   QPushButton *btnOpenLib, *btnOK, *btnApply, *btnCancel;
   QTableWidget *tbwPinsTable;
@@ -45,6 +46,7 @@ private slots:
   void slotFillPinsTable();
   void slotTableCellDoubleClick();
   void slotSelectPin();
+  void slotChanged();
 
 public:
   explicit SpiceLibCompDialog(Component *pc, Schematic *sch);

--- a/qucs/extsimkernels/spicelibcompdialog.h
+++ b/qucs/extsimkernels/spicelibcompdialog.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QWidget>
 #include <QDialog>
+#include <QMap>
 
 class QPushButton;
 class QTableWidget;

--- a/qucs/extsimkernels/spicelibcompdialog.h
+++ b/qucs/extsimkernels/spicelibcompdialog.h
@@ -16,15 +16,17 @@ class SpiceLibCompDialog : public QDialog {
   Q_OBJECT
 
 private:
+  int symbolPinsCount;
+  bool isChanged;
+  QString lastSymbolDir;
+  QString lastLibDir;
+
   Component *comp;
   Schematic *Doc;
 
   SymbolWidget *symbol;
   QLineEdit *edtLibPath, *edtParams, *edtSymFile;
   QPlainTextEdit *edtSPICE;
-
-  int symbolPinsCount;
-  bool isChanged;
 
   QPushButton *btnOpenLib, *btnOK, *btnApply, *btnCancel, *btnOpenSym;
   QTableWidget *tbwPinsTable;

--- a/qucs/extsimkernels/spicelibcompdialog.h
+++ b/qucs/extsimkernels/spicelibcompdialog.h
@@ -35,6 +35,8 @@ private slots:
   void slotSetSymbol();
   void slotFillSubcirComboBox();
   void slotFillPinsTable();
+  void slotTableCellDoubleClick();
+  void slotSelectPin();
 
 public:
   explicit SpiceLibCompDialog(Component *pc, QWidget* parent = nullptr);

--- a/qucs/extsimkernels/spicelibcompdialog.h
+++ b/qucs/extsimkernels/spicelibcompdialog.h
@@ -1,0 +1,45 @@
+#ifndef SPICELIBCOMPDIALOG_H
+#define SPICELIBCOMPDIALOG_H
+
+#include <QObject>
+#include <QWidget>
+#include <QDialog>
+
+class QPushButton;
+class QTableWidget;
+class QComboBox;
+class QLineEdit;
+class Component;
+class SymbolWidget;
+
+class SpiceLibCompDialog : public QDialog {
+  Q_OBJECT
+
+private:
+  Component *comp;
+
+  SymbolWidget *symbol;
+  QLineEdit *edtLibPath;
+
+  QPushButton *btnOpenLib, *btnOK, *btnApply, *btnCancel;
+  QTableWidget *tbwPinsTable;
+  QComboBox *cbxSelectSubcir, *cbxSymPattern;
+
+  void fillSubcirComboBox();
+
+private slots:
+  void slotBtnOpenLib();
+
+public:
+  explicit SpiceLibCompDialog(Component *pc, QWidget* parent = nullptr);
+
+public slots:
+
+  void slotBtnOK();
+  void slotBtnApply();
+  void slotBtnCancel();
+
+signals:
+};
+
+#endif // SPICELIBCOMPDIALOG_H

--- a/qucs/extsimkernels/spicelibcompdialog.h
+++ b/qucs/extsimkernels/spicelibcompdialog.h
@@ -25,10 +25,15 @@ private:
   QTableWidget *tbwPinsTable;
   QComboBox *cbxSelectSubcir, *cbxSymPattern;
 
-  void fillSubcirComboBox();
+  QMap<QString,QStringList> subcirPins;
+
+  bool parseLibFile(const QString &filename);
 
 private slots:
   void slotBtnOpenLib();
+  void slotSetSymbol();
+  void slotFillSubcirComboBox();
+  void slotFillPinsTable();
 
 public:
   explicit SpiceLibCompDialog(Component *pc, QWidget* parent = nullptr);

--- a/qucs/misc.cpp
+++ b/qucs/misc.cpp
@@ -717,6 +717,16 @@ QString misc::unwrapExePath(const QString &exe_file)
     return abs_exe_path;
 }
 
+void misc::getSymbolPatternsList(QStringList &symbols)
+{
+  QString dir_name = QucsSettings.BinDir + "/../share/" QUCS_NAME "/symbols/";
+  QDir sym_dir(dir_name);
+  QStringList sym_files = sym_dir.entryList(QDir::Files);
+  for (const QString& file : sym_files) {
+    QFileInfo inf(file);
+    symbols.append(inf.baseName());
+  }
+}
 
 VersionTriplet::VersionTriplet(){
   major = minor = patch = 0;

--- a/qucs/misc.h
+++ b/qucs/misc.h
@@ -95,6 +95,8 @@ namespace misc {
 
   void draw_richtext(QPainter* painter, int x, int y, const QString& text, QRectF* br = nullptr);
   void draw_resize_handle(QPainter* painter, const QPointF& center);
+
+  void getSymbolPatternsList(QStringList &symbols);
 }
 
 /*! handle the application version string

--- a/qucs/module.cpp
+++ b/qucs/module.cpp
@@ -504,21 +504,12 @@ void Module::registerModules (void) {
   REGISTER_DIGITAL_1 (Verilog_File);
 
   // file components
-  REGISTER_FILE_1 (SpiceFile);
-  //if (QucsSettings.DefaultSimulator == spicecompat::simQucsator) {
-      REGISTER_FILE_3 (SParamFile, info1, info2, info);
-  //}
   REGISTER_FILE_1 (Subcircuit);
-  //if (QucsSettings.DefaultSimulator != spicecompat::simQucsator) {
-      REGISTER_FILE_1 (SpiceGeneric);
-      REGISTER_FILE_1 (SpiceLibComp);
-  //}
-
-  //if ((QucsSettings.DefaultSimulator == spicecompat::simNgspice)|| (QucsSettings.DefaultSimulator == spicecompat::simSpiceOpus)) {
-      REGISTER_FILE_1 (XspiceGeneric);
-      //REGISTER_FILE_1 (XSP_CMlib);
-      //REGISTER_FILE_1 (XSP_CodeModel);
-  //}
+  REGISTER_FILE_1 (SpiceLibComp);
+  REGISTER_FILE_1 (SpiceFile);
+  REGISTER_FILE_3 (SParamFile, info1, info2, info);
+  REGISTER_FILE_1 (SpiceGeneric);
+  REGISTER_FILE_1 (XspiceGeneric);
 
   // simulations
   REGISTER_SIMULATION_1 (DC_Sim);

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -31,6 +31,7 @@
 #include "dialogs/textboxdialog.h"
 #include "dialogs/tuner.h"
 #include "extsimkernels/customsimdialog.h"
+#include "extsimkernels/spicelibcompdialog.h"
 #include "main.h"
 #include "module.h"
 #include "node.h"
@@ -2149,7 +2150,12 @@ void MouseActions::editElement(Schematic *Doc, QMouseEvent *Event)
         if (c->Model == "GND")
             return;
 
-        if ((c->Model == ".CUSTOMSIM") || (c->Model == ".XYCESCR") || (c->Model == "INCLSCR")) {
+        if (c->Model == "SpLib") {
+          SpiceLibCompDialog *sld = new SpiceLibCompDialog(c, Doc);
+          if (sld->exec() != -1) {
+            break;
+          }
+        } else if ((c->Model == ".CUSTOMSIM") || (c->Model == ".XYCESCR") || (c->Model == "INCLSCR")) {
             CustomSimDialog *sd = new CustomSimDialog((SpiceCustomSim *) c, Doc);
             if (sd->exec() != 1)
                 break; // dialog is WDestructiveClose

--- a/qucs/spicecomponents/spicelibcomp.cpp
+++ b/qucs/spicecomponents/spicelibcomp.cpp
@@ -37,7 +37,7 @@ SpiceLibComp::SpiceLibComp()
   Simulator = spicecompat::simSpice;
 
   QStringList patterns;
-  getSymbolPatternsList(patterns);
+  misc::getSymbolPatternsList(patterns);
   QString p_str = "[auto";
   if (!patterns.isEmpty()) p_str += "," + patterns.join(",");
   p_str += "]";
@@ -226,17 +226,4 @@ QString SpiceLibComp::getSpiceModel()
     QString f = misc::properAbsFileName(Props.at(0)->Value, containingSchematic);
     QString s = QString(".INCLUDE \"%1\"\n").arg(f);
     return s;
-}
-
-
-
-void SpiceLibComp::getSymbolPatternsList(QStringList &symbols)
-{
-    QString dir_name = QucsSettings.BinDir + "/../share/" QUCS_NAME "/symbols/";
-    QDir sym_dir(dir_name);
-    QStringList sym_files = sym_dir.entryList(QDir::Files);
-    for (const QString& file : sym_files) {
-        QFileInfo inf(file);
-        symbols.append(inf.baseName());
-    }
 }

--- a/qucs/spicecomponents/spicelibcomp.cpp
+++ b/qucs/spicecomponents/spicelibcomp.cpp
@@ -84,8 +84,14 @@ Element* SpiceLibComp::info(QString& Name, char* &BitmapFile, bool getNewOne)
 void SpiceLibComp::createSymbol()
 {
   int No;
-  QString FileName = QucsSettings.BinDir;
-  FileName += QString("/../share/" QUCS_NAME "/symbols/%1.sym").arg(Props.at(2)->Value);
+  QString FileName;
+  QString symname = Props.at(2)->Value;
+  if (QFileInfo::exists(symname)) {
+    FileName = symname;
+  } else {
+    FileName  = QucsSettings.BinDir;
+    FileName += QString("/../share/" QUCS_NAME "/symbols/%1.sym").arg(Props.at(2)->Value);
+  }
 
   // Default symbol: LM358 in opamps.lib ---> opamps/LM358.sym
   QString LibName = misc::properAbsFileName(Props.at(0)->Value, containingSchematic);

--- a/qucs/spicecomponents/spicelibcomp.h
+++ b/qucs/spicecomponents/spicelibcomp.h
@@ -35,7 +35,6 @@ protected:
   void remakeSymbol(int No, QStringList &pin_names);
   int  loadSymbol(const QString&);
 private:
-  void getSymbolPatternsList(QStringList &symbols);
   void removeUnusedPorts();
 };
 

--- a/qucs/symbolwidget.cpp
+++ b/qucs/symbolwidget.cpp
@@ -48,6 +48,7 @@ SymbolWidget::SymbolWidget(QWidget *parent) : QWidget(parent)
   y1 = 0;
   y2 = 0;
   dragNDrop = true;
+  showPinNumbers = false;
   PaintText = tr("Symbol:");
   setFont(QucsSettings.font);
   QFontMetrics  metrics(QucsSettings.font, 0); // use the the screen-compatible metric
@@ -542,6 +543,9 @@ int SymbolWidget::analyseLine(const QString& Row)
     if(!getCompLineIntegers(Row, &i1, &i2, &i3))  return -1;
     Arcs.append(new struct qucs::Arc(i1-4, i2-4, 8, 8, 0, 16*360,
                                QPen(Qt::red,1)));
+    if (showPinNumbers) {
+      Texts.append(new struct Text(i1+2,i2,QString::number(i3)));
+    }
 
     if((i1-4) < x1)  x1 = i1-4;  // keep track of component boundings
     if((i1+4) > x2)  x2 = i1+4;

--- a/qucs/symbolwidget.cpp
+++ b/qucs/symbolwidget.cpp
@@ -460,6 +460,61 @@ int SymbolWidget::setSymbol( QString& SymbolString,
   return z;      // return number of ports
 }
 
+
+int SymbolWidget::loadSymFile(const QString &file)
+{
+  QString FileString;
+  QFile symfile(file);
+  if (symfile.open(QIODevice::ReadOnly)) {
+    QTextStream ts(&symfile);
+    FileString = ts.readAll();
+    symfile.close();
+  } else return -1;
+
+  Arcs.clear();
+  Lines.clear();
+  Rects.clear();
+  Ellipses.clear();
+  Texts.clear();
+  x1 = y1 = INT_MAX;
+  x2 = y2 = INT_MIN;
+
+  QString Line;
+  QTextStream stream(&FileString, QIODevice::ReadOnly);
+
+
+         // read content *************************
+  while(!stream.atEnd()) {
+    Line = stream.readLine();
+    if(Line == "<Symbol>") break;
+  }
+
+  x1 = y1 = INT_MAX;
+  x2 = y2 = INT_MIN;
+
+  int z=0, Result;
+  while(!stream.atEnd()) {
+    Line = stream.readLine();
+    if(Line == "</Symbol>") {
+      x1 -= 4;   // enlarge component boundings a little
+      x2 += 4;
+      y1 -= 4;
+      y2 += 4;
+      return z;      // return number of ports
+    }
+
+    Line = Line.trimmed();
+    if(Line.at(0) != '<') return -5;
+    if(Line.at(Line.length()-1) != '>') return -6;
+    Line = Line.mid(1, Line.length()-2); // cut off start and end character
+    Result = analyseLine(Line);
+    if(Result < 0) return -7;   // line format error
+    z += Result;
+  }
+
+  return -8;   // field not closed
+}
+
 // ---------------------------------------------------------------------
 int SymbolWidget::analyseLine(const QString& Row)
 {

--- a/qucs/symbolwidget.cpp
+++ b/qucs/symbolwidget.cpp
@@ -49,6 +49,7 @@ SymbolWidget::SymbolWidget(QWidget *parent) : QWidget(parent)
   y2 = 0;
   dragNDrop = true;
   showPinNumbers = false;
+  portsNumber = 0;
   PaintText = tr("Symbol:");
   setFont(QucsSettings.font);
   QFontMetrics  metrics(QucsSettings.font, 0); // use the the screen-compatible metric
@@ -421,6 +422,7 @@ int SymbolWidget::setSymbol( QString& SymbolString,
   Texts.clear();
   LibraryPath = Lib_;
   ComponentName = Comp_;
+  portsNumber = 0;
 
   QString Line;
   ///QString foo = SymbolString;
@@ -479,6 +481,7 @@ int SymbolWidget::loadSymFile(const QString &file)
   Ellipses.clear();
   Texts.clear();
   Warning.clear();
+  portsNumber = 0;
   x1 = y1 = INT_MAX;
   x2 = y2 = INT_MIN;
 
@@ -552,6 +555,7 @@ int SymbolWidget::analyseLine(const QString& Row)
     if((i1+4) > x2)  x2 = i1+4;
     if((i2-4) < y1)  y1 = i2-4;
     if((i2+4) > y2)  y2 = i2+4;
+    portsNumber++;
     return 0;   // do not count Ports
   }
   else if(s == "Line") {

--- a/qucs/symbolwidget.cpp
+++ b/qucs/symbolwidget.cpp
@@ -26,6 +26,7 @@
 #include "main.h"
 #include "qucslib_common.h"
 #include "misc.h"
+#include "main.h"
 
 /*!
  * \file symbolwidget.cpp
@@ -500,6 +501,18 @@ int SymbolWidget::loadSymFile(const QString &file)
       x2 += 4;
       y1 -= 4;
       y2 += 4;
+      cx  = -x1 + TextWidth;
+      cy  = -y1;
+
+      int dx = x2-x1 + TextWidth;
+      if((x2-x1) < DragNDropWidth)
+        dx = (x2-x1 + DragNDropWidth)/2 + TextWidth;
+      if(dx < DragNDropWidth)
+        dx = DragNDropWidth;
+      setMinimumSize(dx, y2-y1 + TextHeight+4);
+      if(width() > dx)  dx = width();
+      resize(dx, y2-y1 + TextHeight+4);
+      update();
       return z;      // return number of ports
     }
 

--- a/qucs/symbolwidget.cpp
+++ b/qucs/symbolwidget.cpp
@@ -478,6 +478,7 @@ int SymbolWidget::loadSymFile(const QString &file)
   Rects.clear();
   Ellipses.clear();
   Texts.clear();
+  Warning.clear();
   x1 = y1 = INT_MAX;
   x2 = y2 = INT_MIN;
 

--- a/qucs/symbolwidget.h
+++ b/qucs/symbolwidget.h
@@ -47,6 +47,7 @@ public:
 
   QString theModel();
   int setSymbol( QString&, const QString&, const QString&);
+  int loadSymFile(const QString &file);
   void enableDragNDrop();
   void disableDragNDrop();
   bool dragNDropEnabled() { return dragNDrop; }

--- a/qucs/symbolwidget.h
+++ b/qucs/symbolwidget.h
@@ -54,6 +54,7 @@ public:
   void enableShowPinNumbers() { showPinNumbers = true; }
   void disableShowPinNumbers() { showPinNumbers = false; }
   bool showPinNumbersEnabled() { return showPinNumbers; }
+  int getPortsNumber() { return portsNumber; }
   // component properties
   int Text_x, Text_y;
   QString Prefix, LibraryPath, ComponentName;
@@ -75,6 +76,7 @@ private:
 
   bool dragNDrop;
   bool showPinNumbers;
+  int portsNumber;
   QString PaintText;
   QString DragNDropText;
   QString Warning;

--- a/qucs/symbolwidget.h
+++ b/qucs/symbolwidget.h
@@ -51,6 +51,9 @@ public:
   void enableDragNDrop();
   void disableDragNDrop();
   bool dragNDropEnabled() { return dragNDrop; }
+  void enableShowPinNumbers() { showPinNumbers = true; }
+  void disableShowPinNumbers() { showPinNumbers = false; }
+  bool showPinNumbersEnabled() { return showPinNumbers; }
   // component properties
   int Text_x, Text_y;
   QString Prefix, LibraryPath, ComponentName;
@@ -71,6 +74,7 @@ private:
   bool getBrush(const QString&, QBrush&, int);
 
   bool dragNDrop;
+  bool showPinNumbers;
   QString PaintText;
   QString DragNDropText;
   QString Warning;


### PR DESCRIPTION
This PR contains a redesign of  the SpiceLibComp as discussed in #679.  The following features are implemented:

* Custom dialog for SpiceLibComp
* Custom pin assignment using pin table
* Symbol preview
* SPICE code preview

Here is a screenshot illustrating a new custom dialog:
![image](https://github.com/ra3xdh/qucs_s/assets/4920080/cee78a7c-0740-4f88-884f-cb83caf850ff)

Here is a video illustrating pins assignment process:

[Screencast_20240612_191828.webm](https://github.com/ra3xdh/qucs_s/assets/4920080/39cd7c9b-1dae-4f39-8113-531942bad5cb)

