### PR TITLE
Fix labels of SPICE netlist sections being rendered too small on some devices

### DIFF
--- a/qucs/components/equation.cpp
+++ b/qucs/components/equation.cpp
@@ -19,6 +19,7 @@
 #include "extsimkernels/spicecompat.h"
 #include "extsimkernels/verilogawriter.h"
 
+#include <QFontInfo>
 #include <QFontMetrics>
 
 Equation::Equation()
@@ -38,7 +39,7 @@ Equation::Equation()
   Lines.append(new qucs::Line(-xb, -yb, -xb,  yb,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-xb,  yb,  xb+3,yb,QPen(Qt::darkBlue,2)));
   Texts.append(new Text(-xb+4,  -yb-3, QObject::tr("Equation"),
-			QColor(0,0,0), 12.0));
+			QColor(0,0,0), QFontInfo(f).pixelSize()));
 
   x1 = -xb-3;  y1 = -yb-5;
   x2 =  xb+9; y2 =  yb+3;

--- a/qucs/spicecomponents/incl_script.cpp
+++ b/qucs/spicecomponents/incl_script.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 #include "incl_script.h"
 #include "main.h"
+#include <QFontInfo>
 #include <QFontMetrics>
 
 
@@ -37,7 +38,7 @@ InclScript::InclScript()
     Lines.append(new qucs::Line(-xb, -yb, -xb,  yb,QPen(Qt::darkRed,2)));
     Lines.append(new qucs::Line(-xb,  yb,  xb+3,yb,QPen(Qt::darkRed,2)));
     Texts.append(new Text(-xb+4,  -yb-3, QObject::tr(".INCLUDE SCRIPT"),
-                          QColor(0,0,0), 12.0));
+                          QColor(0,0,0), QFontInfo(f).pixelSize()));
 
     x1 = -xb-3;  y1 = -yb-5;
     x2 =  xb+9; y2 =  yb+3;

--- a/qucs/spicecomponents/sp_func.cpp
+++ b/qucs/spicecomponents/sp_func.cpp
@@ -17,6 +17,7 @@
 #include "sp_func.h"
 #include "main.h"
 
+#include <QFontInfo>
 #include <QFontMetrics>
 
 SpiceFunc::SpiceFunc()
@@ -37,7 +38,7 @@ SpiceFunc::SpiceFunc()
   Lines.append(new qucs::Line(-xb, -yb, -xb,  yb,QPen(Qt::darkRed,2)));
   Lines.append(new qucs::Line(-xb,  yb,  xb+3,yb,QPen(Qt::darkRed,2)));
   Texts.append(new Text(-xb+4,  -yb-3, QObject::tr(".FUNC"),
-			QColor(0,0,0), 12.0));
+			QColor(0,0,0), QFontInfo(f).pixelSize()));
 
   x1 = -xb-3;  y1 = -yb-5;
   x2 =  xb+9; y2 =  yb+3;

--- a/qucs/spicecomponents/sp_globalpar.cpp
+++ b/qucs/spicecomponents/sp_globalpar.cpp
@@ -17,6 +17,7 @@
 #include "sp_globalpar.h"
 #include "main.h"
 
+#include <QFontInfo>
 #include <QFontMetrics>
 
 SpiceGlobalParam::SpiceGlobalParam()
@@ -37,7 +38,7 @@ SpiceGlobalParam::SpiceGlobalParam()
   Lines.append(new qucs::Line(-xb, -yb, -xb,  yb,QPen(Qt::darkRed,2)));
   Lines.append(new qucs::Line(-xb,  yb,  xb+3,yb,QPen(Qt::darkRed,2)));
   Texts.append(new Text(-xb+4,  -yb-3, QObject::tr(".GLOBAL PARAM"),
-			QColor(0,0,0), 12.0));
+			QColor(0,0,0), QFontInfo(f).pixelSize()));
 
   x1 = -xb-3;  y1 = -yb-5;
   x2 =  xb+9; y2 =  yb+3;

--- a/qucs/spicecomponents/sp_ic.cpp
+++ b/qucs/spicecomponents/sp_ic.cpp
@@ -17,6 +17,7 @@
 #include "sp_ic.h"
 #include "main.h"
 
+#include <QFontInfo>
 #include <QFontMetrics>
 
 SpiceIC::SpiceIC()
@@ -37,7 +38,7 @@ SpiceIC::SpiceIC()
   Lines.append(new qucs::Line(-xb, -yb, -xb,  yb,QPen(Qt::darkRed,2)));
   Lines.append(new qucs::Line(-xb,  yb,  xb+3,yb,QPen(Qt::darkRed,2)));
   Texts.append(new Text(-xb+4,  -yb-3, QObject::tr(".IC"),
-			QColor(0,0,0), 12.0));
+			QColor(0,0,0), QFontInfo(f).pixelSize()));
 
   x1 = -xb-3;  y1 = -yb-5;
   x2 =  xb+9; y2 =  yb+3;

--- a/qucs/spicecomponents/sp_include.cpp
+++ b/qucs/spicecomponents/sp_include.cpp
@@ -18,6 +18,7 @@
 #include "main.h"
 #include "misc.h"
 
+#include <QFontInfo>
 #include <QFontMetrics>
 
 S4Q_Include::S4Q_Include()
@@ -38,7 +39,7 @@ S4Q_Include::S4Q_Include()
   Lines.append(new qucs::Line(-xb, -yb, -xb,  yb,QPen(Qt::darkRed,2)));
   Lines.append(new qucs::Line(-xb,  yb,  xb+3,yb,QPen(Qt::darkRed,2)));
   Texts.append(new Text(-xb+4,  -yb-3, QObject::tr(".INCLUDE"),
-			QColor(0,0,0), 12.0));
+			QColor(0,0,0), QFontInfo(f).pixelSize()));
 
   x1 = -xb-3;  y1 = -yb-5;
   x2 =  xb+9; y2 =  yb+3;

--- a/qucs/spicecomponents/sp_lib.cpp
+++ b/qucs/spicecomponents/sp_lib.cpp
@@ -17,6 +17,7 @@
 #include "sp_lib.h"
 #include "main.h"
 #include "misc.h"
+#include <QFontInfo>
 #include <QFontMetrics>
 
 S4Q_Lib::S4Q_Lib()
@@ -37,7 +38,7 @@ S4Q_Lib::S4Q_Lib()
   Lines.append(new qucs::Line(-xb, -yb, -xb,  yb,QPen(Qt::darkRed,2)));
   Lines.append(new qucs::Line(-xb,  yb,  xb+3,yb,QPen(Qt::darkRed,2)));
   Texts.append(new Text(-xb+4,  -yb-3, QObject::tr(".LIB"),
-			QColor(0,0,0), 12.0));
+			QColor(0,0,0), QFontInfo(f).pixelSize()));
 
   x1 = -xb-3;  y1 = -yb-5;
   x2 =  xb+9; y2 =  yb+3;

--- a/qucs/spicecomponents/sp_model.cpp
+++ b/qucs/spicecomponents/sp_model.cpp
@@ -17,6 +17,7 @@
 #include "sp_model.h"
 #include "main.h"
 
+#include <QFontInfo>
 #include <QFontMetrics>
 
 S4Q_Model::S4Q_Model()
@@ -39,7 +40,7 @@ S4Q_Model::S4Q_Model()
   Lines.append(new qucs::Line(-xb, -yb, -xb,  yb,QPen(Qt::darkRed,2)));
   Lines.append(new qucs::Line(-xb,  yb,  xb+3,yb,QPen(Qt::darkRed,2)));
   Texts.append(new Text(-xb+4,  -yb-3, QObject::tr(".MODEL"),
-			QColor(0,0,0), 12.0));
+			QColor(0,0,0), QFontInfo(f).pixelSize()));
 
   x1 = -xb-3;  y1 = -yb-5;
   x2 =  xb+9; y2 =  yb+3;

--- a/qucs/spicecomponents/sp_nodeset.cpp
+++ b/qucs/spicecomponents/sp_nodeset.cpp
@@ -17,6 +17,7 @@
 #include "sp_nodeset.h"
 #include "main.h"
 
+#include <QFontInfo>
 #include <QFontMetrics>
 
 SpiceNodeset::SpiceNodeset()
@@ -37,7 +38,7 @@ SpiceNodeset::SpiceNodeset()
   Lines.append(new qucs::Line(-xb, -yb, -xb,  yb,QPen(Qt::darkRed,2)));
   Lines.append(new qucs::Line(-xb,  yb,  xb+3,yb,QPen(Qt::darkRed,2)));
   Texts.append(new Text(-xb+4,  -yb-3, QObject::tr(".NODESET"),
-			QColor(0,0,0), 12.0));
+			QColor(0,0,0), QFontInfo(f).pixelSize()));
 
   x1 = -xb-3;  y1 = -yb-5;
   x2 =  xb+9; y2 =  yb+3;

--- a/qucs/spicecomponents/sp_nutmeg.cpp
+++ b/qucs/spicecomponents/sp_nutmeg.cpp
@@ -17,6 +17,7 @@
 #include "sp_nutmeg.h"
 #include "main.h"
 
+#include <QFontInfo>
 #include <QFontMetrics>
 #include <QRegularExpression>
 
@@ -38,7 +39,7 @@ NutmegEquation::NutmegEquation()
   Lines.append(new qucs::Line(-xb, -yb, -xb,  yb,QPen(Qt::blue,2)));
   Lines.append(new qucs::Line(-xb,  yb,  xb+3,yb,QPen(Qt::blue,2)));
   Texts.append(new Text(-xb+4,  -yb-3, QObject::tr("Nutmeg"),
-			QColor(0,0,0), 12.0));
+			QColor(0,0,0), QFontInfo(f).pixelSize()));
 
   x1 = -xb-3;  y1 = -yb-5;
   x2 =  xb+9; y2 =  yb+3;

--- a/qucs/spicecomponents/sp_options.cpp
+++ b/qucs/spicecomponents/sp_options.cpp
@@ -17,6 +17,7 @@
 #include "sp_options.h"
 #include "main.h"
 
+#include <QFontInfo>
 #include <QFontMetrics>
 
 SpiceOptions::SpiceOptions()
@@ -37,7 +38,7 @@ SpiceOptions::SpiceOptions()
   Lines.append(new qucs::Line(-xb, -yb, -xb,  yb,QPen(Qt::darkRed,2)));
   Lines.append(new qucs::Line(-xb,  yb,  xb+3,yb,QPen(Qt::darkRed,2)));
   Texts.append(new Text(-xb+4,  -yb-3, QObject::tr(".OPTIONS"),
-			QColor(0,0,0), 12.0));
+			QColor(0,0,0), QFontInfo(f).pixelSize()));
 
   x1 = -xb-3;  y1 = -yb-5;
   x2 =  xb+9; y2 =  yb+3;

--- a/qucs/spicecomponents/sp_parameter.cpp
+++ b/qucs/spicecomponents/sp_parameter.cpp
@@ -17,6 +17,7 @@
 #include "sp_parameter.h"
 #include "main.h"
 
+#include <QFontInfo>
 #include <QFontMetrics>
 
 SpiceParam::SpiceParam()
@@ -37,7 +38,7 @@ SpiceParam::SpiceParam()
   Lines.append(new qucs::Line(-xb, -yb, -xb,  yb,QPen(Qt::darkRed,2)));
   Lines.append(new qucs::Line(-xb,  yb,  xb+3,yb,QPen(Qt::darkRed,2)));
   Texts.append(new Text(-xb+4,  -yb-3, QObject::tr(".PARAM"),
-			QColor(0,0,0), 12.0));
+			QColor(0,0,0), QFontInfo(f).pixelSize()));
 
   x1 = -xb-3;  y1 = -yb-5;
   x2 =  xb+9; y2 =  yb+3;

--- a/qucs/spicecomponents/sp_spiceinit.cpp
+++ b/qucs/spicecomponents/sp_spiceinit.cpp
@@ -14,6 +14,7 @@
 #include "sp_spiceinit.h"
 #include "main.h"
 
+#include <QFontInfo>
 #include <QFontMetrics>
 
 SpiceSpiceinit::SpiceSpiceinit()
@@ -33,7 +34,7 @@ SpiceSpiceinit::SpiceSpiceinit()
 
   Lines.append(new qucs::Line(-xb, -yb, -xb,  yb,QPen(Qt::darkRed,2)));
   Lines.append(new qucs::Line(-xb,  yb,  xb+3,yb,QPen(Qt::darkRed,2)));
-  Texts.append(new Text(-xb+4,  -yb-3, QObject::tr(".spiceinit"), QColor(0,0,0), 12.0));
+  Texts.append(new Text(-xb+4,  -yb-3, QObject::tr(".spiceinit"), QColor(0,0,0), QFontInfo(f).pixelSize()));
 
   x1 = -xb-3;  y1 = -yb-5;
   x2 =  xb+9; y2 =  yb+3;


### PR DESCRIPTION
Hi!

On some devices the labels of SPICE components like .PARAM, .Nutmeg, etc. were rendered too small comparing to other parts of the component (see [this comment](https://github.com/ra3xdh/qucs_s/pull/723#issuecomment-2131211265) for example). With this PR merged, they would be rendered in appropriate size on all devices.

I've checked this on two machines having 227 PPI and 117 PPI displays respectively: labels have propers sizes on both of them.