### PR TITLE
Qucs Filter - Fix quarter wavelength coupled filter implementation

### DIFF
--- a/qucs-filter/filter.cpp
+++ b/qucs-filter/filter.cpp
@@ -415,6 +415,30 @@ QString Filter::getMS_Via(double height, int x, int y, int rotate)
     return code;
 }
 
+QString Filter::getMS_Open(double width, int x, int y, int rotate)
+{
+    QString code;
+    switch (rotate)
+    {
+        case 0: // No rotation
+            code = QString("<MOPEN MS93 1 %1 %2 -20 -50 0 0 \"Sub1\" 0 \"%3 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x).arg(y).arg(QString::number(width*1e3, 'f', 2));
+            break;
+
+        case 1: // CTRL+R
+            code = QString("<MOPEN MS93 1 %1 %2 15 -12 0 1 \"Sub1\" 0 \"%3 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x).arg(y).arg(QString::number(width*1e3, 'f', 2));
+            break;
+
+        case 2: // 2 x (CTRL+R)
+            code = QString("<MOPEN MS93 1 %1 %2 -20 -50 0 2 \"Sub1\" 0 \"%3 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x).arg(y).arg(QString::number(width*1e3, 'f', 2));
+            break;
+
+        case 3: // 3 x (CTRL+R)
+            code = QString("<MOPEN MS93 1 %1 %2 15 -20 0 3 \"Sub1\" 0 \"%3 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x).arg(y).arg(QString::number(width*1e3, 'f', 2));
+            break;
+    }
+    return code;
+}
+
 QString Filter::getWireString(int x1, int y1, int x2, int y2)
 {
   return QString("<%1 %2 %3 %4 \"\" 0 0 0>\n").arg(x1).arg(y1).arg(x2).arg(y2);

--- a/qucs-filter/filter.cpp
+++ b/qucs-filter/filter.cpp
@@ -391,11 +391,34 @@ QString Filter::getLineString(bool isMicrostrip, double width_or_impedance, doub
   return code;
 }
 
+QString Filter::getMS_Via(double height, int x, int y, int rotate)
+{
+    QString code;
+    switch (rotate)
+    {
+        case 0: // No rotation
+            code = QString("<MVIA MS31 1 %1 %2 20 -10 0 0 \"Sub1\" 0 \"%3 mm\" 1 \"26.85\" 0>\n").arg(x).arg(y).arg(height);
+            break;
+
+        case 1: // CTRL+R
+            code = QString("<MVIA MS31 1 %1 %2 40 -20 0 1 \"Sub1\" 0 \"%3 mm\" 1 \"26.85\" 0>\n").arg(x).arg(y).arg(height);
+            break;
+
+        case 2: // 2 x (CTRL+R)
+            code = QString("<MVIA MS31 1 %1 %2 -85 -40 0 2 \"Sub1\" 0 \"%3 mm\" 1 \"26.85\" 0>\n").arg(x).arg(y).arg(height);
+            break;
+
+        case 3: // 3 x (CTRL+R)
+            code = QString("<MVIA MS31 1 %1 %2 -90 -20 0 3 \"Sub1\" 0 \"%3 mm\" 1 \"26.85\" 0>\n").arg(x).arg(y).arg(height);
+            break;
+    }
+    return code;
+}
+
 QString Filter::getWireString(int x1, int y1, int x2, int y2)
 {
   return QString("<%1 %2 %3 %4 \"\" 0 0 0>\n").arg(x1).arg(y1).arg(x2).arg(y2);
 }
-
 QString Filter::getTeeString(int x, int y, double width1, double width2, double width3)
 {
   return QString("<MTEE MS1 1 %1 %2 -26 20 1 0 \"Sub1\" 0 \"%3mm\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")

--- a/qucs-filter/filter.cpp
+++ b/qucs-filter/filter.cpp
@@ -355,16 +355,40 @@ double Filter::quadraticChebyshevValues(int No, int Order, double Ripple, double
 
 QString Filter::getLineString(bool isMicrostrip, double width_or_impedance, double l, int x, int y, int rotate)
 {
+  QString code;
+  double text_x, text_y; // Coordinates for the text. They change with the rotation
   if (isMicrostrip)
   {
-     return QString("<MLIN MS1 1 %1 %2 26 -30 0 %3 \"Sub1\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
-               .arg(x).arg(y).arg(rotate).arg(width_or_impedance*1000).arg(l*1000);
+     if (rotate)
+     {
+         text_x = 20;
+         text_y = -25;
+     }
+     else
+     {
+         text_x = -30;
+         text_y = -70;
+     }
+     code = QString("<MLIN MS1 1 %1 %2 %3 %4 0 %5 \"Sub1\" 0 \"%6 mm\" 1 \"%7 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
+              .arg(x).arg(y).arg(text_x).arg(text_y).arg(rotate)
+              .arg(QString::number(width_or_impedance*1e3, 'f', 2)).arg(QString::number(l*1e3, 'f', 2));
   }
   else
   {
-     return QString("<TLIN Line1 1 %1 %2 -26 20 0 %3 \"%4\" 1 \"%5\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
-            .arg(x).arg(y).arg(rotate).arg(width_or_impedance).arg(l);
+      if (rotate)
+      {
+          text_x = 10;
+          text_y = -25;
+      }
+      else
+      {
+          text_x = -30;
+          text_y = -60;
+      }
+     code =  QString("<TLIN Line1 1 %1 %2 %3 %4 0 %5 \"%6 Ohm\" 1 \"%7 mm\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
+            .arg(x).arg(y).arg(text_x).arg(text_y).arg(rotate).arg(QString::number(width_or_impedance, 'f', 1)).arg(QString::number(l*1e3, 'f', 2));
   }
+  return code;
 }
 
 QString Filter::getWireString(int x1, int y1, int x2, int y2)
@@ -374,6 +398,6 @@ QString Filter::getWireString(int x1, int y1, int x2, int y2)
 
 QString Filter::getTeeString(int x, int y, double width1, double width2, double width3)
 {
-  return QString("<MTEE MS1 1 %1 %2 -26 20 1 0 \"Sub1\" 1 \"%3mm\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
-    .arg(x).arg(y).arg(width1*1000).arg(width2*1000).arg(width3*1000);
+  return QString("<MTEE MS1 1 %1 %2 -26 20 1 0 \"Sub1\" 0 \"%3mm\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
+        .arg(x).arg(y).arg(QString::number(width1*1e3, 'f', 2)).arg(QString::number(width2*1e3, 'f', 2)).arg(QString::number(width3*1e3, 'f', 2));
 }

--- a/qucs-filter/filter.cpp
+++ b/qucs-filter/filter.cpp
@@ -350,3 +350,30 @@ double Filter::quadraticChebyshevValues(int No, int Order, double Ripple, double
   a *= 2.0 * b * sinh(c);
   return a;
 }
+
+// SCHEMATIC DRAWING FUNCTIONS
+
+QString Filter::getLineString(bool isMicrostrip, double width_or_impedance, double l, int x, int y, int rotate)
+{
+  if (isMicrostrip)
+  {
+     return QString("<MLIN MS1 1 %1 %2 26 -30 0 %3 \"Sub1\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
+               .arg(x).arg(y).arg(rotate).arg(width_or_impedance*1000).arg(l*1000);
+  }
+  else
+  {
+     return QString("<TLIN Line1 1 %1 %2 -26 20 0 %3 \"%4\" 1 \"%5\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
+            .arg(x).arg(y).arg(rotate).arg(width_or_impedance).arg(l);
+  }
+}
+
+QString Filter::getWireString(int x1, int y1, int x2, int y2)
+{
+  return QString("<%1 %2 %3 %4 \"\" 0 0 0>\n").arg(x1).arg(y1).arg(x2).arg(y2);
+}
+
+QString Filter::getTeeString(int x, int y, double width1, double width2, double width3)
+{
+  return QString("<MTEE MS1 1 %1 %2 -26 20 1 0 \"Sub1\" 1 \"%3mm\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
+    .arg(x).arg(y).arg(width1*1000).arg(width2*1000).arg(width3*1000);
+}

--- a/qucs-filter/filter.h
+++ b/qucs-filter/filter.h
@@ -65,6 +65,10 @@ public:
   static double getNormValue(int, tFilter*);
   static double getQuadraticNormValues(int, tFilter*, double&);
 
+  static QString getLineString(bool isMicrostrip, double width_or_impedance, double l, int x, int y, int rotate=0);
+  static QString getTeeString(int x, int y, double width1, double width2, double width3);
+  static QString getWireString(int x1, int x2, int x3, int x4);
+
 protected:
   static QString num2str(double);
   static double getE6value(double);

--- a/qucs-filter/filter.h
+++ b/qucs-filter/filter.h
@@ -70,6 +70,8 @@ public:
   static QString getTeeString(int x, int y, double width1, double width2, double width3);
   static QString getWireString(int x1, int x2, int x3, int x4);
   static QString getMS_Via(double height, int x, int y, int rotate);
+  static QString getMS_Open(double width, int x, int y, int rotate);
+
 
 protected:
   static QString num2str(double);

--- a/qucs-filter/filter.h
+++ b/qucs-filter/filter.h
@@ -65,9 +65,11 @@ public:
   static double getNormValue(int, tFilter*);
   static double getQuadraticNormValues(int, tFilter*, double&);
 
+  // Component wrappers
   static QString getLineString(bool isMicrostrip, double width_or_impedance, double l, int x, int y, int rotate=0);
   static QString getTeeString(int x, int y, double width1, double width2, double width3);
   static QString getWireString(int x1, int x2, int x3, int x4);
+  static QString getMS_Via(double height, int x, int y, int rotate);
 
 protected:
   static QString num2str(double);

--- a/qucs-filter/quarterwave_filter.cpp
+++ b/qucs-filter/quarterwave_filter.cpp
@@ -92,7 +92,7 @@ QString *QuarterWave_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
 
           c_s += getLineString(isMicrostrip, W_line, L_line, x, 180, 0); // Series line
           c_s += getTeeString(x+ 60 + x_space, 180, W_line, W_line, W_res);
-          c_s += getLineString(isMicrostrip, W_res, L_res, x+60 + x_space, 60, 3); // Shunt quarter-wavelength resonator
+          c_s += getLineString(isMicrostrip, W_res, L_res, x+60 + x_space, 60, 1); // Shunt quarter-wavelength resonator
 
           w_s += getWireString(x+30, 180, x+30+x_space, 180);
           w_s += getWireString(x+60 + x_space, 90, x+60 + x_space, 150);

--- a/qucs-filter/quarterwave_filter.cpp
+++ b/qucs-filter/quarterwave_filter.cpp
@@ -42,16 +42,14 @@ QString QuarterWave_Filter::getLineString(bool isMicrostrip, double width_or_imp
 {
   if (isMicrostrip)
   {
-    if (rotate == 3)
-      return QString("<MLIN MS1 1 %1 %2 26 -30 0 %3 \"Sub1\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
-        .arg(x).arg(y).arg(rotate).arg(width_or_impedance*1000).arg(l*1000);
-
-    return QString("<MLIN MS1 1 %1 %2 -26 20 0 %3 \"Sub1\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
-      .arg(x).arg(y).arg(rotate).arg(width_or_impedance*1000).arg(l*1000);
+     return QString("<MLIN MS1 1 %1 %2 26 -30 0 %3 \"Sub1\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
+               .arg(x).arg(y).arg(rotate).arg(width_or_impedance*1000).arg(l*1000);
   }
   else
-      return QString("<TLIN Line1 1 %1 %2 -26 20 0 0 \"%3\" 1 \"%4\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
-        .arg(x).arg(y).arg(width_or_impedance).arg(l);
+  {
+     return QString("<TLIN Line1 1 %1 %2 -26 20 0 %3 \"%4\" 1 \"%5\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
+            .arg(x).arg(y).arg(rotate).arg(width_or_impedance).arg(l);
+  }
 }
 
 double QuarterWave_Filter::getZ(tFilter *Filter, int order, bool is_shunt)
@@ -125,10 +123,10 @@ QString *QuarterWave_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
       double width1 = getMicrostripWidth(Filter, Substrate, i);
       double width2 = getMicrostripWidth(Filter, Substrate, i+1);
       double width3 = getMicrostripWidth(Filter, Substrate, i, true);
-      c_s += getLineString(isMicrostrip, width1, d_lamdba4 - width3 / 2 - previous_width3 / 2, x, 180);
+      c_s += getLineString(isMicrostrip, width1, d_lamdba4 - width3 / 2 - previous_width3 / 2, x, 180, 0); // Series line
       c_s += getTeeString(x+ 60 + x_space, 180, width1, width2, width3);
       double max_width = width1 >= width2 ? width1 : width2;
-      c_s += getLineString(isMicrostrip, width3, d_lamdba4 - max_width/2, x+60 + x_space, 60, 3);
+      c_s += getLineString(isMicrostrip, width3, d_lamdba4 - max_width/2, x+60 + x_space, 60, 3); // Shunt quarter-wavelength resonator
 
       w_s += getWireString(x+30, 180, x+30+x_space, 180);
       w_s += getWireString(x+60 + x_space, 90, x+60 + x_space, 150);
@@ -151,8 +149,8 @@ QString *QuarterWave_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
             Z = (pi*Z0*bw)/(4*getNormValue(i, Filter)); // Bandpass
       else
             Z = (4*Z0)/(pi*bw*getNormValue(i, Filter)); // Bandstop
-      c_s += getLineString(isMicrostrip, Z0, d_lamdba4, x, 180);
-      c_s += getLineString(isMicrostrip, Z, d_lamdba4,  x+80, 60);
+      c_s += getLineString(isMicrostrip, Z0, d_lamdba4, x, 180, 0); // Series transmission line
+      c_s += getLineString(isMicrostrip, Z, d_lamdba4,  x+80, 60, 0); // Shunt quarter-wavelength resonator
       w_s += getWireString(x+30, 180, x+60, 180);
       w_s += getWireString(x+50, 60, x+50, 180);
       if (Filter->Class == CLASS_BANDPASS)

--- a/qucs-filter/quarterwave_filter.cpp
+++ b/qucs-filter/quarterwave_filter.cpp
@@ -1,7 +1,7 @@
 /*
  * quarterwave_filter.cpp - Quarter wavelength filter implementation
  *
- * copyright (C) 2015 Andres Martinez-Mera <andresmartinezmera@gmail.com>
+ * copyright (C) 2015, 2024 Andres Martinez-Mera <andresmartinezmera@gmail.com>
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/qucs-filter/quarterwave_filter.cpp
+++ b/qucs-filter/quarterwave_filter.cpp
@@ -92,7 +92,11 @@ QString *QuarterWave_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
 
           c_s += getLineString(isMicrostrip, W_line, L_line, x, 180, 0); // Series line
           c_s += getTeeString(x+ 60 + x_space, 180, W_line, W_line, W_res);
-          c_s += getLineString(isMicrostrip, W_res, L_res, x+60 + x_space, 60, 1); // Shunt quarter-wavelength resonator
+          c_s += getLineString(isMicrostrip, W_res, L_res, x + 60 + x_space, 60, 1); // Shunt quarter-wavelength resonator
+
+          if (Filter->Class == CLASS_BANDSTOP){// If MS bandstop, add MOPEN
+              c_s += getMS_Open(W_res, x + 60 + x_space, 0, 1); // MS open
+          }
 
           w_s += getWireString(x+30, 180, x+30+x_space, 180);
           w_s += getWireString(x+60 + x_space, 90, x+60 + x_space, 150);
@@ -106,14 +110,15 @@ QString *QuarterWave_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
           w_s += getWireString(x+30, 180, x+90+2*x_space, 180);// Join series lines
           w_s += getWireString(x+60 + x_space, 90, x+60 + x_space, 180); // Join middle point with the stub
       }
-      if (Filter->Class == CLASS_BANDPASS) // If bandpass, shunt resonators
+      if (Filter->Class == CLASS_BANDPASS){
+          // If bandpass, shunt resonators
           if (isMicrostrip){
               c_s += getMS_Via(0.5, x+40 + x_space, 30, 2); // MS via diameter = 0.5 mm
           }
           else{
               c_s += QString("<GND * 1 %1 30 0 0 1 0>\n").arg(x + 60 + x_space);
           }
-
+      }
 
     x += 120 + 2 * x_space;
   }

--- a/qucs-filter/quarterwave_filter.cpp
+++ b/qucs-filter/quarterwave_filter.cpp
@@ -38,31 +38,6 @@ QuarterWave_Filter::QuarterWave_Filter()
 {
 }
 
-QString QuarterWave_Filter::getLineString(bool isMicrostrip, double width_or_impedance, double l, int x, int y, int rotate)
-{
-  if (isMicrostrip)
-  {
-     return QString("<MLIN MS1 1 %1 %2 26 -30 0 %3 \"Sub1\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
-               .arg(x).arg(y).arg(rotate).arg(width_or_impedance*1000).arg(l*1000);
-  }
-  else
-  {
-     return QString("<TLIN Line1 1 %1 %2 -26 20 0 %3 \"%4\" 1 \"%5\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
-            .arg(x).arg(y).arg(rotate).arg(width_or_impedance).arg(l);
-  }
-}
-
-QString QuarterWave_Filter::getWireString(int x1, int y1, int x2, int y2)
-{
-  return QString("<%1 %2 %3 %4 \"\" 0 0 0>\n").arg(x1).arg(y1).arg(x2).arg(y2);
-}
-
-QString QuarterWave_Filter::getTeeString(int x, int y, double width1, double width2, double width3)
-{
-  return QString("<MTEE MS1 1 %1 %2 -26 20 1 0 \"Sub1\" 1 \"%3mm\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
-    .arg(x).arg(y).arg(width1*1000).arg(width2*1000).arg(width3*1000);
-}
-
 // -----------------------------------------------------------------------
 QString *QuarterWave_Filter::createSchematic(tFilter *Filter, tSubstrate *Substrate, bool isMicrostrip)
 {

--- a/qucs-filter/quarterwave_filter.cpp
+++ b/qucs-filter/quarterwave_filter.cpp
@@ -45,7 +45,7 @@ QString QuarterWave_Filter::getLineString(bool isMicrostrip, double width_or_imp
     if (rotate == 3)
       return QString("<MLIN MS1 1 %1 %2 26 -30 0 %3 \"Sub1\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
         .arg(x).arg(y).arg(rotate).arg(width_or_impedance*1000).arg(l*1000);
-    
+
     return QString("<MLIN MS1 1 %1 %2 -26 20 0 %3 \"Sub1\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
       .arg(x).arg(y).arg(rotate).arg(width_or_impedance*1000).arg(l*1000);
   }
@@ -94,6 +94,10 @@ QString *QuarterWave_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
                             QObject::tr("Quarter wave filters do not allow low-pass nor high-pass masks\n"));
       return NULL;
   }
+  // Auxiliary variables
+  double Z;
+  double Z0 = Filter->Impedance;
+
   // Set filter main params as static members
   fc = Filter->Frequency + 0.5 * (Filter->Frequency2 - Filter->Frequency);
   d_lamdba4 = 0.25 * LIGHTSPEED / fc / (isMicrostrip ? sqrt(Substrate->er) : 1);
@@ -143,9 +147,12 @@ QString *QuarterWave_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
     for (int i = 0; i < Filter->Order; i++)
     {
       x += 90;
-      double impedance = Filter->Impedance;
-      c_s += getLineString(isMicrostrip, impedance, d_lamdba4, x, 180);
-      c_s += getLineString(isMicrostrip, impedance, d_lamdba4,  x+80, 60);
+      if (Filter->Class == CLASS_BANDPASS)
+            Z = (pi*Z0*bw)/(4*getNormValue(i, Filter)); // Bandpass
+      else
+            Z = (4*Z0)/(pi*bw*getNormValue(i, Filter)); // Bandstop
+      c_s += getLineString(isMicrostrip, Z0, d_lamdba4, x, 180);
+      c_s += getLineString(isMicrostrip, Z, d_lamdba4,  x+80, 60);
       w_s += getWireString(x+30, 180, x+60, 180);
       w_s += getWireString(x+50, 60, x+50, 180);
       if (Filter->Class == CLASS_BANDPASS)

--- a/qucs-filter/quarterwave_filter.cpp
+++ b/qucs-filter/quarterwave_filter.cpp
@@ -107,7 +107,13 @@ QString *QuarterWave_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
           w_s += getWireString(x+60 + x_space, 90, x+60 + x_space, 180); // Join middle point with the stub
       }
       if (Filter->Class == CLASS_BANDPASS) // If bandpass, shunt resonators
-          c_s += QString("<GND * 1 %1 30 0 0 1 0>\n").arg(x + 60 + x_space);
+          if (isMicrostrip){
+              c_s += getMS_Via(0.5, x+40 + x_space, 30, 2); // MS via diameter = 0.5 mm
+          }
+          else{
+              c_s += QString("<GND * 1 %1 30 0 0 1 0>\n").arg(x + 60 + x_space);
+          }
+
 
     x += 120 + 2 * x_space;
   }

--- a/qucs-filter/quarterwave_filter.h
+++ b/qucs-filter/quarterwave_filter.h
@@ -23,7 +23,6 @@
 #ifndef QUARTERWAVE_FILTER_H
 #define QUARTERWAVE_FILTER_H
 
-
 #include "tl_filter.h"
 
 // Quarter wave transmission line filter
@@ -37,10 +36,6 @@ public:
   QuarterWave_Filter();
 
   static QString* createSchematic(tFilter*, tSubstrate*, bool);
-  static QString getLineString(bool isMicrostrip, double width_or_impedance, double l, int x, int y, int rotate=0);
-  static QString getTeeString(int x, int y, double width1, double width2, double width3);
-  static QString getWireString(int x1, int x2, int x3, int x4);
 };
-
 
 #endif

--- a/qucs-filter/quarterwave_filter.h
+++ b/qucs-filter/quarterwave_filter.h
@@ -1,7 +1,7 @@
 /*
  * quarterwave_filter.h - Quarter wavelength filter definition
  *
- * copyright (C) 2015 Andres Martinez-Mera <andresmartinezmera@gmail.com>
+ * copyright (C) 2015, 2024 Andres Martinez-Mera <andresmartinezmera@gmail.com>
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/qucs-filter/quarterwave_filter.h
+++ b/qucs-filter/quarterwave_filter.h
@@ -38,8 +38,6 @@ public:
 
   static QString* createSchematic(tFilter*, tSubstrate*, bool);
   static QString getLineString(bool isMicrostrip, double width_or_impedance, double l, int x, int y, int rotate=0);
-  static double getZ(tFilter *Filter, int order, bool is_shunt);
-  static double getMicrostripWidth(tFilter *Filter, tSubstrate *Substrate, int order, bool is_shunt = false);
   static QString getTeeString(int x, int y, double width1, double width2, double width3);
   static QString getWireString(int x1, int x2, int x3, int x4);
 };


### PR DESCRIPTION

I have found that the QW transmission line filter synthesis was not working properly after commit [601548](https://github.com/ra3xdh/qucs_s/commit/6015488fc24c746aad6ebec5991c51e26d65be2b). Specifically, the impedance of the shunt resonators was set to Z0 regardless the design parameters. This leads to excessively wide passbands.

![image](https://github.com/ra3xdh/qucs_s/assets/13180689/e9bc9719-2589-4550-a4b8-489e17eef258)

In addition to this, I have found that when the MTEE was added in commit [601548, L124](https://github.com/ra3xdh/qucs_s/commit/6015488fc24c746aad6ebec5991c51e26d65be2b#diff-88ec292e540c7ae794efecb233cf45be5ed1f23b41b9f1b1785448e9425316e8R124), the length of the coupling was shortened in an attempt to compensate for the extra length added by the tee. As far as I know, this does not restore the original filter response. Notice that the MTEE equivalent circuit adds stray circuit elements that degrade the filter response so the compensation seems not to be as simple as that.

I couldn't find any literature on how to compensate for this analytically, so IMHO it's better to manually tune the couplings and resonator variables.

Please have a look at the attached workspace [3] and the PR notes [4]. They contain 4 examples of QW coupled resonator BP and BS filters. These examples cover the complete filter design and (except for the 4-8 GHz BSF case) they show good agreement between the ideal transmission line filter, simulation with MS models and EM data obtained using [Sonnet Lite](https://www.sonnetsoftware.com/products/lite/).

![image](https://github.com/ra3xdh/qucs_s/assets/13180689/cef05745-4653-42cf-b917-4fd3bd36e651)

**Other issues**

A user has pointed out to me (via private email) that the length of the microstrip resonator was calculated using the dielectric permittivity instead of the effective dielectric permittivity. This caused a frequency shift in the design. This issue is addressed in this PR.

**Other changes**

- It was found duplicity on the transmission line filter and MS implementation logic [601548, L113](https://github.com/ra3xdh/qucs_s/commit/6015488fc24c746aad6ebec5991c51e26d65be2b#diff-88ec292e540c7ae794efecb233cf45be5ed1f23b41b9f1b1785448e9425316e8L113). This issue is addressed in this PR.
- Added MS open to BSF open stubs. The MS open circuits account for the fringing effects and omitting this leads to a frequency shift in the filter response. This was not included in the original code.
- Added MS vias to terminate the shunt resonators in the BPF implementation. This is more realistic than having an ideal ground.
- The physical values of the filter have been rounded to two decimal places. This reduces clutter in the schematic and is more than enough in practice.


**References**

[1] [Tian, Ge et al. “Research on the equivalent circuit of microstrip T-junctions and its application on branch-line coupler.”
2012 International Conference on Microwave and Millimeter Wave Technology (ICMMT) 1 (2012): 1-4.](https://ieeexplore.ieee.org/document/6229911)
 
[2] Microstrip tee junction. Qucs Manual. https://qucs.sourceforge.net/tech/node81.html

[3] PR test workspace. [TEST_QW_FILTER_prj.zip](https://github.com/user-attachments/files/15873718/TEST_QW_FILTER_prj.zip)
[4] [Spreadsheet with commit details and tests. ](https://docs.google.com/spreadsheets/d/1K1G0WspB7u91xZWsOQpYXJdZXGEHzE0MlGIpDEbM_uw/edit?usp=sharing)




