### PR TITLE
Fix "nested subcircuit" warning

### DIFF
--- a/qucs/components/component.h
+++ b/qucs/components/component.h
@@ -48,6 +48,7 @@ public:
   virtual QStringList getExtraVariables();
   virtual QString getProbeVariable(bool isXyce = false);
   virtual QString getSpiceModel();
+  virtual QString getSpiceLibrary() { return QString(""); }
   virtual QString getNgspiceBeforeSim(QString sim, int lvl=0);
   virtual QString getNgspiceAfterSim(QString sim, int lvl=0);
   virtual QString getVAvariables() {return QString("");};

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -198,21 +198,6 @@ void AbstractSpiceKernel::startNetlist(QTextStream &stream, bool xyce)
             }
         }
 
-        QStringList incls;
-        // Include Directives
-        for(Component *pc = Sch->DocComps.first(); pc != 0; pc = Sch->DocComps.next()) {
-            if ((pc->SpiceModel==".INCLUDE")||
-                (pc->SpiceModel==".LIB")||
-                (pc->Model=="SpLib")) {
-                s = pc->getSpiceModel();
-                if (!incls.contains(s)) {
-                    // prevent multiple libraries inclusion
-                    incls.append(s);
-                    stream<<s;
-                }
-            }
-        }
-
         // create .IC from wire labels
         QStringList wire_labels;
         for(Wire *pw = Sch->DocWires.first(); pw != 0; pw = Sch->DocWires.next()) {
@@ -1545,10 +1530,16 @@ QString AbstractSpiceKernel::collectSpiceLibs(Schematic* sch)
         delete sub;
         continue;
       }
-      collected_spicelib += collectSpiceLibs(sub);
+      QString libstr = collectSpiceLibs(sub);
+      if (!collected_spicelib.contains(libstr)) {
+        collected_spicelib.append(libstr);
+      }
       delete sub;
     } else {
-      collected_spicelib += pc->getSpiceLibrary();
+      QString libstr = pc->getSpiceLibrary();
+      if (!collected_spicelib.contains(libstr)) {
+        collected_spicelib.append(libstr);
+      }
     }
   }
   return collected_spicelib.join("");

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -27,6 +27,7 @@
 #include "main.h"
 #include "../paintings/id_text.h"
 #include "dialogs/sweepdialog.h"
+#include "components/subcircuit.h"
 
 
 #include <QPlainTextEdit>
@@ -1531,5 +1532,25 @@ void AbstractSpiceKernel::SaveNetlist(QString)
 bool AbstractSpiceKernel::waitEndOfSimulation()
 {
     return SimProcess->waitForFinished(10000);
+}
+
+QString AbstractSpiceKernel::collectSpiceLibs(Schematic* sch)
+{
+  QStringList collected_spicelib;
+  for(Component *pc = sch->DocComps.first(); pc != 0; pc = sch->DocComps.next()) {
+    if (pc->Model == "Sub") {
+      Schematic *sub = new Schematic(0, ((Subcircuit *)pc)->getSubcircuitFile());
+      if(!sub->loadDocument())      // load document if possible
+      {
+        delete sub;
+        continue;
+      }
+      collected_spicelib += collectSpiceLibs(sub);
+      delete sub;
+    } else {
+      collected_spicelib += pc->getSpiceLibrary();
+    }
+  }
+  return collected_spicelib.join("");
 }
 

--- a/qucs/extsimkernels/abstractspicekernel.h
+++ b/qucs/extsimkernels/abstractspicekernel.h
@@ -78,6 +78,7 @@ protected:
     bool checkGround();
     bool checkSimulations();
     bool checkDCSimulation();
+    QString collectSpiceLibs(Schematic* sch);
 
 public:
 

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -28,6 +28,7 @@
 #include "main.h"
 #include "misc.h"
 #include "qucs.h"
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -70,7 +71,7 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
 {
     Q_UNUSED(simulations);
 
-    if(!prepareSpiceNetlist(stream)) return; // Unable to perform spice simulation
+    stream << "* Qucs " << PACKAGE_VERSION << "  " << Sch->DocName << "\n";
 
     // include math. functions for inter-simulator compat.
     QString mathf_inc;
@@ -79,6 +80,8 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
     if (found && QucsSettings.DefaultSimulator != spicecompat::simSpiceOpus)
         stream<<QString(".INCLUDE \"%1\"\n").arg(mathf_inc);
 
+    stream<<collectSpiceLibs(Sch); // collect libraries on the top of netlist
+    if(!prepareSpiceNetlist(stream)) return; // Unable to perform spice simulation
     startNetlist(stream); // output .PARAM and components
 
     if (DC_OP_only) {

--- a/qucs/extsimkernels/xyce.cpp
+++ b/qucs/extsimkernels/xyce.cpp
@@ -21,6 +21,9 @@
 #include "main.h"
 #include "misc.h"
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 
 /*!
   \file xyce.cpp
@@ -81,7 +84,11 @@ void Xyce::createNetlist(QTextStream &stream, int , QStringList &simulations,
     QString s;
     bool hasParSweep = false;
 
+    stream << "* Qucs " << PACKAGE_VERSION << "  " << Sch->DocName << "\n";
+    stream<<collectSpiceLibs(Sch); // collect libraries on the top of netlist
+
     if(!prepareSpiceNetlist(stream)) return; // Unable to perform spice simulation
+
     startNetlist(stream,true);
 
     // set variable names for named nodes and wires

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -2146,15 +2146,21 @@ int Schematic::prepareNetlist(QTextStream& stream, QStringList& Collect,
   }
 
   // first line is documentation
+  bool has_header = true;
   if(allTypes & isAnalogComponent) {
-    if (QucsSettings.DefaultSimulator != spicecompat::simQucsator)
-        stream << "*";
-    else stream << '#';
-  } else if (isVerilog)
+    if (QucsSettings.DefaultSimulator != spicecompat::simQucsator) {
+      has_header = false;
+    } else {
+      stream << '#';
+    }
+  } else if (isVerilog) {
     stream << "//";
-  else
+  } else {
     stream << "--";
-  stream << " Qucs " << PACKAGE_VERSION << "  " << DocName << "\n";
+  }
+  if (has_header) {
+    stream << " Qucs " << PACKAGE_VERSION << "  " << DocName << "\n";
+  }
 
   // set timescale property for verilog schematics
   if (isVerilog) {

--- a/qucs/spicecomponents/sp_include.cpp
+++ b/qucs/spicecomponents/sp_include.cpp
@@ -75,7 +75,7 @@ Element* S4Q_Include::info(QString& Name, char* &BitmapFile, bool getNewOne)
   return 0;
 }
 
-QString S4Q_Include::getSpiceModel()
+QString S4Q_Include::getSpiceLibrary()
 {
     if (isActive != COMP_IS_ACTIVE) return QString("");
     QString s;

--- a/qucs/spicecomponents/sp_include.h
+++ b/qucs/spicecomponents/sp_include.h
@@ -28,7 +28,7 @@ public:
   ~S4Q_Include();
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
-  QString getSpiceModel();
+  QString getSpiceLibrary();
 
 protected:
   QString vhdlCode(int) { return QString(""); }

--- a/qucs/spicecomponents/sp_lib.cpp
+++ b/qucs/spicecomponents/sp_lib.cpp
@@ -71,7 +71,7 @@ Element* S4Q_Lib::info(QString& Name, char* &BitmapFile, bool getNewOne)
   return 0;
 }
 
-QString S4Q_Lib::getSpiceModel()
+QString S4Q_Lib::getSpiceLibrary()
 {
   if (isActive != COMP_IS_ACTIVE) return QString("");
   QString s;

--- a/qucs/spicecomponents/sp_lib.h
+++ b/qucs/spicecomponents/sp_lib.h
@@ -28,7 +28,7 @@ public:
   ~S4Q_Lib();
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
-  QString getSpiceModel();
+  QString getSpiceLibrary();
 
 protected:
   QString vhdlCode(int) { return QString(""); }

--- a/qucs/spicecomponents/spicelibcomp.cpp
+++ b/qucs/spicecomponents/spicelibcomp.cpp
@@ -239,7 +239,7 @@ QString SpiceLibComp::spice_netlist(bool)
   return s;
 }
 
-QString SpiceLibComp::getSpiceModel()
+QString SpiceLibComp::getSpiceLibrary()
 {
     if (isActive != COMP_IS_ACTIVE) return QString("");
     QString f = misc::properAbsFileName(Props.at(0)->Value, containingSchematic);

--- a/qucs/spicecomponents/spicelibcomp.h
+++ b/qucs/spicecomponents/spicelibcomp.h
@@ -27,7 +27,7 @@ public:
  ~SpiceLibComp() {};
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
-  QString getSpiceModel();
+  QString getSpiceLibrary();
 
 protected:
   QString spice_netlist(bool isXyce);


### PR DESCRIPTION
This PR fixes `nested subcircuit` warning that comes from SpiceLibComp wrapped in subcircuit. This warning may cause convergence issue that are very hard to debug. This is part of #679. 

The patch introduces `Component::getSpiceLibrary` and `AbstractSpiceKernel::collectSpiceLibs`. This function recursively collect the libraries from all subcircuits and places them in the start of the netlist. 