### PR TITLE
Generalise Text::angle() logic

### DIFF
--- a/qucs/element.cpp
+++ b/qucs/element.cpp
@@ -18,6 +18,7 @@
 #include "element.h"
 #include "misc.h"
 
+#include <cmath>
 #include <QPainter>
 
 namespace qucs {

--- a/qucs/element.cpp
+++ b/qucs/element.cpp
@@ -70,28 +70,37 @@ void Text::draw(QPainter *painter, QRectF* br) const {
 }
 
 double Text::angle() const {
-  // Historically Text uses mSin and mCos values to store
-  // its rotation factor.
+  // Historically Text uses mSin and mCos values to describe
+  // at what angle the text is rotated.
   //
-  // The actual rotation was implemented as a clever
-  // tranformation for a painter, like:
-  //    QTransform(mCos, -mSin, mSin, mCos, …
+  // It employed some clever technique to draw the text rotated
+  // by applying "skew" transformations to QPainter and using mCos
+  // and mSin as skew factors, but later the whole drawing routine
+  // was refactored and it switched to using QPainter::rotate() and
+  // degrees to describe the rotation angle.
   //
-  // There were only four combinations of these values
-  // and here we convert them to their human-readable
-  // equivalents
-  if (mCos == 0.0) {
-    if (mSin == 1.0) {
-      return 270;
-    }
-    return 90;
-  }
+  // Many other parts of the codebase still depend on mCos and mSin,
+  // for example rotating and mirroring of a component and more than
+  // 200 component constructors. It is a piece of work to get rid
+  // of mCos and mSin completely, so they're kept as is and their
+  // "degrees" equivalent is calculated when the text needs to be drawn.
 
-  if (mCos == -1.0 && mSin == 0.0) {
-    return 180;
-  }
+  const double radians = std::acos(mCos);
+  // convert from radians to degrees and normalize
+  const double degrees = std::remainder(
+    (radians * 180.0) / 3.14159265 /* Pi */, 360.0 /* Full circle */);
 
-  return 0;
+  // Above we've found the angle in degrees from a cosinus value.
+  // A single cosinus value corresponds to two angles. If sinus is positive
+  // the angle is in upper half of a circle. If sinus in negative, then
+  // in lower half.
+  //
+  // At the same time QPainter::rotate() rotates *clockwise*, so if you
+  // want a text to have rotation angle of 45° (towards up-right direction),
+  // then the -45° has to be passed to QPainter::rotate().
+  //
+  // QPainter::rotate() is called in Text::draw
+  return mSin < 0 ? degrees : -degrees;
 }
 
 

--- a/qucs/element.cpp
+++ b/qucs/element.cpp
@@ -86,22 +86,15 @@ double Text::angle() const {
   // of mCos and mSin completely, so they're kept as is and their
   // "degrees" equivalent is calculated when the text needs to be drawn.
 
-  const double radians = std::acos(mCos);
-  // convert from radians to degrees and normalize
-  const double degrees = std::remainder(
-    (radians * 180.0) / 3.14159265 /* Pi */, 360.0 /* Full circle */);
+  const double radians = std::atan2(mSin, mCos);
+  const double degrees = (radians * 180.0) / 3.14159265 /* Pi */;
 
-  // Above we've found the angle in degrees from a cosinus value.
-  // A single cosinus value corresponds to two angles. If sinus is positive
-  // the angle is in upper half of a circle. If sinus in negative, then
-  // in lower half.
-  //
-  // At the same time QPainter::rotate() rotates *clockwise*, so if you
-  // want a text to have rotation angle of 45° (towards up-right direction),
+  // QPainter::rotate() rotates *clockwise*, so if you want a text
+  // to have rotation angle of 45° (towards up-right direction),
   // then the -45° has to be passed to QPainter::rotate().
   //
   // QPainter::rotate() is called in Text::draw
-  return mSin < 0 ? degrees : -degrees;
+  return -degrees;
 }
 
 


### PR DESCRIPTION
Hi!

I've rewritten `Text::angle()` to make it generic and able to handle any combination of `mCos` and `mSin` values. Before that `Text::angle()` could handle only three distinct cases and all other cases fell in "default", it was rather "stiff". I believe that is the reason why subcircuit symbol has text with wrong rotation angle.

It looks good now (at least on my machine):
<img width="421" alt="image" src="https://github.com/ra3xdh/qucs_s/assets/40355531/e0c7edf5-1494-47ce-820b-88bafce5079f">


May fix #765