### PR TITLE
Refactor simulation components

### DIFF
--- a/qucs/components/CMakeLists.txt
+++ b/qucs/components/CMakeLists.txt
@@ -61,6 +61,7 @@ circline.cpp
 taperedline.cpp
 circularloop.cpp
 spiralinductor.cpp
+simulation.cpp
 )
 
 SET(COMPONENTS_HDRS
@@ -194,6 +195,7 @@ rfedd.h
 rfedd2p.h
 rlcg.h
 rs_flipflop.h
+simulation.h
 source_ac.h
 sp_sim.h
 sparamfile.h

--- a/qucs/components/ac_sim.cpp
+++ b/qucs/components/ac_sim.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "ac_sim.h"
-#include "main.h"
 #include "misc.h"
 #include "extsimkernels/spicecompat.h"
 
@@ -26,25 +25,7 @@ AC_Sim::AC_Sim()
 {
   isSimulation = true;
   Description = QObject::tr("ac simulation");
-
-  QString s = Description;
-  int a = s.indexOf(" ");
-  int b = s.lastIndexOf(" ");
-  if (a != -1 && b != -1) {
-    if (a > (int) s.length() - b)  b = a;
-  }
-  if (a < 8 || s.length() - b < 8) b = -1;
-  if (b != -1) s[b] = '\n';
-
-  Texts.append(new Text(0, 0, s.left(b), Qt::darkBlue, QucsSettings.largeFontSize));
-  if (b != -1)
-    Texts.append(new Text(0, 0, s.mid(b+1), Qt::darkBlue, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+128; y2 = y1+41;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".AC";
   SpiceModel = ".AC";
   Name  = "AC";

--- a/qucs/components/ac_sim.h
+++ b/qucs/components/ac_sim.h
@@ -18,10 +18,10 @@
 #ifndef AC_SIM_H
 #define AC_SIM_H
 
-#include "component.h"
+#include "simulation.h"
 
 
-class AC_Sim : public Component  {
+class AC_Sim : public qucs::component::SimulationComponent  {
 public:
   AC_Sim();
  ~AC_Sim();

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -237,15 +237,11 @@ bool Component::getSelected(int x_, int y_) {
     return false;
 }
 
-void Component::paint(QPainter *p) const {
+void Component::paint(QPainter *p) {
     p->save();
     p->translate(cx, cy);
 
-    if (Model.at(0) == '.') {   // is simulation component (dc, ac, ...)
-        drawSimulator(p);
-    } else {    // normal components go here
-        drawUsual(p);
-    }
+    drawSymbol(p);
 
     p->setPen(QPen(Qt::black, 1));
     QRect text_br{tx, ty, 0, 0};
@@ -279,74 +275,7 @@ void Component::paint(QPainter *p) const {
     p->restore();
 }
 
-void Component::drawSimulator(QPainter* p) const {
-    const bool correctSimulator = (Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator;
-    p->save();
-    if (correctSimulator) {
-        if ((Model == ".CUSTOMSIM") || (Model == ".DISTO")
-            || (Model == ".NOISE") || (Model == ".PZ") ||
-            (Model == ".SENS") || (Model == ".SENS_AC") ||
-            (Model == ".FFT"))
-            p->setPen(QPen(Qt::blue, 2));
-        else if ((Model == ".XYCESCR") || (Model == ".SENS_XYCE")
-                    || (Model == ".SENS_TR_XYCE"))
-            p->setPen(QPen(Qt::darkGreen, 2));
-        else if (Model == ".FOURIER") p->setPen(QPen(Qt::darkRed, 2));
-        else p->setPen(QPen(Qt::darkBlue, 2));
-    } else {
-        p->setPen(WrongSimulatorPen);
-    }
-
-    QFont title_font{ p->font() };
-    title_font.setWeight(QFont::DemiBold);
-    p->setFont(title_font);
-
-    QRect all_text_br;
-    QRect br;
-    for (Text *t: Texts) {
-        p->drawText(br.left(), br.bottom(), 0, 0, Qt::TextDontClip, t->s, &br);
-        all_text_br |= br;
-    }
-
-    // Simulation components look like an isometric box
-    // or a brick, with a title on its top side, being
-    // observed from some strange angle, like this:
-    //
-    //  +-----------+
-    //  |           |`.
-    //  | T I T L E | |
-    //  |           | |
-    //  +-----------+ |
-    //   `___________`!
-
-    // It's drawn below step by step. Remember that
-    // in painter's coordinate system Y-axis grows downwards
-
-    // Top side
-    QRect plate = all_text_br.marginsAdded(QMargins{5,5,5,5});
-    p->drawRect(plate);
-
-    // Box "depth"
-    QPoint offset{5, 5};
-
-    // Three short edges of the box which define its "depth"
-    auto topRight_ = plate.topRight() + offset;
-    p->drawLine(plate.topRight(), topRight_);
-
-    auto bottomRight_ = plate.bottomRight() + offset;
-    p->drawLine(plate.bottomRight(), bottomRight_);
-
-    auto bottomLeft_ = plate.bottomLeft() + offset;
-    p->drawLine(plate.bottomLeft(), bottomLeft_);
-
-    // Finally two visble edges of bottom side of the box
-    p->drawLine(bottomLeft_, bottomRight_);
-    p->drawLine(bottomRight_, topRight_);
-
-    p->restore();
-}
-
-void Component::drawUsual(QPainter* p) const {
+void Component::drawSymbol(QPainter* p) {
     const bool correctSimulator = (Simulator & QucsSettings.DefaultSimulator) == QucsSettings.DefaultSimulator;
 
     auto draw_primitive = [&](qucs::DrawingPrimitive* prim, QPainter* p) {

--- a/qucs/components/component.h
+++ b/qucs/components/component.h
@@ -56,7 +56,7 @@ public:
   virtual void getExtraVANodes(QStringList& ) {};
   QString get_VHDL_Code(int);
   QString get_Verilog_Code(int);
-  void    paint(QPainter* painter) const;
+  void    paint(QPainter* painter);
   void    paintScheme(Schematic*);
   void    setCenter(int, int, bool relative=false);
   void    getCenter(int&, int&);
@@ -127,9 +127,7 @@ protected:
   Property * getProperty(const QString&);
   Schematic* containingSchematic;
 
-private:
-  void drawSimulator(QPainter* p) const;
-  void drawUsual(QPainter* p) const;
+  virtual void drawSymbol(QPainter* p);
 };
 
 

--- a/qucs/components/dc_sim.cpp
+++ b/qucs/components/dc_sim.cpp
@@ -15,36 +15,15 @@
  *                                                                         *
  ***************************************************************************/
 #include "dc_sim.h"
-#include "main.h"
-
 
 DC_Sim::DC_Sim()
 {
   isSimulation = true;
   Description = QObject::tr("dc simulation");
-
-  QString s = Description;
-  int a = s.indexOf(" ");
-  int b = s.lastIndexOf(" ");
-  if (a != -1 && b != -1) {
-    if (a > (int) s.length() - b)  b = a;
-  }
-  if (a < 8 || s.length() - b < 8) b = -1;
-  if (b != -1) s[b] = '\n';
-
-  Texts.append(new Text(0, 0, s.left(b), Qt::darkBlue, QucsSettings.largeFontSize));
-  if (b != -1)
-    Texts.append(new Text(0, 0, s.mid(b+1), Qt::darkBlue, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+128; y2 = y1+41;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".DC";
   Name  = "DC";
   SpiceModel = ".OP";
-  isSimulation = true;
 
   Props.append(new Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));

--- a/qucs/components/dc_sim.h
+++ b/qucs/components/dc_sim.h
@@ -18,10 +18,10 @@
 #ifndef DC_SIM_H
 #define DC_SIM_H
 
-#include "component.h"
+#include "simulation.h"
 
 
-class DC_Sim : public Component  {
+class DC_Sim : public qucs::component::SimulationComponent  {
 public:
   DC_Sim();
   ~DC_Sim();

--- a/qucs/components/digi_sim.cpp
+++ b/qucs/components/digi_sim.cpp
@@ -15,27 +15,13 @@
  *                                                                         *
  ***************************************************************************/
 #include "digi_sim.h"
-#include "main.h"
 
 
 Digi_Sim::Digi_Sim()
 {
   Type = isDigitalComponent;
   Description = QObject::tr("digital simulation");
-
-  QString  s = Description;
-  int a = s.indexOf(" ");
-  if (a != -1) s[a] = '\n';  // break line before the word "simulation"
-
-  Texts.append(new Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
-  if (a != -1)
-    Texts.append(new Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+120; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".Digi";
   Name  = "Digi";
 

--- a/qucs/components/digi_sim.h
+++ b/qucs/components/digi_sim.h
@@ -18,10 +18,10 @@
 #ifndef DIGI_SIM_H
 #define DIGI_SIM_H
 
-#include "component.h"
+#include "simulation.h"
 
 
-class Digi_Sim : public Component  {
+class Digi_Sim : public qucs::component::SimulationComponent  {
 public:
   Digi_Sim();
  ~Digi_Sim();

--- a/qucs/components/etr_sim.cpp
+++ b/qucs/components/etr_sim.cpp
@@ -15,27 +15,13 @@
  *                                                                         *
  ***************************************************************************/
 #include "etr_sim.h"
-#include "main.h"
 
 
 ETR_Sim::ETR_Sim()
 {
   Description = QObject::tr("externally driven transient simulation");
   Simulator = spicecompat::simQucsator;
-
-  QString s = Description;
-  int a = 17;
-  s[a] = '\n';
-
-  Texts.append(new Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
-  if (a != -1)
-    Texts.append(new Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+130; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".ETR";
   Name  = "ETR";
 

--- a/qucs/components/etr_sim.h
+++ b/qucs/components/etr_sim.h
@@ -18,10 +18,10 @@
 #ifndef ETR_SIM_H
 #define ETR_SIM_H
 
-#include "component.h"
+#include "simulation.h"
 
 
-class ETR_Sim : public Component  {
+class ETR_Sim : public qucs::component::SimulationComponent  {
 public:
   ETR_Sim();
   ~ETR_Sim();

--- a/qucs/components/hb_sim.cpp
+++ b/qucs/components/hb_sim.cpp
@@ -15,8 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "hb_sim.h"
-#include "main.h"
-#include "misc.h"
 #include "extsimkernels/spicecompat.h"
 #include <QRegularExpression>
 
@@ -27,18 +25,7 @@ HB_Sim::HB_Sim()
   Simulator = spicecompat::simXyce | spicecompat::simQucsator;
 
   QString  s = Description;
-  int a = s.lastIndexOf(" ");
-  if (a != -1) s[a] = '\n';    // break line before the word "simulation"
-
-  Texts.append(new Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
-  if (a != -1)
-    Texts.append(new Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+163; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".HB";
   Name  = "HB";
   SpiceModel = ".HB";

--- a/qucs/components/hb_sim.h
+++ b/qucs/components/hb_sim.h
@@ -18,10 +18,10 @@
 #ifndef HB_SIM_H
 #define HB_SIM_H
 
-#include "component.h"
+#include "simulation.h"
 
 
-class HB_Sim : public Component  {
+class HB_Sim : public qucs::component::SimulationComponent  {
 public:
   HB_Sim();
   ~HB_Sim();

--- a/qucs/components/opt_sim.cpp
+++ b/qucs/components/opt_sim.cpp
@@ -29,14 +29,7 @@ Optimize_Sim::Optimize_Sim()
 {
   Description = QObject::tr("Optimization");
   Simulator = spicecompat::simQucsator;
-
-  Texts.append(new Text(0, 0, Description, Qt::darkBlue, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+128; y2 = y1+41;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".Opt";
   Name  = "Opt";
 

--- a/qucs/components/opt_sim.h
+++ b/qucs/components/opt_sim.h
@@ -18,10 +18,10 @@
 #ifndef OPT_SIM_H
 #define OPT_SIM_H
 
-#include "component.h"
+#include "simulation.h"
 
 
-class Optimize_Sim : public Component  {
+class Optimize_Sim : public qucs::component::SimulationComponent  {
 public:
   Optimize_Sim();
  ~Optimize_Sim();

--- a/qucs/components/param_sweep.cpp
+++ b/qucs/components/param_sweep.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "param_sweep.h"
-#include "main.h"
 #include "schematic.h"
 #include "misc.h"
 
@@ -24,18 +23,7 @@ Param_Sweep::Param_Sweep()
   Description = QObject::tr("Parameter sweep");
 
   QString  s = Description;
-  int a = s.lastIndexOf(" ");
-  if (a != -1) s[a] = '\n';    // break line
-
-  Texts.append(new Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
-  if (a != -1)
-    Texts.append(new Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+104; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".SW";
   Name  = "SW";
   SpiceModel = "*";

--- a/qucs/components/param_sweep.h
+++ b/qucs/components/param_sweep.h
@@ -18,10 +18,10 @@
 #ifndef PARAM_SWEEP_H
 #define PARAM_SWEEP_H
 
-#include "component.h"
+#include "simulation.h"
 
 
-class Param_Sweep : public Component  {
+class Param_Sweep : public qucs::component::SimulationComponent  {
 public:
   Param_Sweep();
   ~Param_Sweep();

--- a/qucs/components/simulation.cpp
+++ b/qucs/components/simulation.cpp
@@ -1,0 +1,163 @@
+#include "simulation.h"
+#include "settings.h"
+#include <vector>
+#include <QPainter>
+
+namespace {
+const QPen wrongSimulatorPen{Qt::gray};
+// "Air" around a simulation component title.
+constexpr QMargins label_margins{5, 5, 5, 5};
+// Height of component "box". See 'drawSymbol()' below for more about the "box"
+constexpr QPoint box_height{5, 5};
+
+// Wraps simulation label text on spaces to make it consist of multiple
+// lines of almost the same length
+QString wrapLabel(const QString &label)
+{
+    // Acting here like this: given a desired line length L, take every L-th
+    // character, find first space before and first space after it, and then
+    // replace the closest one with linebreak.
+
+    constexpr int line_len_hint = 14;
+    QString wrapped = label.trimmed();
+
+    int prev_break = 0;
+    for (int curr_ix = line_len_hint; curr_ix < wrapped.length(); curr_ix += line_len_hint) {
+        const int not_found = -1;
+
+        int prev_space = not_found;
+        for (int j = curr_ix; j > prev_break; j--) {
+            if (wrapped[j].isSpace()) {
+                prev_space = j;
+                break;
+            }
+        }
+
+        int next_space = not_found;
+        for (int j = curr_ix + 1; j < wrapped.length(); j++) {
+            if (wrapped[j].isSpace()) {
+                next_space = j;
+                break;
+            }
+        }
+
+        // Not a single space could be found, thus current string segment
+        // cannot be broken into lines and we can exit early
+        if (prev_space == not_found && next_space == not_found) {
+            return wrapped;
+        }
+
+        // Locate the place to wrap the string
+        if (prev_space != not_found && next_space != not_found) {
+            // find the closest space
+            curr_ix = curr_ix - prev_space > next_space - curr_ix
+                    ? next_space
+                    : prev_space;
+        } else if (prev_space != not_found) {
+            curr_ix = prev_space;
+        } else if (next_space != not_found) {
+            curr_ix = next_space;
+        }
+
+        wrapped[curr_ix] = '\n';
+        prev_break = curr_ix;
+    }
+    return wrapped;
+}
+
+QRect selectionRect(const QRect& label_bounds)
+{
+    auto selection_rect = label_bounds.marginsAdded({3, 3, 3, 3});
+    selection_rect.setBottomRight(selection_rect.bottomRight() + box_height);
+    return selection_rect;
+}
+
+QFont labelFont()
+{
+    auto label_font = _settings::Get().item<QFont>("font");
+    label_font.setWeight(QFont::DemiBold);
+    label_font.setPointSizeF(_settings::Get().item<double>("LargeFontSize"));
+    return label_font;
+}
+} // namespace
+
+namespace qucs::component {
+
+QPen SimulationComponent::pen() const
+{
+    auto default_sim      = _settings::Get().item<int>("DefaultSimulator");
+    auto correctSimulator = (Simulator & default_sim) == default_sim;
+
+    return correctSimulator ? QPen{color(), 2, Qt::SolidLine, Qt::FlatCap}
+                            : wrongSimulatorPen;
+}
+
+void SimulationComponent::updateComponentBounds(const QRect& label_bounds)
+{
+    auto sr = selectionRect(label_bounds);
+    x1 = sr.top();
+    y1 = sr.left();
+    x2 = sr.right();
+    y2 = sr.bottom();
+    tx = 0;
+    ty = y2;
+}
+
+
+void SimulationComponent::initSymbol(const QString &label)
+{
+    label_text = wrapLabel(label);
+    updateComponentBounds(QRect{{0,0}, QFontMetrics{labelFont()}.size(0, label_text)});
+}
+
+
+void SimulationComponent::drawSymbol(QPainter *p)
+{
+    const auto label_font = labelFont();
+
+    p->save();
+    p->setPen(pen());
+    p->setFont(label_font);
+    QRect label_bounds;
+    p->drawText(0, 0, 0, 0, Qt::TextDontClip, label_text, &label_bounds);
+
+    // Simulation component look like an isometric box
+    // or a brick, with a label on its top side, being
+    // observed from some strange angle, like this:
+    //   B                 C
+    //   +-----------------+
+    //   |                 |`. E
+    //   |  L  A  B  E  L  | |
+    //   |                 | |
+    // A +-----------------+D|
+    //    `_________________`!
+    //    G                   F
+
+    const QRect ABCD = label_bounds.marginsAdded(label_margins);
+    p->drawRect(ABCD);
+
+    const std::vector<QPoint> CEFGA{
+      ABCD.topRight(),
+      ABCD.topRight()    + box_height,
+      ABCD.bottomRight() + box_height,
+      ABCD.bottomLeft()  + box_height,
+      ABCD.bottomLeft()
+    };
+    p->drawPolyline(CEFGA.data(), CEFGA.size());
+
+    // DF
+    p->drawLine(ABCD.bottomRight(), ABCD.bottomRight() + box_height);
+    p->restore();
+
+    // Changing component properties from within the drawing routine
+    // IMO is bad and semantically wrong, but this is the only way
+    // to account changes made to font used to draw it. If user changes
+    // the font, simulation component has to be drawn according to
+    // these changes. And as the whole component appearence is built
+    // around its label text, other parts of component has to be updated
+    // when the text changes. E.g. when user makes font larger, we want
+    // component selection box to reflect this change.
+    updateComponentBounds(ABCD);
+}
+
+} // namespace qucs::component

--- a/qucs/components/simulation.h
+++ b/qucs/components/simulation.h
@@ -1,0 +1,20 @@
+#ifndef SIMULATION_H
+#define SIMULATION_H
+#include "component.h"
+#include <QString>
+
+namespace qucs::component {
+class SimulationComponent : public Component {
+private:
+     QString label_text;
+     void updateComponentBounds(const QRect& label_bounds);
+     QPen pen() const;
+protected:
+     void initSymbol(const QString& label);
+     void drawSymbol(QPainter* p) override;
+     // Override in your subclass if you want other color
+     // for your simulation component
+     virtual Qt::GlobalColor color() const { return Qt::darkBlue; }
+};
+}
+#endif

--- a/qucs/components/sp_sim.cpp
+++ b/qucs/components/sp_sim.cpp
@@ -15,33 +15,16 @@
  *                                                                         *
  ***************************************************************************/
 #include "sp_sim.h"
-#include "main.h"
 #include "misc.h"
 #include "schematic.h"
+#include "settings.h"
 
 
 SP_Sim::SP_Sim()
 {
   isSimulation = true;
   Description = QObject::tr("S parameter simulation");
-
-  QString s = Description;
-  int a = s.indexOf(" ");
-  int b = s.lastIndexOf(" ");
-  if (a != -1 && b != -1) {
-    if (a > (int) s.length() - b)  b = a;
-  }
-  if (b != -1) s[b] = '\n';
-
-  Texts.append(new Text(0, 0, s.left(b), Qt::darkBlue, QucsSettings.largeFontSize));
-  if (b != -1)
-    Texts.append(new Text(0, 0, s.mid(b+1), Qt::darkBlue, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+121; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".SP";
   Name  = "SP";
   SpiceModel = ".SP";
@@ -124,7 +107,7 @@ int SP_Sim::getSPortsNumber()
 
 QStringList SP_Sim::getExtraVariables()
 {
-    switch (QucsSettings.DefaultSimulator) {
+    switch (_settings::Get().item<int>("DefaultSimulator")) {
         case spicecompat::simNgspice:
             return getNgspiceExtraVariables();
         case spicecompat::simXyce:

--- a/qucs/components/sp_sim.h
+++ b/qucs/components/sp_sim.h
@@ -18,10 +18,10 @@
 #ifndef SP_SIM_H
 #define SP_SIM_H
 
-#include "component.h"
+#include "simulation.h"
 
 
-class SP_Sim : public Component  {
+class SP_Sim : public qucs::component::SimulationComponent  {
 private:
     QString xyce_netlist();
     QString ngspice_netlist();

--- a/qucs/components/tr_sim.cpp
+++ b/qucs/components/tr_sim.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "tr_sim.h"
-#include "main.h"
 #include "misc.h"
 #include "extsimkernels/spicecompat.h"
 
@@ -24,20 +23,7 @@ TR_Sim::TR_Sim()
 {
   isSimulation = true;
   Description = QObject::tr("transient simulation");
-
-  QString  s = Description;
-  int a = s.indexOf(" ");
-  if (a != -1) s[a] = '\n';
-
-  Texts.append(new Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
-  if (a != -1)
-    Texts.append(new Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+104; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".TR";
   Name  = "TR";
   SpiceModel = ".TRAN";

--- a/qucs/components/tr_sim.h
+++ b/qucs/components/tr_sim.h
@@ -18,10 +18,10 @@
 #ifndef TR_SIM_H
 #define TR_SIM_H
 
-#include "component.h"
+#include "simulation.h"
 
 
-class TR_Sim : public Component  {
+class TR_Sim : public qucs::component::SimulationComponent {
 public:
   TR_Sim();
   ~TR_Sim();

--- a/qucs/spicecomponents/sp_customsim.cpp
+++ b/qucs/spicecomponents/sp_customsim.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "sp_customsim.h"
-#include "main.h"
 
 
 SpiceCustomSim::SpiceCustomSim()
@@ -23,14 +22,7 @@ SpiceCustomSim::SpiceCustomSim()
   isSimulation = true;
   Description = QObject::tr("Nutmeg script");
   Simulator = spicecompat::simNgspice | spicecompat::simSpiceOpus;
-
-  Texts.append(new Text(0, 0, Description, Qt::darkRed, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+104; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".CUSTOMSIM";
   Name  = "CUSTOM";
   SpiceModel = "CUSTOM";

--- a/qucs/spicecomponents/sp_customsim.h
+++ b/qucs/spicecomponents/sp_customsim.h
@@ -18,10 +18,10 @@
 #ifndef SP_CUSTOMSIM_H
 #define SP_CUSTOMSIM_H
 
-#include "components/component.h"
+#include "components/simulation.h"
 
 
-class SpiceCustomSim : public Component  {
+class SpiceCustomSim : public qucs::component::SimulationComponent {
 public:
   SpiceCustomSim();
   ~SpiceCustomSim();

--- a/qucs/spicecomponents/sp_disto.cpp
+++ b/qucs/spicecomponents/sp_disto.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "sp_disto.h"
-#include "main.h"
 #include "misc.h"
 #include "extsimkernels/spicecompat.h"
 #include <cmath>
@@ -25,20 +24,7 @@ SpiceDisto::SpiceDisto()
   isSimulation = true;
   Description = QObject::tr("Distortion simulation");
   Simulator = spicecompat::simNgspice | spicecompat::simSpiceOpus;
-
-  QString  s = Description;
-  int a = s.indexOf(" ");
-  if (a != -1) s[a] = '\n';
-
-  Texts.append(new Text(0, 0, s.left(a), Qt::darkRed, QucsSettings.largeFontSize));
-  if (a != -1)
-    Texts.append(new Text(0, 0, s.mid(a+1), Qt::darkRed, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+104; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".DISTO";
   Name  = "DISTO";
   SpiceModel = ".DISTO";

--- a/qucs/spicecomponents/sp_disto.h
+++ b/qucs/spicecomponents/sp_disto.h
@@ -18,10 +18,10 @@
 #ifndef SP_DISTO_H
 #define SP_DISTO_H
 
-#include "components/component.h"
+#include "components/simulation.h"
 
 
-class SpiceDisto : public Component  {
+class SpiceDisto : public qucs::component::SimulationComponent {
 public:
   SpiceDisto();
   ~SpiceDisto();

--- a/qucs/spicecomponents/sp_fourier.cpp
+++ b/qucs/spicecomponents/sp_fourier.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "sp_fourier.h"
-#include "main.h"
 #include "extsimkernels/spicecompat.h"
 
 
@@ -24,20 +23,7 @@ SpiceFourier::SpiceFourier()
   isSimulation = true;
   Description = QObject::tr("Fourier simulation");
   Simulator = spicecompat::simSpice;
-
-  QString  s = Description;
-  int a = s.indexOf(" ");
-  if (a != -1) s[a] = '\n';
-
-  Texts.append(new Text(0, 0, s.left(a), Qt::darkRed, QucsSettings.largeFontSize));
-  if (a != -1)
-    Texts.append(new Text(0, 0, s.mid(a+1), Qt::darkRed, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+104; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".FOURIER";
   Name  = "FOUR";
   SpiceModel = ".FOURIER";

--- a/qucs/spicecomponents/sp_fourier.h
+++ b/qucs/spicecomponents/sp_fourier.h
@@ -18,10 +18,10 @@
 #ifndef SP_FOURIER_H
 #define SP_FOURIER_H
 
-#include "components/component.h"
+#include "components/simulation.h"
 
 
-class SpiceFourier : public Component  {
+class SpiceFourier : public qucs::component::SimulationComponent {
 public:
   SpiceFourier();
   ~SpiceFourier();
@@ -30,6 +30,7 @@ public:
 
 protected:
   QString spice_netlist(bool isXyce = false);
+  Qt::GlobalColor color() const override { return Qt::darkRed; }
 };
 
 #endif

--- a/qucs/spicecomponents/sp_noise.cpp
+++ b/qucs/spicecomponents/sp_noise.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "sp_noise.h"
-#include "main.h"
 #include "misc.h"
 #include "extsimkernels/spicecompat.h"
 #include <cmath>
@@ -26,20 +25,7 @@ SpiceNoise::SpiceNoise()
   isSimulation = true;
   Description = QObject::tr("Noise simulation");
   Simulator = spicecompat::simSpice;
-
-  QString  s = Description;
-  int a = s.indexOf(" ");
-  if (a != -1) s[a] = '\n';
-
-  Texts.append(new Text(0, 0, s.left(a), Qt::darkRed, QucsSettings.largeFontSize));
-  if (a != -1)
-    Texts.append(new Text(0, 0, s.mid(a+1), Qt::darkRed, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+104; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".NOISE";
   Name  = "NOISE";
   SpiceModel = ".NOISE";

--- a/qucs/spicecomponents/sp_noise.h
+++ b/qucs/spicecomponents/sp_noise.h
@@ -18,10 +18,10 @@
 #ifndef SP_NOISE_H
 #define SP_NOISE_H
 
-#include "components/component.h"
+#include "components/simulation.h"
 
 
-class SpiceNoise : public Component  {
+class SpiceNoise : public qucs::component::SimulationComponent {
 public:
   SpiceNoise();
   ~SpiceNoise();

--- a/qucs/spicecomponents/sp_pz.cpp
+++ b/qucs/spicecomponents/sp_pz.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "sp_pz.h"
-#include "main.h"
 #include "extsimkernels/spicecompat.h"
 
 
@@ -24,20 +23,7 @@ SpicePZ::SpicePZ()
   isSimulation = true;
   Description = QObject::tr("Pole-Zero simulation");
   Simulator = spicecompat::simNgspice | spicecompat::simSpiceOpus;
-
-  QString  s = Description;
-  int a = s.indexOf(" ");
-  if (a != -1) s[a] = '\n';
-
-  Texts.append(new Text(0, 0, s.left(a), Qt::darkRed, QucsSettings.largeFontSize));
-  if (a != -1)
-    Texts.append(new Text(0, 0, s.mid(a+1), Qt::darkRed, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+104; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".PZ";
   Name  = "PZ";
   SpiceModel = ".PZ";

--- a/qucs/spicecomponents/sp_pz.h
+++ b/qucs/spicecomponents/sp_pz.h
@@ -18,10 +18,10 @@
 #ifndef SP_PZ_H
 #define SP_PZ_H
 
-#include "components/component.h"
+#include "components/simulation.h"
 
 
-class SpicePZ : public Component  {
+class SpicePZ : public qucs::component::SimulationComponent {
 public:
   SpicePZ();
   ~SpicePZ();

--- a/qucs/spicecomponents/sp_sens.cpp
+++ b/qucs/spicecomponents/sp_sens.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "sp_sens.h"
-#include "main.h"
 #include "extsimkernels/spicecompat.h"
 
 
@@ -24,20 +23,7 @@ SpiceSENS::SpiceSENS()
   isSimulation = true;
   Description = QObject::tr("DC sensitivity simulation");
   Simulator = spicecompat::simNgspice | spicecompat::simSpiceOpus;
-
-  QString  s = Description;
-  int a = s.indexOf(" ");
-  if (a != -1) s[a] = '\n';
-
-  Texts.append(new Text(0, 0, s.left(a), Qt::darkRed, QucsSettings.largeFontSize));
-  if (a != -1)
-    Texts.append(new Text(0, 0, s.mid(a+1), Qt::darkRed, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+104; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".SENS";
   Name  = "SENS";
   SpiceModel = ".SENS";

--- a/qucs/spicecomponents/sp_sens.h
+++ b/qucs/spicecomponents/sp_sens.h
@@ -18,10 +18,10 @@
 #ifndef SP_SENS_H
 #define SP_SENS_H
 
-#include "components/component.h"
+#include "components/simulation.h"
 
 
-class SpiceSENS : public Component  {
+class SpiceSENS : public qucs::component::SimulationComponent {
 public:
   SpiceSENS();
   ~SpiceSENS();

--- a/qucs/spicecomponents/sp_sens_ac.cpp
+++ b/qucs/spicecomponents/sp_sens_ac.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "sp_sens_ac.h"
-#include "main.h"
 #include "extsimkernels/spicecompat.h"
 
 
@@ -24,20 +23,7 @@ SpiceSENS_AC::SpiceSENS_AC()
   isSimulation = true;
   Description = QObject::tr("AC sensitivity simulation");
   Simulator = spicecompat::simNgspice | spicecompat::simSpiceOpus;
-
-  QString  s = Description;
-  int a = s.indexOf(" ");
-  if (a != -1) s[a] = '\n';
-
-  Texts.append(new Text(0, 0, s.left(a), Qt::darkRed, QucsSettings.largeFontSize));
-  if (a != -1)
-    Texts.append(new Text(0, 0, s.mid(a+1), Qt::darkRed, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+104; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".SENS_AC";
   Name  = "SENS";
   SpiceModel = ".SENS";

--- a/qucs/spicecomponents/sp_sens_ac.h
+++ b/qucs/spicecomponents/sp_sens_ac.h
@@ -18,10 +18,10 @@
 #ifndef SP_SENS_AC_H
 #define SP_SENS_AC_H
 
-#include "components/component.h"
+#include "components/simulation.h"
 
 
-class SpiceSENS_AC : public Component  {
+class SpiceSENS_AC : public qucs::component::SimulationComponent  {
 public:
   SpiceSENS_AC();
   ~SpiceSENS_AC();

--- a/qucs/spicecomponents/sp_sens_tr_xyce.cpp
+++ b/qucs/spicecomponents/sp_sens_tr_xyce.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "sp_sens_tr_xyce.h"
-#include "main.h"
 #include "extsimkernels/spicecompat.h"
 
 
@@ -24,20 +23,7 @@ SpiceSENS_TR_Xyce::SpiceSENS_TR_Xyce()
   isSimulation = true;
   Description = QObject::tr("Transient .SENS analysis with Xyce");
   Simulator = spicecompat::simXyce;
-
-  QString  s = Description;
-  int a = s.indexOf(" ");
-  if (a != -1) s[a] = '\n';
-
-  Texts.append(new Text(0, 0, s.left(a), Qt::darkRed, QucsSettings.largeFontSize));
-  if (a != -1)
-    Texts.append(new Text(0, 0, s.mid(a+1), Qt::darkRed, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+104; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".SENS_TR_XYCE";
   Name  = "TSENS";
   SpiceModel = ".SENS";

--- a/qucs/spicecomponents/sp_sens_tr_xyce.h
+++ b/qucs/spicecomponents/sp_sens_tr_xyce.h
@@ -18,10 +18,10 @@
 #ifndef SP_SENS_TR_XYCE_H
 #define SP_SENS_TR_XYCE_H
 
-#include "components/component.h"
+#include "components/simulation.h"
 
 
-class SpiceSENS_TR_Xyce : public Component  {
+class SpiceSENS_TR_Xyce : public qucs::component::SimulationComponent  {
 public:
   SpiceSENS_TR_Xyce();
   ~SpiceSENS_TR_Xyce();
@@ -30,6 +30,7 @@ public:
 
 protected:
   QString spice_netlist(bool isXyce = false);
+  Qt::GlobalColor color() const override { return Qt::darkGreen; }
 };
 
 #endif

--- a/qucs/spicecomponents/sp_sens_xyce.cpp
+++ b/qucs/spicecomponents/sp_sens_xyce.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "sp_sens_xyce.h"
-#include "main.h"
 #include "extsimkernels/spicecompat.h"
 
 
@@ -24,20 +23,7 @@ SpiceSENS_Xyce::SpiceSENS_Xyce()
   isSimulation = true;
   Description = QObject::tr("DC .SENS simulation with Xyce");
   Simulator = spicecompat::simXyce;
-
-  QString  s = Description;
-  int a = s.indexOf(" ");
-  if (a != -1) s[a] = '\n';
-
-  Texts.append(new Text(0, 0, s.left(a), Qt::darkRed, QucsSettings.largeFontSize));
-  if (a != -1)
-    Texts.append(new Text(0, 0, s.mid(a+1), Qt::darkRed, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+104; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".SENS_XYCE";
   Name  = "SENS";
   SpiceModel = ".SENS";

--- a/qucs/spicecomponents/sp_sens_xyce.h
+++ b/qucs/spicecomponents/sp_sens_xyce.h
@@ -18,10 +18,10 @@
 #ifndef SP_SENS_XYCE_H
 #define SP_SENS_XYCE_H
 
-#include "components/component.h"
+#include "components/simulation.h"
 
 
-class SpiceSENS_Xyce : public Component  {
+class SpiceSENS_Xyce : public qucs::component::SimulationComponent  {
 public:
   SpiceSENS_Xyce();
   ~SpiceSENS_Xyce();
@@ -30,6 +30,7 @@ public:
 
 protected:
   QString spice_netlist(bool isXyce = false);
+  Qt::GlobalColor color() const override { return Qt::darkGreen; }
 };
 
 #endif

--- a/qucs/spicecomponents/sp_spectrum.cpp
+++ b/qucs/spicecomponents/sp_spectrum.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "sp_spectrum.h"
-#include "main.h"
 #include "misc.h"
 #include "extsimkernels/spicecompat.h"
 
@@ -25,20 +24,7 @@ SpiceFFT::SpiceFFT()
   isSimulation = true;
   Description = QObject::tr("Spectrum analysis");
   Simulator = spicecompat::simNgspice | spicecompat::simSpiceOpus;
-
-  QString  s = Description;
-  int a = s.indexOf(" ");
-  if (a != -1) s[a] = '\n';
-
-  Texts.append(new Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
-  if (a != -1)
-    Texts.append(new Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+104; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".FFT";
   Name  = "FFT";
   SpiceModel = ".FFT";

--- a/qucs/spicecomponents/sp_spectrum.h
+++ b/qucs/spicecomponents/sp_spectrum.h
@@ -18,10 +18,10 @@
 #ifndef SP_SPECTRUM_H
 #define SP_SPECTRUM_H
 
-#include "components/component.h"
+#include "components/simulation.h"
 
 
-class SpiceFFT : public Component  {
+class SpiceFFT : public qucs::component::SimulationComponent  {
 public:
   SpiceFFT();
   ~SpiceFFT();

--- a/qucs/spicecomponents/xyce_script.cpp
+++ b/qucs/spicecomponents/xyce_script.cpp
@@ -15,7 +15,6 @@
  *                                                                         *
  ***************************************************************************/
 #include "xyce_script.h"
-#include "main.h"
 
 
 XyceScript::XyceScript()
@@ -23,14 +22,7 @@ XyceScript::XyceScript()
   isSimulation = true;
   Description = QObject::tr("XYCE script");
   Simulator = spicecompat::simXyce;
-
-  Texts.append(new Text(0, 0, Description, Qt::darkRed, QucsSettings.largeFontSize));
-
-  x1 = -10; y1 = -9;
-  x2 = x1+104; y2 = y1+59;
-
-  tx = 0;
-  ty = y2+1;
+  initSymbol(Description);
   Model = ".XYCESCR";
   Name  = "XYCESCR";
   SpiceModel = "XYCESCR";

--- a/qucs/spicecomponents/xyce_script.h
+++ b/qucs/spicecomponents/xyce_script.h
@@ -18,10 +18,10 @@
 #ifndef SP_XYCESCRIPT_H
 #define SP_XYCESCRIPT_H
 
-#include "components/component.h"
+#include "components/simulation.h"
 
 
-class XyceScript : public Component  {
+class XyceScript : public qucs::component::SimulationComponent  {
 public:
   XyceScript();
   ~XyceScript();
@@ -30,6 +30,7 @@ public:
 
 protected:
   QString spice_netlist(bool isXyce = false);
+  Qt::GlobalColor color() const override { return Qt::darkGreen; }
 };
 
 #endif


### PR DESCRIPTION
Hi!

I started working on #730 and found out that in order to fix it it's better to refine components inheritance hierarchy a bit, so I've come up with this. A short description of changes:
1. Distinction between drawing of simulation and usual components
```
if (Model.at(0) == '.') {   // is simulation component (dc, ac, ...)
    drawSimulator(p);
} else {    // normal components go here
    drawUsual(p);
}
```
is removed from `Component` in favour of a single method — `Component::drawSymbol`. By default it draws a usual component and anyone wanting their own logic has to override it.

2. A new class `SimulationComponent` is added: it inherits from `Component` overriding its `drawSymbol` to provide logic specific to simulation components. This class is meant to be a common base class for all simulation components.
3. All simulation components are changed to inherit from newly created base class .

There are a lot of commits, but most of them are tiny, and the most important ones are the first two. They lay the foundation for all subsequent ones.