### PR TITLE
fixed appimage release.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
           submodules: recursive
 
@@ -59,9 +59,9 @@ jobs:
              mv *.AppImage Qucs-S-x86_64-Linux.AppImage
 
     - name: 'Upload artifact: AppImage'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-          name: Qucs-S-x86_64-Linux.AppImage
+          name: Qucs-S-x86_64-Linux
           path: Qucs-S-x86_64-Linux.AppImage
                 
  


### PR DESCRIPTION
Hi, appimage release not appear in continuous build. Upload artifact and checkout actions updated v4 and upload artifact name changed because of double .appimage appear in release section. 

CI goes to create-release stage but old actions will upload artifact but it didn't show up on artifact section.