### PR TITLE
Small fixeds of SpiceLibComp

### DIFF
--- a/qucs/extsimkernels/spicelibcompdialog.cpp
+++ b/qucs/extsimkernels/spicelibcompdialog.cpp
@@ -333,6 +333,10 @@ void SpiceLibCompDialog::slotSetSymbol()
     listSymPattern->setEnabled(false);
     edtSymFile->setEnabled(true);
     btnOpenSym->setEnabled(true);
+    if (edtSymFile->text().isEmpty()) {
+      symbolPinsCount = 0;
+      return;
+    }
     result = symbol->loadSymFile(edtSymFile->text());
     symbolPinsCount = symbol->getPortsNumber();
   }

--- a/qucs/projectView.cpp
+++ b/qucs/projectView.cpp
@@ -84,6 +84,7 @@ ProjectView::refresh()
   APPEND_ROW(m_model, tr("VHDL")         );
   APPEND_ROW(m_model, tr("Octave")       );
   APPEND_ROW(m_model, tr("Schematics")   );
+  APPEND_ROW(m_model, tr("Symbols")      );
   APPEND_ROW(m_model, tr("SPICE")       );
   APPEND_ROW(m_model, tr("Others")       );
 
@@ -139,13 +140,14 @@ ProjectView::refresh()
         }
         APPEND_CHILD(6, columnData);
       }
-    }
-    else if ((extName == "cir") || (extName=="ckt") ||
-             (extName=="sp")) {
+    } else if (extName == "sym") {
         APPEND_CHILD(7,columnData);
+    } else if ((extName == "cir") || (extName=="ckt") ||
+             (extName=="sp")) {
+        APPEND_CHILD(8,columnData);
     }
     else {
-      APPEND_CHILD(8, columnData);
+      APPEND_CHILD(9, columnData);
     }
   }
 

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -660,7 +660,7 @@ void QucsApp::initActions()
   helpGetStart->setWhatsThis(tr("Getting Started\n\nShort introduction into Qucs"));
   connect(helpGetStart, SIGNAL(triggered()), SLOT(slotGettingStarted()));
 
-  helpAboutApp = new QAction(tr("&About qucs-s"), this);
+  helpAboutApp = new QAction(tr("&About Qucs-S"), this);
   helpAboutApp->setStatusTip(tr("About the application"));
   helpAboutApp->setWhatsThis(tr("About\n\nAbout the application"));
   connect(helpAboutApp, SIGNAL(triggered()),this, SLOT(slotHelpAbout()));

--- a/qucs/spicecomponents/spicelibcomp.cpp
+++ b/qucs/spicecomponents/spicelibcomp.cpp
@@ -85,7 +85,7 @@ void SpiceLibComp::createSymbol()
 {
   int No;
   QString FileName;
-  QString symname = Props.at(2)->Value;
+  QString symname = misc::properAbsFileName(Props.at(2)->Value, containingSchematic);
   if (QFileInfo::exists(symname)) {
     FileName = symname;
   } else {


### PR DESCRIPTION
This PR fixes problems with SpiceLibComp reported in #792 

* Crash on editing properties of the device using user or auto symbol
* Loading symbol file if the schematic is a part of project
* Added *Symbols* group in project tree
* Fixed application name in *Help->About Qucs-S*