### PR TITLE
Set validator for component name

### DIFF
--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -69,6 +69,8 @@ ComponentDialog::ComponentDialog(Component *c, Schematic *d)
   Validator2 = new QRegularExpressionValidator(Expr, this);
   Expr.setPattern("[\\w_.,\\(\\) @:\\[\\]]+");  // valid expression for property 'NameEdit'. Space to enable Spice-style par sweep
   ValRestrict = new QRegularExpressionValidator(Expr, this);
+  Expr.setPattern("[A-Za-z][A-Za-z0-9_]+");
+  ValName = new QRegularExpressionValidator(Expr,this);
 
   checkSim  = 0;  comboSim  = 0;  comboType  = 0;  checkParam = 0;
   editStart = 0;  editStop = 0;  editNumber = 0;
@@ -286,7 +288,7 @@ ComponentDialog::ComponentDialog(Component *c, Schematic *d)
   CompNameEdit = new QLineEdit;
   h5->addWidget(CompNameEdit);
 
-  CompNameEdit->setValidator(ValRestrict);
+  CompNameEdit->setValidator(ValName);
   connect(CompNameEdit, SIGNAL(returnPressed()), SLOT(slotButtOK()));
 
   showName = new QCheckBox(tr("display in schematic"));

--- a/qucs/components/componentdialog.h
+++ b/qucs/components/componentdialog.h
@@ -83,7 +83,8 @@ protected slots:
 
 private:
   QVBoxLayout *all;   // the mother of all widgets
-  QValidator  *Validator, *ValRestrict, *Validator2;
+  QValidator  *Validator, *ValRestrict, *Validator2,
+              *ValName;
   QRegularExpression     Expr;
   QIntValidator *ValInteger;
   QTableWidget  *prop;


### PR DESCRIPTION
This PR fixes #812. The sapces in component name are not allowed anymore. 