### PR TITLE
Recognize TEMP or TEMPER variable and sweep temperature

### DIFF
--- a/qucs/components/param_sweep.cpp
+++ b/qucs/components/param_sweep.cpp
@@ -150,6 +150,7 @@ QString Param_Sweep::getNgspiceBeforeSim(QString sim, int lvl)
 
         bool modelsweep = false; // Find component and its modelstring
         bool compfound = false;
+        bool temper_sweep = false;
         QString mod,mod_par;
 
         if (!par.contains('@')) {
@@ -172,14 +173,21 @@ QString Param_Sweep::getNgspiceBeforeSim(QString sim, int lvl)
         if (pc != NULL) compfound = true;
         else compfound = false;
 
+        if (step_var == "temp" || step_var == "temper") temper_sweep = true;
+
         if (modelsweep) { // Model parameter sweep
             s += QString("altermod %1 %2 = $%3_act%4").arg(mod).arg(mod_par).arg(step_var).arg(nline_char);
         } else {
             QString mswp = getProperty("SweepModel")->Value;
-            if (mswp == "true")
-                s += QString("altermod %1 = $%2_act%3").arg(par).arg(step_var).arg(nline_char);
-            else if (compfound) s += QString("alter %1 = $%2_act%3").arg(par).arg(step_var).arg(nline_char);
-            else s += QString("alterparam %1 = $%2_act%3reset%3").arg(par).arg(step_var).arg(nline_char);
+            if (mswp == "true") {
+              s += QString("altermod %1 = $%2_act%3").arg(par).arg(step_var).arg(nline_char);
+            } else if (temper_sweep) {
+              s += QString("option temp = $%1_act%2").arg(step_var).arg(nline_char);
+            } else if (compfound) {
+              s += QString("alter %1 = $%2_act%3").arg(par).arg(step_var).arg(nline_char);
+            } else {
+              s += QString("alterparam %1 = $%2_act%3reset%3").arg(par).arg(step_var).arg(nline_char);
+            }
         }
     }
     return s;


### PR DESCRIPTION
This PR is follow-up of the discussion #809. Qucs-S is now able to recognize `TEMP` and `TEMPER` variable in parameter sweep and sweep global schematic temperature. Here is an example illustrating a new feature. 

![image](https://github.com/ra3xdh/qucs_s/assets/4920080/4fd8e60f-e2d0-426f-89bf-756aa4a7c4f4)
