### PR TITLE
Draw component port as filled square when it has only one connection

### DIFF
--- a/qucs/node.cpp
+++ b/qucs/node.cpp
@@ -50,13 +50,11 @@ void Node::paint(QPainter* painter) const {
       return;
 
     case 2:
-      if (Connections.getFirst()->Type == isWire) {
-        if (Connections.getLast()->Type == isWire) {
+      if (Connections.getFirst()->Type == isWire && Connections.getLast()->Type == isWire) {
           painter->restore();
           return;
-        }
-        painter->fillRect(cx-2, cy-2, 4, 4, Qt::darkBlue);
       }
+      painter->fillRect(cx-2, cy-2, 4, 4, Qt::darkBlue);
       break;
 
     default:


### PR DESCRIPTION
This is a fix of regression introduced in 4e9e9680.

When I was adapting the `Node::paint` to QPainter I made a mistake in translation from couple of braceless `if`s to `if` blocks with braces. Compare this:

```
    case 2:  if(Connections.getFirst()->Type == isWire)
               if(Connections.getLast()->Type == isWire) return;
             p->fillRect(cx-2, cy-2, 4, 4, Qt::darkBlue);
             break;
```
and this 
```
    case 2:
      if (Connections.getFirst()->Type == isWire) {
        if (Connections.getLast()->Type == isWire) {
          painter->restore();
          return;
        }
        painter->fillRect(cx-2, cy-2, 4, 4, Qt::darkBlue);
      }
      break;
```

— the former is logical AND of two conditions, and the latter is something else.

The problem with component port rendering is described in #818