### PR TITLE
Use stylesheet to change appearance of QLineEdit used for editing a property value

### DIFF
--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -1319,7 +1319,7 @@ void QucsApp::slotApplyCompText()
   z = editText->fontMetrics().lineSpacing();
   view->MAy2 += n*z;
   editText->setText(s);
-  misc::setWidgetBackgroundColor(editText,QucsSettings.BGColor);
+  editText->setStyleSheet("color: black; background-color: " + QucsSettings.BGColor.name());
   editText->setFocus();
   editText->selectAll();
   editText->setParent(Doc->viewport());


### PR DESCRIPTION
In ra3xdh/qucs_s#818 @dsm mentioned that when property value text is being edited, the color of text background depends on current colorscheme (dark/light), which sometimes makes text barely visible.

With this commit the background color of QLineEdit, used to modifying property value, is set using stylesheet instead of QPalette.