### PR TITLE
Enable variables for blue nonlinear devices

### DIFF
--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -739,9 +739,7 @@ QString Component::form_spice_param_list(QStringList &ignore_list, QStringList &
             } else {
                 nam = Props.at(i)->Name;
             }
-            double val, fac;
-            misc::str2num(Props.at(i)->Value, val, unit, fac);
-            val *= fac;
+            QString val = spicecompat::normalize_value(Props.at(i)->Value);
             par_str += QString("%1=%2 ").arg(nam).arg(val);
         }
 

--- a/qucs/components/equation.cpp
+++ b/qucs/components/equation.cpp
@@ -87,7 +87,7 @@ Component* Equation::newOne()
 
 Element* Equation::info(QString& Name, char* &BitmapFile, bool getNewOne)
 {
-  Name = QObject::tr("Qucs legacy equation");
+  Name = QObject::tr("Qucsator equation");
   BitmapFile = (char *) "equation";
 
   if(getNewOne)  return new Equation();

--- a/qucs/components/param_sweep.h
+++ b/qucs/components/param_sweep.h
@@ -35,7 +35,6 @@ public:
 
 protected:
   QString spice_netlist(bool isXyce);
-  QString netlist();
   QString param_split_str=";";
 };
 

--- a/qucs/diagrams/diagram.cpp
+++ b/qucs/diagrams/diagram.cpp
@@ -213,6 +213,7 @@ void Diagram::createAxisLabels() {
 
     QStringList used_kernels, used_simulations;
     for (const auto pg: Graphs) {
+      if (!pg->Var.contains("/")) continue; // Qucsator data
         QString kernel_name = pg->Var.section('/', 0, 0);
         QString var_name = pg->Var;
         auto p = var_name.indexOf('/');


### PR DESCRIPTION
This PR contains the following fixes:

* Enabled variables for blue devices parameters
* Rename *Qucs legacy equation* to *Qucsator equation*
* Deprecate SweepModel property of Parameter sweep simulation. See #839 
* Fixed chopping of Qucsator variable names in diagram axis labels

Here is the test case for the fix. The version before fix gives error on this schematic and doesn't accept `Bf=BF1`.

![image](https://github.com/user-attachments/assets/d079946b-4271-4a95-a15b-c753d374b628)

