### PR TITLE
Get rid of MouseActions::drawn

### DIFF
--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -178,7 +178,6 @@ void MouseActions::editLabel(Schematic *Doc, WireLabel *pl)
 
     Doc->updateAllBoundingRect();
     Doc->viewport()->update();
-    drawn = false;
     Doc->setChanged(true, true);
 }
 
@@ -239,7 +238,6 @@ void MouseActions::endElementMoving(Schematic *Doc,
   Doc->enlargeView(totalBounds.left(), totalBounds.top(), totalBounds.right(), totalBounds.bottom());
 
   Doc->viewport()->update();
-  drawn = false;
 }
 
 // -----------------------------------------------------------
@@ -322,16 +320,10 @@ void MouseActions::MMoveElement(Schematic *Doc, QMouseEvent *Event)
 
     if (selElem->Type == isPainting) {
         Doc->PostPaintEvent(_NotRop, 0, 0, 0, 0);
-        ((Painting *) selElem)->MouseMoving(Doc, x, y, gx, gy, Doc, fx, fy, drawn);
-        drawn = true;
+        ((Painting *) selElem)->MouseMoving(Doc, x, y, gx, gy, Doc, fx, fy);
         Doc->viewport()->update();
         return;
     } // of "if(isPainting)"
-
-    // ********** it is a component or diagram
-    if (drawn)
-        selElem->paintScheme(Doc); // erase old scheme
-    drawn = true;
 
     //  Component *comp = (Component*)selElem;
     //qDebug() << "desc" << comp->Description << "gx" << gx << "gy" << gy;
@@ -561,7 +553,6 @@ void MouseActions::MMoveMoving(Schematic *Doc, QMouseEvent *Event)
         pe->paintScheme(Doc);
     }
 
-    drawn = true;
     MAx1 = MAx2;
     MAy1 = MAy2;
     QucsMain->MouseMoveAction = &MouseActions::MMoveMoving2;
@@ -582,11 +573,7 @@ void MouseActions::MMoveMoving2(Schematic *Doc, QMouseEvent *Event)
   MAy2 = inModel.y();
 
   Element *pe;
-  if (drawn) // erase old scheme
-    for (pe = movingElements.first(); pe != nullptr; pe = movingElements.next())
-      pe->paintScheme(Doc);
 
-  drawn = true;
   if ((Event->modifiers().testFlag(Qt::ControlModifier)) == 0)
     Doc->setOnGrid(MAx2, MAy2); // use grid only if CTRL key not pressed
   MAx1 = MAx2 - MAx1;
@@ -620,7 +607,6 @@ void MouseActions::MMovePaste(Schematic *Doc, QMouseEvent *Event)
     moveElements(Doc, MAx1, MAy1);
     paintElementsScheme(Doc);
 
-    drawn = true;
     QucsMain->MouseMoveAction = &MouseActions::MMoveMoving2;
     QucsMain->MouseReleaseAction = &MouseActions::MReleasePaste;
 }
@@ -1008,7 +994,6 @@ void MouseActions::rightPressMenu(Schematic *Doc, QMouseEvent *Event, float fX, 
     ComponentMenu->popup(Event->globalPos());
 #endif
     Doc->viewport()->update();
-    drawn = false;
 }
 
 // -----------------------------------------------------------
@@ -1082,7 +1067,6 @@ void MouseActions::MPressLabel(Schematic *Doc, QMouseEvent *, float fX, float fY
 
     Doc->updateAllBoundingRect();
     Doc->viewport()->update();
-    drawn = false;
     Doc->setChanged(true, true);
 }
 
@@ -1180,7 +1164,6 @@ void MouseActions::MPressSelect(Schematic *Doc, QMouseEvent *Event, float fX, fl
             // Update matching wire label highlighting
             Doc->highlightWireLabels();
             Doc->viewport()->update();
-            drawn = false;
             return;
 
         case isComponentText: // property text of component ?
@@ -1222,7 +1205,6 @@ void MouseActions::MPressSelect(Schematic *Doc, QMouseEvent *Event, float fX, fl
     QucsMain->MouseDoubleClickAction = 0;
     Doc->grabKeyboard(); // no keyboard inputs during move actions
     Doc->viewport()->update();
-    drawn = false;
 
     if (focusElement == 0) {
         MAx2 = 0; // if not clicking on an element => open a rectangle
@@ -1253,7 +1235,6 @@ void MouseActions::MPressDelete(Schematic *Doc, QMouseEvent *, float fX, float f
 
         Doc->updateAllBoundingRect();
         Doc->viewport()->update();
-        drawn = false;
     }
 }
 
@@ -1271,7 +1252,6 @@ void MouseActions::MPressActivate(Schematic *Doc, QMouseEvent *, float fX, float
         QucsMain->MouseMoveAction = &MouseActions::MMoveSelect;
     }
     Doc->viewport()->update();
-    drawn = false;
 }
 
 // -----------------------------------------------------------
@@ -1292,7 +1272,6 @@ void MouseActions::MPressMirrorX(Schematic *Doc, QMouseEvent *, float fX, float 
     }
 
     Doc->viewport()->update();
-    drawn = false;
     Doc->setChanged(true, true);
 }
 
@@ -1314,7 +1293,6 @@ void MouseActions::MPressMirrorY(Schematic *Doc, QMouseEvent *, float fX, float 
     }
 
     Doc->viewport()->update();
-    drawn = false;
     Doc->setChanged(true, true);
 }
 
@@ -1370,7 +1348,6 @@ void MouseActions::MPressRotate(Schematic *Doc, QMouseEvent *, float fX, float f
         return;
     }
     Doc->viewport()->update();
-    drawn = false;
     Doc->setChanged(true, true);
 }
 
@@ -1409,7 +1386,6 @@ void MouseActions::MPressElement(Schematic *Doc, QMouseEvent *Event, float, floa
             Doc->enlargeView(x1, y1, x2, y2);
             //Doc->setOnGrid(Comp->cx,Comp->cy);
 
-            drawn = false;
             Doc->viewport()->update();
             Doc->setChanged(true, true);
             rot = Comp->rotated;
@@ -1458,7 +1434,6 @@ void MouseActions::MPressElement(Schematic *Doc, QMouseEvent *Event, float, floa
         DiagramDialog *dia = new DiagramDialog(Diag, Doc);
         if (dia->exec() == QDialog::Rejected) { // don't insert if dialog canceled
             Doc->viewport()->update();
-            drawn = false;
             return;
         }
 
@@ -1484,7 +1459,6 @@ void MouseActions::MPressElement(Schematic *Doc, QMouseEvent *Event, float, floa
         Doc->setChanged(true, true);
 
         MMoveElement(Doc, Event); // needed before next mouse pressing
-        drawn = false;
     }
 }
 
@@ -1567,7 +1541,6 @@ void MouseActions::MPressWire2(Schematic *Doc, QMouseEvent *Event, float fX, flo
         //ALYS: excessive update. end of function does it.
         //Doc->viewport()->update();
 
-        drawn = false;
         if (set1 | set2)
             Doc->setChanged(true, true);
         MAx3 = MAx2;
@@ -1627,7 +1600,6 @@ void MouseActions::MPressMarker(Schematic *Doc, QMouseEvent *, float fX, float f
         Doc->enlargeView(x0 + pm->x1, y0 - pm->y1 - pm->y2, x0 + pm->x1 + pm->x2, y0 - pm->y1);
     }
     Doc->viewport()->update();
-    drawn = false;
 }
 
 /**
@@ -1665,7 +1637,6 @@ void MouseActions::MPressSetLimits(Schematic *Doc, QMouseEvent*, float fX, float
     }
 
     Doc->viewport()->update();
-    drawn = false;
 }
 
 // -----------------------------------------------------------
@@ -1683,7 +1654,6 @@ void MouseActions::MPressOnGrid(Schematic *Doc, QMouseEvent *, float fX, float f
         // Update matching wire label highlighting
         Doc->highlightWireLabels();
         Doc->viewport()->update();
-        drawn = false;
     }
 }
 
@@ -1700,7 +1670,6 @@ void MouseActions::MPressMoveText(Schematic *Doc, QMouseEvent *, float fX, float
         MAx1 = ((Component *) focusElement)->cx + ((Component *) focusElement)->tx;
         MAy1 = ((Component *) focusElement)->cy + ((Component *) focusElement)->ty;
         Doc->viewport()->update();
-        drawn = false;
         QucsMain->MouseMoveAction = &MouseActions::MMoveMoveText;
         QucsMain->MouseReleaseAction = &MouseActions::MReleaseMoveText;
         Doc->grabKeyboard(); // no keyboard inputs during move actions
@@ -1720,7 +1689,6 @@ void MouseActions::MPressZoomIn(Schematic *Doc, QMouseEvent *, float fX, float f
     QucsMain->MouseReleaseAction = &MouseActions::MReleaseZoomIn;
     Doc->grabKeyboard(); // no keyboard inputs during move actions
     Doc->viewport()->update();
-    drawn = false;
 }
 
 // ***********************************************************************
@@ -1753,7 +1721,6 @@ void MouseActions::MReleaseSelect(Schematic *Doc, QMouseEvent *Event)
     QucsMain->MouseMoveAction = 0; // no element moving
     Doc->highlightWireLabels();
     Doc->viewport()->update();
-    drawn = false;
 }
 
 // -----------------------------------------------------------
@@ -1777,7 +1744,6 @@ void MouseActions::MReleaseSelect2(Schematic *Doc, QMouseEvent *Event)
     Doc->highlightWireLabels();
     Doc->PostedPaintEvents.clear();
     Doc->viewport()->update();
-    drawn = false;
 }
 
 // -----------------------------------------------------------
@@ -1795,7 +1761,6 @@ void MouseActions::MReleaseActivate(Schematic *Doc, QMouseEvent *Event)
     QucsMain->MouseDoubleClickAction = 0;
     Doc->highlightWireLabels();
     Doc->viewport()->update();
-    drawn = false;
 }
 
 // -----------------------------------------------------------
@@ -1869,7 +1834,6 @@ void MouseActions::MReleaseResizeDiagram(Schematic *Doc, QMouseEvent *Event)
     Doc->releaseKeyboard(); // allow keyboard inputs again
 
     Doc->viewport()->update();
-    drawn = false;
     Doc->setChanged(true, true);
 }
 
@@ -1886,7 +1850,6 @@ void MouseActions::MReleaseResizePainting(Schematic *Doc, QMouseEvent *Event)
     Doc->releaseKeyboard(); // allow keyboard inputs again
 
     Doc->viewport()->update();
-    drawn = false;
     Doc->setChanged(true, true);
 }
 
@@ -2058,7 +2021,6 @@ void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
         QucsMain->MouseReleaseAction = 0;
         QucsMain->MouseDoubleClickAction = 0;
 
-        drawn = false;
         Doc->viewport()->update();
         Doc->setChanged(true, true);
         break;
@@ -2066,10 +2028,6 @@ void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
     // ............................................................
     case Qt::RightButton: {// right button rotates the elements
         //setPainter(Doc, &painter);
-
-        if (drawn) // erase old scheme
-            paintElementsScheme(Doc);
-        drawn = true;
 
         auto inModel = Doc->contentsToModel(Event->pos());
         x1 = inModel.x();
@@ -2099,7 +2057,6 @@ void MouseActions::MReleaseMoveText(Schematic *Doc, QMouseEvent *Event)
     ((Component *) focusElement)->tx = MAx1 - ((Component *) focusElement)->cx;
     ((Component *) focusElement)->ty = MAy1 - ((Component *) focusElement)->cy;
     Doc->viewport()->update();
-    drawn = false;
     Doc->setChanged(true, true);
 }
 
@@ -2265,7 +2222,6 @@ void MouseActions::editElement(Schematic *Doc, QMouseEvent *Event)
     Doc->setFocus();
 
     Doc->viewport()->update();
-    drawn = false;
 }
 
 // -----------------------------------------------------------

--- a/qucs/mouseactions.h
+++ b/qucs/mouseactions.h
@@ -44,7 +44,6 @@ public:
   void editElement(Schematic*, QMouseEvent*);
   void editLabel(Schematic*, WireLabel*);
 
-  bool drawn;  // indicates whether the scheme element was drawn last time
   Element *selElem;  // component/diagram/painting selected in IconView
   Element *focusElement;
   QMouseEvent *focusMEvent;

--- a/qucs/paintings/arrow.cpp
+++ b/qucs/paintings/arrow.cpp
@@ -257,7 +257,7 @@ void Arrow::calcArrowHead()
 // x/y are coordinates without scaling.
 void Arrow::MouseMoving(
 	Schematic *paintScale, int, int, int gx, int gy,
-	Schematic *p, int x, int y, bool drawn)
+	Schematic *p, int x, int y)
 {
   if(State > 0) {
     if(State > 1) {
@@ -272,13 +272,6 @@ void Arrow::MouseMoving(
   }
   else { cx = gx; cy = gy; }
 
-
-// FIXME #warning  p->setPen(Qt::SolidLine);
-  if(drawn) {
-    p->PostPaintEvent(_Line, x1+25, y1, x1+13, y1+12,0,0,true);  // erase old cursor symbol
-    p->PostPaintEvent(_Line, x1+18, y1+2, x1+25, y1,0,0,true);
-    p->PostPaintEvent(_Line, x1+23, y1+7, x1+25, y1,0,0,true);
-  }
   x1 = x;
   y1 = y;
   p->PostPaintEvent(_Line, x1+25, y1, x1+13, y1+12,0,0,true);  // paint new cursor symbol

--- a/qucs/paintings/arrow.h
+++ b/qucs/paintings/arrow.h
@@ -39,7 +39,7 @@ public:
   QString save();
   QString saveCpp();
   QString saveJSON();
-  void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int, bool);
+  void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int);
   bool MousePressing(Schematic *sch = 0);
   bool getSelected(float, float, float);
   void Bounding(int&, int&, int&, int&);

--- a/qucs/paintings/ellipse.cpp
+++ b/qucs/paintings/ellipse.cpp
@@ -260,7 +260,7 @@ void qucs::Ellipse::MouseResizeMoving(int x, int y, Schematic *p)
 // x/y are coordinates without scaling.
 void qucs::Ellipse::MouseMoving(
 	Schematic *paintScale, int, int, int gx, int gy,
-	Schematic *p, int x, int y, bool drawn)
+	Schematic *p, int x, int y)
 {
   if(State > 0) {
     if(State > 1)
@@ -273,14 +273,6 @@ void qucs::Ellipse::MouseMoving(
   }
   else { x2 = gx; y2 = gy; }
 
-  if(drawn) {
-    p->PostPaintEvent(_Ellipse, cx+13, cy, 18, 12,0,0,true);  // erase old cursor symbol
-    if(filled) {
-      p->PostPaintEvent(_Line, cx+14, cy+7, cx+20, cy+1,0,0,true);
-      p->PostPaintEvent(_Line, cx+25, cy+2, cx+18, cy+9,0,0,true);
-      p->PostPaintEvent(_Line, cx+29, cy+4, cx+23, cy+10,0,0,true);
-    }
-  }
   cx = x;
   cy = y;
   p->PostPaintEvent(_Ellipse, cx+13, cy, 18, 12,0,0,true);  // paint new cursor symbol

--- a/qucs/paintings/ellipse.h
+++ b/qucs/paintings/ellipse.h
@@ -41,7 +41,7 @@ public:
   QString saveCpp();
   QString saveJSON();
   void paint(QPainter* painter);
-  void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int, bool);
+  void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int);
   bool MousePressing(Schematic *sch = 0);
   bool getSelected(float, float, float);
   bool resizeTouched(float, float, float);

--- a/qucs/paintings/ellipsearc.cpp
+++ b/qucs/paintings/ellipsearc.cpp
@@ -227,7 +227,7 @@ void EllipseArc::MouseResizeMoving(int x, int y, Schematic *p)
 // x/y are coordinates without scaling.
 void EllipseArc::MouseMoving(
 	Schematic *paintScale, int fx, int fy, int gx, int gy,
-	Schematic *p, int x, int y, bool drawn)
+	Schematic *p, int x, int y)
 {
   switch(State) {
     case 0 :
@@ -286,11 +286,6 @@ void EllipseArc::MouseMoving(
       paintScale->PostPaintEvent(_Arc, cx, cy, x2, y2, Angle, ArcLen);// paint new painting
       break;
   }
-
-
-  // FIXME #warning p->setPen(Qt::SolidLine);
-  if(drawn)
-    p->PostPaintEvent(_Arc, x1+13, y1, 18, 12, 16*45, 16*200,true); // erase old cursor symbol
 
   x1 = x;
   y1 = y;

--- a/qucs/paintings/ellipsearc.h
+++ b/qucs/paintings/ellipsearc.h
@@ -39,7 +39,7 @@ public:
   QString saveCpp();
   QString saveJSON();
   void paint(QPainter* painter);
-  void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int, bool);
+  void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int);
   bool MousePressing(Schematic *sch = 0);
   bool getSelected(float, float, float);
   bool resizeTouched(float, float, float);

--- a/qucs/paintings/graphicline.cpp
+++ b/qucs/paintings/graphicline.cpp
@@ -203,7 +203,7 @@ void GraphicLine::MouseResizeMoving(int x, int y, Schematic *p)
 // x/y are coordinates without scaling.
 void GraphicLine::MouseMoving(
 	Schematic *paintScale, int, int, int gx, int gy,
-	Schematic *p, int x, int y, bool drawn)
+	Schematic *p, int x, int y)
 {
   if(State > 0) {
     if(State > 1)
@@ -215,13 +215,6 @@ void GraphicLine::MouseMoving(
   }
   else { cx = gx; cy = gy; }
 
-
-  // FIXME #warning p->setPen(Qt::SolidLine);
-  if(drawn) {
-    p->PostPaintEvent(_Line, x1+27, y1, x1+15, y1+12,0,0,true);  // erase old cursor symbol
-    p->PostPaintEvent(_Line, x1+25, y1-2, x1+29, y1+2,0,0,true);
-    p->PostPaintEvent(_Line, x1+13, y1+10, x1+17, y1+14,0,0,true);
-  }
   x1 = x;
   y1 = y;
   p->PostPaintEvent(_Line, x1+27, y1, x1+15, y1+12,0,0,true);  // paint new cursor symbol

--- a/qucs/paintings/graphicline.h
+++ b/qucs/paintings/graphicline.h
@@ -40,7 +40,7 @@ public:
   QString saveCpp();
   QString saveJSON();
   void paint(QPainter* painter);
-  void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int, bool);
+  void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int);
   bool MousePressing(Schematic *sch = 0);
   bool getSelected(float, float, float);
   void Bounding(int&, int&, int&, int&);

--- a/qucs/paintings/graphictext.cpp
+++ b/qucs/paintings/graphictext.cpp
@@ -214,14 +214,8 @@ QString GraphicText::saveJSON()
 // fx/fy are the precise coordinates, gx/gy are the coordinates set on grid.
 // x/y are coordinates without scaling.
 void GraphicText::MouseMoving(
-    Schematic *, int, int, int gx, int gy, Schematic *p, int x, int y, bool drawn)
+    Schematic *, int, int, int gx, int gy, Schematic *p, int x, int y)
 {
-    // FIXME #warning p->setPen(Qt::SolidLine);
-    if (drawn) {
-        p->PostPaintEvent(_Line, x1 + 15, y1 + 15, x1 + 20, y1, 0, 0, true); // erase old cursor symbol
-        p->PostPaintEvent(_Line, x1 + 26, y1 + 15, x1 + 21, y1, 0, 0, true);
-        p->PostPaintEvent(_Line, x1 + 17, y1 + 8, x1 + 23, y1 + 8, 0, 0, true);
-    }
     x1 = x;
     y1 = y;
     p->PostPaintEvent(_Line, x1 + 15, y1 + 15, x1 + 20, y1, 0, 0, true); // paint new cursor symbol

--- a/qucs/paintings/graphictext.h
+++ b/qucs/paintings/graphictext.h
@@ -41,7 +41,7 @@ public:
   QString saveCpp();
   QString saveJSON();
   void paint(QPainter* painter);
-  void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int, bool);
+  void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int);
   bool MousePressing(Schematic *sch = 0);
   bool getSelected(float, float, float);
   void Bounding(int&, int&, int&, int&);

--- a/qucs/paintings/painting.h
+++ b/qucs/paintings/painting.h
@@ -36,7 +36,7 @@ public:
   virtual QString saveJSON();
   virtual void paint(QPainter*) {};
   virtual void MouseMoving(Schematic*, int, int, int, int,
-                           Schematic*, int, int, bool) {};
+                           Schematic*, int, int) {};
   virtual bool MousePressing(Schematic *sch = 0) { Q_UNUSED(sch) return false; };
   virtual void Bounding(int&, int&, int&, int&);
   virtual bool resizeTouched(float, float, float) { return false; };

--- a/qucs/paintings/portsymbol.cpp
+++ b/qucs/paintings/portsymbol.cpp
@@ -249,7 +249,7 @@ bool PortSymbol::MousePressing(Schematic *sch) {
   return false;
 }
 
-void PortSymbol::MouseMoving(Schematic* doc, int, int, int gx, int gy, Schematic *, int, int, bool) {
+void PortSymbol::MouseMoving(Schematic* doc, int, int, int gx, int gy, Schematic *, int, int) {
   cx = gx;
   cy = gy;
   paintScheme(doc);

--- a/qucs/paintings/portsymbol.h
+++ b/qucs/paintings/portsymbol.h
@@ -31,7 +31,7 @@ public:
   void paintScheme(Schematic*);
   void getCenter(int&, int&);
   void setCenter(int, int, bool relative=false);
-  void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int, bool) override;
+  void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int) override;
   bool MousePressing(Schematic*sch) override;
   Painting* newOne() override;
   bool Dialog(QWidget *Doc) override;

--- a/qucs/paintings/rectangle.cpp
+++ b/qucs/paintings/rectangle.cpp
@@ -258,7 +258,7 @@ void qucs::Rectangle::MouseResizeMoving(int x, int y, Schematic *p)
 // x/y are coordinates without scaling.
 void qucs::Rectangle::MouseMoving(
 	Schematic *paintScale, int, int, int gx, int gy,
-	Schematic *p, int x, int y, bool drawn)
+	Schematic *p, int x, int y)
 {
   if(State > 0) {
     if(State > 1)
@@ -270,16 +270,6 @@ void qucs::Rectangle::MouseMoving(
   }
   else { x2 = gx; y2 = gy; }
 
-
-  // FIXME #warning p->setPen(Qt::SolidLine);
-  if(drawn) {
-    p->PostPaintEvent(_Rect, cx+13, cy, 18, 12,0,0,true);  // erase old cursor symbol
-    if(filled) {   // hatched ?
-      p->PostPaintEvent(_Line, cx+14, cy+6, cx+19, cy+1,0,0,true);
-      p->PostPaintEvent(_Line, cx+26, cy+1, cx+17, cy+10,0,0,true);
-      p->PostPaintEvent(_Line, cx+29, cy+5, cx+24, cy+10,0,0,true);
-    }
-  }
   cx = x;
   cy = y;
   p->PostPaintEvent(_Rect,cx+13, cy, 18, 12,0,0,true);  // paint new cursor symbol

--- a/qucs/paintings/rectangle.h
+++ b/qucs/paintings/rectangle.h
@@ -41,7 +41,7 @@ public:
   QString saveCpp();
   QString saveJSON();
   void paint(QPainter* painter);
-  void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int, bool);
+  void MouseMoving(Schematic*, int, int, int, int, Schematic*, int, int);
   bool MousePressing(Schematic *sch = 0);
   bool getSelected(float, float, float);
   bool resizeTouched(float, float, float);

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -1023,9 +1023,9 @@ void QucsApp::slotSelectComponent(QListWidgetItem *item)
     return;
   }
 
-  if(view->drawn)
-    ((Q3ScrollView*)DocumentTab->currentWidget())->viewport()->update();
-  view->drawn = false;
+  //if(view->drawn)
+  //  ((Q3ScrollView*)DocumentTab->currentWidget())->viewport()->update();
+  //view->drawn = false;
 
   // toggle last toolbar button off
   if(activeAction) {
@@ -1382,8 +1382,6 @@ void QucsApp::openProject(const QString& Path)
   int i = addDocumentTab(d);
   DocumentTab->setCurrentIndex(i);
 
-  view->drawn = false;
-
   slotResetWarnings();
 
   QucsSettings.QucsWorkDir.setPath(ProjDir.path());
@@ -1455,8 +1453,6 @@ void QucsApp::slotMenuProjClose()
   Schematic *d = new Schematic(this, "");
   int i = addDocumentTab(d);
   DocumentTab->setCurrentIndex(i);
-
-  view->drawn = false;
 
   slotResetWarnings();
   setWindowTitle(windowTitle);
@@ -1624,7 +1620,6 @@ bool QucsApp::gotoPage(const QString& Name)
   if(!d->load()) {    // load document if possible
     delete d;
     DocumentTab->setCurrentIndex(No);
-    view->drawn = false;
     return false;
   }
   slotChangeView();
@@ -1645,7 +1640,6 @@ bool QucsApp::gotoPage(const QString& Name)
     if(!getDoc(0)->DocChanged)
       delete DocumentTab->widget(0);
 
-  view->drawn = false;
   return true;
 }
 
@@ -1865,7 +1859,6 @@ void QucsApp::slotFileSaveAll()
   if (tabType == "Schematic") {
     ((Q3ScrollView*)DocumentTab->currentWidget())->viewport()->update();
   }
-  view->drawn = false;
   statusBar()->showMessage(tr("Ready."));
 
   // refresh the schematic file path
@@ -2042,8 +2035,6 @@ void QucsApp::slotChangeView()
 //    setWindowTitle(Info.fileName() + " (" + Info.filePath() +") - " + windowTitle);
 //  }
 
-  view->drawn = false;
-
   HierarchyHistory.clear();
   popH->setEnabled(false);
 }
@@ -2076,7 +2067,6 @@ void QucsApp::slotFileSettings ()
     SettingsDialog * d = new SettingsDialog ((Schematic *) w);
     d->exec ();
   }
-  view->drawn = false;
 }
 
 // --------------------------------------------------------------
@@ -2086,7 +2076,6 @@ void QucsApp::slotApplSettings()
 
   QucsSettingsDialog *d = new QucsSettingsDialog(this);
   d->exec();
-  view->drawn = false;
 }
 
 // --------------------------------------------------------------
@@ -2656,7 +2645,6 @@ void QucsApp::slotChangePage(QString& DocName, QString& DataDisplay)
       file.close();
       if(!d->load()) {
         delete d;
-        view->drawn = false;
         return;
       }
     }
@@ -2841,9 +2829,6 @@ void QucsApp::slotSelectSubcircuit(const QModelIndex &idx)
   Comp->recreate(0);
   view->selElem = Comp;
 
-  if(view->drawn)
-    ((Q3ScrollView*)DocumentTab->currentWidget())->viewport()->update();
-  view->drawn = false;
   MouseMoveAction = &MouseActions::MMoveElement;
   MousePressAction = &MouseActions::MPressElement;
   MouseReleaseAction = 0;
@@ -3067,7 +3052,6 @@ void QucsApp::slotSymbolEdit()
     changeSchematicSymbolMode(SDoc);
     SDoc->becomeCurrent(true);
     SDoc->viewport()->update();
-    view->drawn = false;
   }
   // in a normal schematic, symbol file
   else {
@@ -3078,7 +3062,6 @@ void QucsApp::slotSymbolEdit()
       changeSchematicSymbolMode(SDoc);
       SDoc->becomeCurrent(true);
       SDoc->viewport()->update();
-      view->drawn = false;
     }
   }
 }

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -117,7 +117,6 @@ bool QucsApp::performToggleAction(bool on, QAction *Action,
   } while(false);   // to perform "break"
 
   Doc->viewport()->update();
-  view->drawn = false;
   return true;
 }
 
@@ -299,7 +298,6 @@ void QucsApp::slotSelect(bool on)
     MouseMoveAction = &MouseActions::MMoveWire1;
     MousePressAction = &MouseActions::MPressWire1;
     Doc->viewport()->update();
-    view->drawn = false;
 
     select->blockSignals(true);
     select->setChecked(false);
@@ -373,9 +371,6 @@ void QucsApp::slotEditPaste(bool on)
       MouseReleaseAction = 0;
       MouseDoubleClickAction = 0;
       activeAction = 0;   // no action active
-      if(view->drawn) {
-        ((Schematic *)Doc)->viewport()->update();
-      }
       return;
     }
 
@@ -395,7 +390,6 @@ void QucsApp::slotEditPaste(bool on)
     }
     activeAction = editPaste;
 
-    view->drawn = false;
     MouseMoveAction = &MouseActions::MMovePaste;
     view->movingRotated = 0;
     MousePressAction = 0;
@@ -450,8 +444,7 @@ void QucsApp::slotInsertEquation(bool on)
   }
 
   Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
-  if(view->drawn) Doc->viewport()->update();
-  view->drawn = false;
+
   MouseMoveAction = &MouseActions::MMoveElement;
   MousePressAction = &MouseActions::MPressElement;
 }
@@ -483,8 +476,7 @@ void QucsApp::slotInsertGround(bool on)
   view->selElem = new Ground();
 
   Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
-  if(view->drawn) Doc->viewport()->update();
-  view->drawn = false;
+
   MouseMoveAction = &MouseActions::MMoveElement;
   MousePressAction = &MouseActions::MPressElement;
 }
@@ -520,8 +512,6 @@ void QucsApp::slotInsertPort(bool on)
      view->selElem = new SubCirPort();
   }
 
-  if(view->drawn) Doc->viewport()->update();
-  view->drawn = false;
   MouseMoveAction = &MouseActions::MMoveElement;
   MousePressAction = &MouseActions::MPressElement;
 }
@@ -541,7 +531,6 @@ void QucsApp::slotEditUndo()
 
   Doc->undo();
   Doc->viewport()->update();
-  view->drawn = false;
 }
 
 // --------------------------------------------------------------
@@ -559,7 +548,6 @@ void QucsApp::slotEditRedo()
 
   Doc->redo();
   Doc->viewport()->update();
-  view->drawn = false;
 }
 
 // --------------------------------------------------------------
@@ -573,7 +561,6 @@ void QucsApp::slotAlignTop()
     QMessageBox::information(this, tr("Info"),
 		      tr("At least two elements must be selected !"));
   Doc->viewport()->update();
-  view->drawn = false;
 }
 
 // --------------------------------------------------------------
@@ -587,7 +574,6 @@ void QucsApp::slotAlignBottom()
     QMessageBox::information(this, tr("Info"),
 		      tr("At least two elements must be selected !"));
   Doc->viewport()->update();
-  view->drawn = false;
 }
 
 // --------------------------------------------------------------
@@ -601,7 +587,6 @@ void QucsApp::slotAlignLeft()
     QMessageBox::information(this, tr("Info"),
 		      tr("At least two elements must be selected !"));
   Doc->viewport()->update();
-  view->drawn = false;
 }
 
 // --------------------------------------------------------------
@@ -615,7 +600,6 @@ void QucsApp::slotAlignRight()
     QMessageBox::information(this, tr("Info"),
 		      tr("At least two elements must be selected !"));
   Doc->viewport()->update();
-  view->drawn = false;
 }
 
 // --------------------------------------------------------------
@@ -627,7 +611,6 @@ void QucsApp::slotDistribHoriz()
   Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
   Doc->distributeHorizontal();
   Doc->viewport()->update();
-  view->drawn = false;
 }
 
 // --------------------------------------------------------------
@@ -639,7 +622,6 @@ void QucsApp::slotDistribVert()
   Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
   Doc->distributeVertical();
   Doc->viewport()->update();
-  view->drawn = false;
 }
 
 // --------------------------------------------------------------
@@ -653,7 +635,6 @@ void QucsApp::slotCenterHorizontal()
     QMessageBox::information(this, tr("Info"),
 		      tr("At least two elements must be selected !"));
   Doc->viewport()->update();
-  view->drawn = false;
 }
 
 // --------------------------------------------------------------
@@ -667,7 +648,6 @@ void QucsApp::slotCenterVertical()
     QMessageBox::information(this, tr("Info"),
 		      tr("At least two elements must be selected !"));
   Doc->viewport()->update();
-  view->drawn = false;
 }
 
 // ---------------------------------------------------------------------
@@ -686,7 +666,6 @@ void QucsApp::slotSelectAll()
     auto selectionRect = ((Schematic*)Doc)->allBoundingRect().marginsAdded(QMargins{1, 1, 1, 1});
     ((Schematic*)Doc)->selectElements(selectionRect.left(), selectionRect.top(), selectionRect.right(), selectionRect.bottom(), true, false);
     ((Schematic*)Doc)->viewport()->update();
-    view->drawn = false;
   }
 }
 
@@ -699,7 +678,6 @@ void QucsApp::slotSelectMarker()
   Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
   Doc->selectMarkers();
   Doc->viewport()->update();
-  view->drawn = false;
 }
 
 
@@ -1137,7 +1115,6 @@ void QucsApp::slotCursorLeft(bool left)
     }
 
     Doc->viewport()->update();
-    view->drawn = false;
     return;
   } else { // random selection. move all of them
     view->moveElements(&movingElements, sign*Doc->GridX, 0);
@@ -1204,7 +1181,6 @@ void QucsApp::slotCursorUp(bool up)
     }
 
     Doc->viewport()->update();
-    view->drawn = false;
     return;
   }else{ // some random selection, put it back
     view->moveElements(&movingElements, 0, ((up)?-1:1) * Doc->GridY);

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -2495,7 +2495,6 @@ void Schematic::slotScrollUp()
 {
     App->editText->setHidden(true); // disable edit of component property
     scrollUp(verticalScrollBar()->singleStep());
-    App->view->drawn = false;
 }
 
 // -----------------------------------------------------------
@@ -2504,7 +2503,6 @@ void Schematic::slotScrollDown()
 {
     App->editText->setHidden(true); // disable edit of component property
     scrollDown(verticalScrollBar()->singleStep());
-    App->view->drawn = false;
 }
 
 // -----------------------------------------------------------
@@ -2513,7 +2511,6 @@ void Schematic::slotScrollLeft()
 {
     App->editText->setHidden(true); // disable edit of component property
     scrollLeft(horizontalScrollBar()->singleStep());
-    App->view->drawn = false;
 }
 
 // -----------------------------------------------------------
@@ -2522,7 +2519,6 @@ void Schematic::slotScrollRight()
 {
     App->editText->setHidden(true); // disable edit of component property
     scrollRight(horizontalScrollBar()->singleStep());
-    App->view->drawn = false;
 }
 
 // *********************************************************************
@@ -2629,15 +2625,6 @@ void Schematic::contentsDragEnterEvent(QDragEnterEvent *Event)
 // ---------------------------------------------------
 void Schematic::contentsDragLeaveEvent(QDragLeaveEvent *)
 {
-    if (App->view->selElem)
-        if (App->view->selElem->Type & isComponent)
-            if (App->view->drawn) {
-                QPainter painter(viewport());
-                App->view->setPainter(this);
-                ((Component *) App->view->selElem)->paintScheme(this);
-                App->view->drawn = false;
-            }
-
     if (formerAction)
         formerAction->setChecked(true); // restore old action
 }

--- a/qucs/schematic_render.cpp
+++ b/qucs/schematic_render.cpp
@@ -189,7 +189,6 @@ double Schematic::renderModel(const double offeredScale, QRect newModel, const Q
     setContentsPos(contentTopLeft.x(), contentTopLeft.y());
 
     viewport()->update();
-    App->view->drawn = false;
 
     return Scale;
 }


### PR DESCRIPTION
Hi!

Probably you've seen lines like
```
drawn = false;
```
or
```
view->drawn = false;
```
and so on scattered all around the codebase. This flag is mostly set to 'false' and only occasionally to 'true', and when it's 'true' it enables blocks of code which are described as "erase old symbol". I honestly tried to grasp its meaning and purpose, what "old symbol" is being erased, and I failed. I started thinking that it would be easier to remove it and see what effect it would make. 

I tried removing it and surprisingly (or not?) there was no difference at all. Everything looked and behaved as usual, at least at first sight. And now I am asking you to kindly include this change to mainline to test it in real life conditions (testing in prod, yeah 😞).

If there will be no problems discovered in, say, week or month, than we'll be happy having get rid of the dead code. In other case I'll revert it. I crammed everything in a single large commit for the sake of easier reverting if it will be needed later.