### PR TITLE
Set Ngspice compatibility mode from GUI

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Redesign of schematic rendering engine. Improve rendering quality on HiDPI displays #723
 * Improved Qucsconv GUI to reflect new converter features #826
 * Improved libraries portability, relative path support for libraries, show libraries from project directory #567
+* Added a global setting for Ngspice compatibility mode (LTspice, HSPICE, etc.) #851
 * QucsatorRF updated to version 1.0.1
 
 ## Deprecated features

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -27,6 +27,7 @@
 #include "main.h"
 #include "misc.h"
 #include "qucs.h"
+#include "settings.h"
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -631,13 +632,29 @@ void Ngspice::cleanSpiceinit()
 
 void Ngspice::createSpiceinit(const QString &initial_spiceinit)
 {
-    if (initial_spiceinit.isEmpty()) return;
-    QFile spinit(spinit_name);
-    if (spinit.open(QIODevice::WriteOnly)) {
-        QTextStream stream(&spinit);
-        if (!initial_spiceinit.isEmpty()) {
-          stream << initial_spiceinit << '\n';
-        }
-        spinit.close();
-    }
+  auto compat_mode = _settings::Get().item<int>("NgspiceCompatMode");
+  QString compat_str;
+  switch(compat_mode) {
+  case spicecompat::NgspLTspice:
+    compat_str = "set ngbehavior=ltpsa\n";
+    break;
+  case spicecompat::NgspHSPICE:
+    compat_str = "set ngbehavior=hsa\n";
+    break;
+  case spicecompat::NgspS3:
+    compat_str = "set ngbehavior=s3\n";
+    break;
+  default: break;
+  }
+  if (initial_spiceinit.isEmpty() &&
+      compat_str.isEmpty()) {
+    return;
+  }
+  QFile spinit(spinit_name);
+  if (spinit.open(QIODevice::WriteOnly)) {
+    QTextStream stream(&spinit);
+    stream << compat_str << '\n';
+    stream << initial_spiceinit << '\n';
+    spinit.close();
+  }
 }

--- a/qucs/extsimkernels/simsettingsdialog.cpp
+++ b/qucs/extsimkernels/simsettingsdialog.cpp
@@ -22,6 +22,7 @@
 
 #include "simsettingsdialog.h"
 #include "main.h"
+#include "settings.h"
 
 SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     QDialog(parent)
@@ -76,6 +77,14 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     btnSetQucsator = new QPushButton(tr("Select ..."));
     connect(btnSetQucsator,SIGNAL(clicked()),this,SLOT(slotSetQucsator()));
 
+    lblCompatMode = new QLabel(tr("Ngspice compatibility mode"));
+    cbxCompatMode = new QComboBox;
+    QStringList lst_modes;
+    lst_modes<<"Default"<<"LTspice"<<"HSPICE"<<"Spice3";
+    cbxCompatMode->addItems(lst_modes);
+    auto compat_mode = _settings::Get().item<int>("NgspiceCompatMode");
+    cbxCompatMode->setCurrentIndex(compat_mode);
+
     QVBoxLayout *top = new QVBoxLayout;
 
 //    QHBoxLayout *h8 = new QHBoxLayout;
@@ -91,6 +100,11 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     h1->addWidget(edtNgspice,3);
     h1->addWidget(btnSetNgspice,1);
     top2->addLayout(h1);
+
+    QHBoxLayout *h4 = new QHBoxLayout;
+    h4->addWidget(lblCompatMode);
+    h4->addWidget(cbxCompatMode);
+    top2->addLayout(h4);
 
     top2->addWidget(lblXyce);
     QHBoxLayout *h2 = new QHBoxLayout;
@@ -172,6 +186,8 @@ void SimSettingsDialog::slotApply()
 //                                                              "Please restart Qucs to affect changes!"));
 //    }
 //    QucsSettings.DefaultSimulator = cbxSimulator->currentIndex();
+    settingsManager& qs = _settings::Get();
+    qs.setItem<int>("NgspiceCompatMode", cbxCompatMode->currentIndex());
     accept();
     saveApplSettings();
   }

--- a/qucs/extsimkernels/simsettingsdialog.h
+++ b/qucs/extsimkernels/simsettingsdialog.h
@@ -34,8 +34,9 @@ private:
     //QLabel *lblNprocs;
     QLabel *lblQucsator;
     //QLabel *lblSimulator;
-    QLabel *lblSimParam;
+    QLabel *lblSimParam, *lblCompatMode;
 
+    QComboBox *cbxCompatMode;
     //QComboBox *cbxSimulator;
 
     QLineEdit *edtNgspice;

--- a/qucs/extsimkernels/spicecompat.h
+++ b/qucs/extsimkernels/spicecompat.h
@@ -34,6 +34,8 @@ namespace spicecompat {
          simSpice        = 0b00000111,
          simAll          = 0b11111111};
      enum CMgen_mode {cmgenSUBifs = 0, cmgenEDDifs = 1, cmgenSUBmod = 2, cmgenEDDmod = 3};
+
+     enum NgspiceCompatMode  { NgspDefault = 0, NgspLTspice = 1, NgspHSPICE = 2, NgspS3 = 3  };
 }
 
 #endif // SPICECOMPAT_H

--- a/qucs/settings.cpp
+++ b/qucs/settings.cpp
@@ -70,6 +70,7 @@ void settingsManager::initDefaults()
     m_Defaults["GraphAntiAliasing"] = false;
     m_Defaults["TextAntiAliasing"] = false;
     m_Defaults["fullTraceName"] = false;
+    m_Defaults["NgspiceCompatMode"] = spicecompat::NgspDefault;
 }
 
 void settingsManager::initAliases()


### PR DESCRIPTION
This PR adds a possibility to set Ngspice compatibility mode (Default/LTspice/HSPICE/SPICE3) from GUI. A new drop down list has been added  in *Simulation->Simulator settings*

![image](https://github.com/user-attachments/assets/831c4dba-12cc-4c47-9cfd-8411c049f417)

