### PR TITLE
Remove Schematic::textCorr

### DIFF
--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1153,37 +1153,6 @@ void Schematic::relativeRotation(int &newX, int &newY, int comX, int comY, int o
     newY = -(oldX-comX)+comY;
 }
 
-// ---------------------------------------------------
-// Correction factor for unproportional font scaling.
-float Schematic::textCorr()
-{
-    QFont Font = QucsSettings.font;
-    Font.setPointSizeF(Scale * float(Font.pointSize()));
-    // use the screen-compatible metric
-    QFontMetrics metrics(Font, 0);
-    // Line spacing is the distance from one base line to the next
-    // and I think it's obvious that line spacing value somehow depends on
-    // font size.
-    // For simplicity let's say that this dependency has the form of
-    // a coefficient <k>, i.e. line spacing is equal to
-    //   fontSize * k.
-    //
-    // Then:
-    //   metrics.lineSpacing = (Scale * QucsSettings.font.pointSize()) * k
-    //
-    // And then the value returned here is a fraction:
-    //                   Scale
-    //   ———————————————————————————————————————————
-    //   (Scale * QucsSettings.font.pointSize()) * k
-    //
-    // Which is equal to one divided by original, n o t - s c a l e d
-    // lines spacing:
-    //                 1
-    //   —————————————————————————————————
-    //   QucsSettings.font.pointSize() * k
-    return (Scale / float(metrics.lineSpacing()));
-}
-
 void Schematic::updateAllBoundingRect() {
     sizeOfAll(UsedX1, UsedY1, UsedX2, UsedY2);
 }

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -88,7 +88,6 @@ public:
 
   void PostPaintEvent(PE pe, int x1=0, int y1=0, int x2=0, int y2=0, int a=0, int b=0,bool PaintOnViewport=false);
 
-  float textCorr();
   bool sizeOfFrame(int&, int&);
 
   /**

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -1031,7 +1031,6 @@ Element* Schematic::selectElement(float fX, float fY, bool flag, int *index)
     Element *pe_1st = 0;
     Element *pe_sel = 0;
     WireLabel *pl = 0;
-    float Corr = textCorr(); // for selecting text
 
     // test all nodes and their labels
     for(Node *pn = Nodes->last(); pn != 0; pn = Nodes->prev())
@@ -1178,7 +1177,7 @@ Element* Schematic::selectElement(float fX, float fY, bool flag, int *index)
         }
     }
 
-    Corr = 5.0 / Scale;  // size of line select and area for resizing
+    const double Corr = 5.0 / Scale;  // size of line select and area for resizing
     // test all diagrams
     for(Diagram *pd = Diagrams->last(); pd != 0; pd = Diagrams->prev())
     {


### PR DESCRIPTION
Hi!

Not a great change, just a bit tidying up.

The `Schematic::textCorr` is called only in one place, and the variable which receives its return value is later reassigned new value without being used, i.e. function return value is discarded. All this renders Schematic::textCorr useless and safe to remove.