### PR TITLE
QucsAttenuator: Ensure Zout=Zin in QW and Lpad attenuators

### DIFF
--- a/qucs-attenuator/qucsattenuator.cpp
+++ b/qucs-attenuator/qucsattenuator.cpp
@@ -412,7 +412,12 @@ void QucsAttenuator::slotQuit()
 
 void QucsAttenuator::slotSetText_Zin( double val )
 {
-  if((ComboTopology->currentIndex() == BRIDGE_TYPE) || (ComboTopology->currentIndex() == REFLECTION_TYPE)) {
+  if((ComboTopology->currentIndex() == BRIDGE_TYPE) ||
+     (ComboTopology->currentIndex() == REFLECTION_TYPE) ||
+     (ComboTopology->currentIndex() == L_PAD_1ST_SERIES) ||
+     (ComboTopology->currentIndex() == L_PAD_1ST_SHUNT) ||
+     (ComboTopology->currentIndex() == QW_SERIES_TYPE) ||
+     (ComboTopology->currentIndex() == QW_SHUNT_TYPE)) {
       QSpinBox_Zout->blockSignals(true);
       QSpinBox_Zout->setValue(val);
       QSpinBox_Zout->blockSignals(false);


### PR DESCRIPTION
Hello:

I have found that when selecting the QW or L-pad attenuators and marking the option to include the S-parameter analysis block, the impedance of the output term was not $Z_0$ if $Z_0 \neq 50 \Omega$

This happened because these attenuator topologies were missing from [slotSetText_Zin()](https://github.com/ra3xdh/qucs_s/blob/current/qucs-attenuator/qucsattenuator.cpp). This function calls the calculation function in order to update the power dissipation data whenever the user changes $Z_0$.

### Steps to reproduce

1) Select a L-pad attenuator (or a QW attenuator) and set $Z_0 =75 \Omega$
2) Check the S-parameter box option
![Selection_034](https://github.com/user-attachments/assets/312869f7-92f6-4ceb-9d7b-4517599dd1ef)

3) Paste the schematic in Qucs-S: The impedance of the output port is not $75 \Omega$, but $50 \Omega$
![Selection_036](https://github.com/user-attachments/assets/a995c281-c0d5-4b82-889e-82023c83ced9)


### Solution

Simply add QW and Lpad attenuators to [slotSetText_Zin()](https://github.com/ra3xdh/qucs_s/blob/current/qucs-attenuator/qucsattenuator.cpp)
![Selection_035](https://github.com/user-attachments/assets/4c762713-7c80-4251-a46e-8007cf2d85bd)



