### PR TITLE
Fix wrong Octave path

### DIFF
--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -131,7 +131,6 @@ bool loadSettings()
 
     QucsSettings.SimParameters = _settings::Get().item<QString>("SimParameters");
     QucsSettings.OctaveExecutable = _settings::Get().item<QString>("OctaveExecutable");
-    QucsSettings.OctaveExecutable = _settings::Get().item<QString>("OctaveBinDir");
     QucsSettings.OpenVAFExecutable = _settings::Get().item<QString>("OpenVAFExecutable");
 
     QucsSettings.RFLayoutExecutable = _settings::Get().item<QString>("RFLayoutExecutable");

--- a/qucs/settings.cpp
+++ b/qucs/settings.cpp
@@ -56,10 +56,12 @@ void settingsManager::initDefaults()
     m_Defaults["NgspiceExecutable"] = "ngspice_con.exe";
     m_Defaults["XyceExecutable"] = "Xyce.exe";
     m_Defaults["RFLayoutExecutable"] = "qucsrflayout.exe";
+    m_Defaults["OctaveExecutable"] = "octave.exe";
 #else
     m_Defaults["NgspiceExecutable"] = "ngspice";
     m_Defaults["XyceExecutable"] = "/usr/local/Xyce-Release-6.8.0-OPENSOURCE/bin/Xyce";
     m_Defaults["RFLayoutExecutable"] = "qucsrflayout";
+    m_Defaults["OctaveExecutable"] = "octave";
 #endif
 
     m_Defaults["XyceParExecutable"] = "mpirun -np %p /usr/local/Xyce-Release-6.8.0-OPENMPI-OPENSOURCE/bin/Xyce";


### PR DESCRIPTION
This PR provides a fix for #883. The Octave path was loaded wrong after migrating settings to new APIs. 