### PR TITLE
adding macos 10.14 support and universal macos app support.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,100 +87,7 @@ jobs:
       with:
           name: ${{ env.APP_NAME }}-${{env.VERSION}}-linux-x86_64
           path: ${{ env.APP_NAME }}-${{env.VERSION}}-linux-x86_64.AppImage
-                
-  build-mac-intel-qt5:
-    runs-on: macos-12
-    needs: setup
-    strategy:
-      fail-fast: false
-    steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: latest-stable
-        
-    - name: Set version environment variable
-      run: echo "VERSION=${{ needs.setup.outputs.version }}" >> $GITHUB_ENV
-
-    - name: Print version
-      run: echo "Qucs-S version is ${{ env.VERSION }}"
-      
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-      
-    #- name: 'Install Qt5'
-    #  uses: jurplel/install-qt-action@v4
-    #  with:
-    #    version: '5.15.2'
-    #    host: 'mac'
-    #    target: 'desktop'
-    #    cache: true
-    #    arch: 'clang_64'
-    #    install-deps: 'true'
-    #    tools: 'tools_cmake'
-       
-    - name: 'Install Dependencies'
-      shell: bash
-      run: |
-          brew install qt@5 gperf dos2unix bison flex ninja graphicsmagick
-          echo 'export PATH="$(brew --prefix bison)/bin:$PATH"' >> /Users/runner/.bashrc
-          export LDFLAGS="-L$(brew --prefix bison)/lib"
-          source ~/.bashrc
-          brew link bison --force
-
-          
-    - name: 'Configure CMake'
-      run: |
-        cmake -B ${{github.workspace}}/build  -G 'Ninja' \
-                  -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-                  -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)
-
-    - name: 'Build Qucs-s'
-      run: |
-        cmake --build ${{github.workspace}}/build --parallel --config=${{env.BUILD_TYPE}}
-    
-    #- name: Install
-    #  run: | 
-    #    cd build
-    #    make install DESTDIR=./deploy
-    #    cd ..
-        
-    - name: 'Package App Bundle'
-      run: |
-        mkdir -p ${{env.QUCS_MACOS_BIN}}
-        mkdir -p ${{env.QUCS_MACOS_RESOURCES}}/examples
-        mkdir -p ${{env.QUCS_MACOS_RESOURCES}}/library
-        mkdir -p ${{env.QUCS_MACOS_RESOURCES}}/symbols
-        cp -pR ./build/qucs-activefilter/qucs-sactivefilter.app ${{env.QUCS_MACOS_BIN}}
-        cp -pR ./build/qucs-attenuator/qucs-sattenuator.app ${{env.QUCS_MACOS_BIN}}
-        cp -pR ./build/qucs-filter/qucs-sfilter.app ${{env.QUCS_MACOS_BIN}}
-        cp -pR ./build/qucs-powercombining/qucs-spowercombining.app ${{env.QUCS_MACOS_BIN}}
-        cp -pR ./build/qucs-transcalc/qucs-strans.app ${{env.QUCS_MACOS_BIN}}
-        cp -pR ./build/qucsator_rf/src/qucsator_rf ${{env.QUCS_MACOS_BIN}}
-        cp -pR ./build/qucsator_rf/src/converter/qucsconv_rf ${{env.QUCS_MACOS_BIN}}
-        cp -pR ./examples/* ${{env.QUCS_MACOS_RESOURCES}}/examples
-        cp -pR ./library/*.lib ${{env.QUCS_MACOS_RESOURCES}}/library
-        cp -pR ./library/*.blacklist ${{env.QUCS_MACOS_RESOURCES}}/library
-        cp -pR ./library/symbols/* ${{env.QUCS_MACOS_RESOURCES}}/symbols
-        $(brew --prefix qt@5)/bin/macdeployqt ./build/qucs/qucs-s.app
-        $(brew --prefix qt@5)/bin/macdeployqt ${{env.QUCS_MACOS_BIN}}/qucs-sactivefilter.app
-        $(brew --prefix qt@5)/bin/macdeployqt ${{env.QUCS_MACOS_BIN}}/qucs-sattenuator.app
-        $(brew --prefix qt@5)/bin/macdeployqt ${{env.QUCS_MACOS_BIN}}/qucs-sfilter.app
-        $(brew --prefix qt@5)/bin/macdeployqt ${{env.QUCS_MACOS_BIN}}/qucs-spowercombining.app
-        $(brew --prefix qt@5)/bin/macdeployqt ${{env.QUCS_MACOS_BIN}}/qucs-strans.app
-        strip ${{env.QUCS_MACOS_BIN}}/qucsator_rf
-        strip ${{env.QUCS_MACOS_BIN}}/qucsconv_rf 
-        codesign --force --deep --sign - ./build/qucs/qucs-s.app
-        npm install --global create-dmg
-        create-dmg ./build/qucs/qucs-s.app ./build/qucs/ || true
-        cp -pR ./build/qucs/qucs-*.dmg ./${{ env.APP_NAME }}-${{env.VERSION}}-macOS-qt5-x86_64.dmg
-
-    - name: 'Upload build artifacts'
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.APP_NAME }}-${{env.VERSION}}-macOS-qt5-x86_64
-        path: ${{ env.APP_NAME }}-${{env.VERSION}}-macOS-qt5-x86_64.dmg
-
+              
  
   build-mac-intel:
     runs-on: macos-12
@@ -205,7 +112,7 @@ jobs:
     - name: 'Install Qt6'
       uses: jurplel/install-qt-action@v4
       with:
-        version: ${{env.QT_VERSION}}
+        version: '6.2.4'
         host: 'mac'
         target: 'desktop'
         cache: true
@@ -225,7 +132,9 @@ jobs:
     - name: 'Configure CMake'
       run: |
         qt-cmake -B ${{github.workspace}}/build  -G 'Ninja' \
-                  -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DWITH_QT6=1
+                  -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DWITH_QT6=1 \
+                  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 \
+                  -DCMAKE_OSX_ARCHITECTURES="x86_64"
 
     - name: 'Build Qucs-s'
       run: |
@@ -265,16 +174,16 @@ jobs:
         codesign --force --deep --sign - ./build/qucs/qucs-s.app
         npm install --global create-dmg
         create-dmg ./build/qucs/qucs-s.app ./build/qucs/ || true
-        cp -pR ./build/qucs/qucs-*.dmg ./${{ env.APP_NAME }}-${{env.VERSION}}-macOS-x86_64.dmg
+        cp -pR ./build/qucs/qucs-*.dmg ./${{ env.APP_NAME }}-${{env.VERSION}}-macOSX-x86_64.dmg
 
     - name: 'Upload build artifacts'
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.APP_NAME }}-${{env.VERSION}}-macOS-x86_64
-        path: ${{ env.APP_NAME }}-${{env.VERSION}}-macOS-x86_64.dmg
+        name: ${{ env.APP_NAME }}-${{env.VERSION}}-macOSX-x86_64
+        path: ${{ env.APP_NAME }}-${{env.VERSION}}-macOSX-x86_64.dmg
+        
 
-      
-  build-mac-arm:
+  build-mac-universal:
     runs-on: macos-latest
     needs: setup
     strategy:
@@ -303,7 +212,7 @@ jobs:
         cache: true
         arch: 'clang_64'
         install-deps: 'true'
-       
+        
     - name: 'Install Dependencies'
       shell: bash
       run: |
@@ -317,7 +226,9 @@ jobs:
     - name: 'Configure CMake'
       run: |
         qt-cmake -B ${{github.workspace}}/build  -G 'Ninja' \
-                  -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DWITH_QT6=1
+                  -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DWITH_QT6=1 \
+                  -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+                  -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 
     - name: 'Build Qucs-s'
       run: |
@@ -357,13 +268,13 @@ jobs:
         codesign --force --deep --sign - ./build/qucs/qucs-s.app
         npm install --global create-dmg
         create-dmg ./build/qucs/qucs-s.app ./build/qucs/ || true
-        cp -pR ./build/qucs/qucs-*.dmg ./${{ env.APP_NAME }}-${{env.VERSION}}-macOS-arm64.dmg
+        cp -pR ./build/qucs/qucs-*.dmg ./${{ env.APP_NAME }}-${{env.VERSION}}-macOS.dmg
     
     - name: 'Upload build artifacts'
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.APP_NAME }}-${{env.VERSION}}-macOS-arm64
-        path: ${{ env.APP_NAME }}-${{env.VERSION}}-macOS-arm64.dmg
+        name: ${{ env.APP_NAME }}-${{env.VERSION}}-macOS
+        path: ${{ env.APP_NAME }}-${{env.VERSION}}-macOS.dmg
       
   build-windows:
     runs-on: windows-2022
@@ -471,9 +382,8 @@ jobs:
     needs:
      - setup
      - build-linux-appimage-qt6
-     - build-mac-intel-qt5
      - build-mac-intel
-     - build-mac-arm
+     - build-mac-universal
      - build-windows
     steps:
     - name: Checkout repository

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ if(WITH_QT6)
 else()
     set(QT_VERSION_MAJOR 5)
 endif()
+
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widgets LinguistTools)
 set(QT_VERSION ${Qt${QT_VERSION_MAJOR}Core_VERSION})
 

--- a/qucs-activefilter/CMakeLists.txt
+++ b/qucs-activefilter/CMakeLists.txt
@@ -34,7 +34,6 @@ else()
     set(QT_VERSION_MAJOR 5)
 endif()
 
-
 if(QT_VERSION_MAJOR EQUAL 6)
   find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core  Widgets Svg SvgWidgets)
   include_directories(

--- a/qucs-attenuator/CMakeLists.txt
+++ b/qucs-attenuator/CMakeLists.txt
@@ -32,6 +32,7 @@ if(WITH_QT6)
 else()
     set(QT_VERSION_MAJOR 5)
 endif()
+
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widgets)
 include_directories(
       ${Qt${QT_VERSION_MAJOR}Core_INCLUDE_DIRS}


### PR DESCRIPTION
Hi, This PR solve #898 qt 6.2.4 build with MacOS-X 10.14 support. std::filesystem::path supported on MacOS-X 10.15 so I'll try to convert Qt API and now universal MacOS app added support MacOS 11 to latest.