### PR TITLE
Fix issue #905 - The matching network tool gives incorrect results when conditionally stable data is provided

### DIFF
--- a/qucs/dialogs/matchdialog.h
+++ b/qucs/dialogs/matchdialog.h
@@ -33,6 +33,8 @@
 #include <QDialog>
 #include <cmath>
 
+#include <complex>
+
 class Element;
 class QLabel;
 class QLineEdit;


### PR DESCRIPTION
As reported in issue #905, the matching network tool gave incorrect  results when using a conditionally stable S-matrix.To obtain a conjugate match at both ports, the device must satisfy the unconditional stability criteria, defined as K > 1 and abs(delta) < 1. See [1].

A condition has been added [here](https://github.com/andresmmera/qucs_s/blob/Fix_Issue_905_Matching_Tool_K_less_1/qucs/dialogs/matchdialog.cpp#L745C1-L745C33). It checks the stability and stops the execution if the criteria is not met.

## Tests

### 1) Conditionally stable device (#905)

Using the S-parameter data provided in #905, a message is now displayed warning of conditional stability and advising the user to consider adding losses and/or FB.

![Selection_019](https://github.com/user-attachments/assets/ca4cdedb-d060-4eb5-8682-4c8d07dc5f5b)
![Selection_020](https://github.com/user-attachments/assets/b4e304e5-2c93-4007-83af-b1865bf1506e)

### 2) Unconditionally stable device.

The device in 1) is stabilized with 12 Ohm at the input. This makes it unconditionally stable (K = 1.06 < 1, |delta| = 0.228 < 1)
![Selection_021](https://github.com/user-attachments/assets/c1cade11-d69c-4b43-9940-4262c8d2b8de)

The tool is used to synthesise the input and output matching networks. It works as usual: Note that S11 and S22 are matched to 50 ohms at the given frequency (400 MHz).

![Selection_022](https://github.com/user-attachments/assets/498649eb-a15f-4d9f-8401-22f07a5aa6ec)
![Selection_023](https://github.com/user-attachments/assets/7ab39f69-c763-4eb2-8421-e62e3a93a0ba)

Thank you @tomhajjar

[1] Microwave Engineering. David M Pozar. 2012. Eqs 12.28 and 12.29