### PR TITLE
Matching tool: Keep dialog open in case the synthesis goes wrong

### DIFF
--- a/qucs/dialogs/matchdialog.cpp
+++ b/qucs/dialogs/matchdialog.cpp
@@ -764,6 +764,10 @@ void MatchDialog::slotButtCreate() {
                                   gamma_MAX, BalancedStubs);
   }
 
+  if (!success) {
+      // Something went wrong. Return to the main window without closing the dialog
+      return;
+  }
   QucsMain->slotEditPaste(success);
   accept();
 }


### PR DESCRIPTION
As pointed out in issue #905, the dialog closes if the synthesis goes wrong. This can be annoying since the user needs to input all the design data again. Keeping the dialog open allows the user to make corrections.

A condition has been added at the end of the slotButtCreate() function to keep the dialog open in case the synthesis goes wrong. If the synthesis is ok, the program will exit as usual.