### PR TITLE
Fix Qucsconv GUI

### DIFF
--- a/qucs/dialogs/importdialog.cpp
+++ b/qucs/dialogs/importdialog.cpp
@@ -290,26 +290,15 @@ void ImportDialog::slotImport()
 }
 
 // ------------------------------------------------------------------------
-void ImportDialog::slotType()
+void ImportDialog::slotType(int index)
 {
-  auto index = OutType->currentIndex();
-  switch(index) {
-  case 0:
-  case 3:
-  case 4:
-  case 5:
-    OutputData->setEnabled(false);
-    OutputLabel->setEnabled(false);
-    break;
-  case 1:
-  case 2:
+  //auto index = OutType->currentIndex();
+  if (index == 2) {
     OutputData->setEnabled(true);
     OutputLabel->setEnabled(true);
-    break;
-  default:
+  } else {
     OutputData->setEnabled(false);
     OutputLabel->setEnabled(false);
-    break;
   }
 
   if (index == 3) {
@@ -441,7 +430,7 @@ void ImportDialog::slotValidateOutput()
     default:
         break;
     }
-    slotType();
+    slotType(OutType->currentIndex());
 }
 
 

--- a/qucs/dialogs/importdialog.cpp
+++ b/qucs/dialogs/importdialog.cpp
@@ -242,8 +242,6 @@ void ImportDialog::slotImport()
     break;
   case 1:
     CommandLine << "touchstone";
-    if (!OutputData->currentText().isEmpty())
-      CommandLine << "-d" << OutputData->currentText();
     break;
   case 2:
     CommandLine << "csv";

--- a/qucs/dialogs/importdialog.h
+++ b/qucs/dialogs/importdialog.h
@@ -49,7 +49,7 @@ private slots:
   void slotAbort();
   void slotBrowse();
   void slotSaveBrowse();
-  void slotType();
+  void slotType(int index);
   void slotValidateInput();
   void slotValidateOutput();
 


### PR DESCRIPTION
This PR provides a fix for Qucsconv GUI #910 The variable name is not applied when converting qucsdata to touchstone. 