### PR TITLE
use different version for snapshot build.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,11 +33,11 @@ jobs:
       id: read_version
       run: |
         if [ "${{github.ref_type}}" == "tag" ]; then
-          VERSION=$(cat VERSION)
+          VERSION=${{ github.ref_name }}
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "version=$VERSION" >> $GITHUB_OUTPUT
         else
-          VERSION=${{env.CI_VERSION}}
+          VERSION=${{ env.CI_VERSION }}
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "version=$VERSION" >> $GITHUB_OUTPUT
         fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
   
 env:
   APP_NAME: "Qucs-S"
+  CI_VERSION: 24.3.99
   EXECUTABLE_NAME: "qucs-s"
   PUBLISHER_NAME: "The Qucs-S Team"
   BUILD_TYPE: Release
@@ -31,9 +32,15 @@ jobs:
     - name: Read version from file
       id: read_version
       run: |
-        VERSION=$(cat VERSION)
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        if [ "${{github.ref_type}}" == "tag" ]; then
+          VERSION=$(cat VERSION)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+        else
+          VERSION=${{env.CI_VERSION}}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+        fi
         
     - name: Print version 
       run: echo "Qucs-S version is ${{ env.VERSION }}"
@@ -68,10 +75,13 @@ jobs:
         arch: 'linux_gcc_64'
         install-deps: 'true'
 
-        
     - name: 'Configure CMake'
       run: |
-          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=/usr -DWITH_QT6=ON
+          cmake -B ${{github.workspace}}/build \
+                -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+                -DCMAKE_INSTALL_PREFIX=/usr \
+                -DWITH_QT6=ON \
+                -DCI_VERSION="${{env.VERSION}}"
 
     - name: 'Build'
       # Build your program with the given configuration
@@ -144,10 +154,11 @@ jobs:
           
     - name: 'Configure CMake'
       run: |
-            cmake -B ${{github.workspace}}/build  -G 'Ninja' \
-                  -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DWITH_QT6=1 \
-                  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 \
-                  -DCMAKE_OSX_ARCHITECTURES="x86_64"
+        cmake -B ${{github.workspace}}/build  -G 'Ninja' \
+              -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DWITH_QT6=1 \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 \
+              -DCMAKE_OSX_ARCHITECTURES="x86_64" \
+              -DCI_VERSION="${{env.VERSION}}"
 
     - name: 'Build Qucs-s'
       run: |
@@ -238,14 +249,15 @@ jobs:
           
     - name: 'Configure CMake'
       run: |
-        qt-cmake -B ${{github.workspace}}/build  -G 'Ninja' \
-                  -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DWITH_QT6=1 \
-                  -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
-                  -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+          cmake -B ${{github.workspace}}/build  -G 'Ninja' \
+                -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DWITH_QT6=1 \
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+                -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
+                -DCI_VERSION="${{env.VERSION}}"
 
     - name: 'Build Qucs-s'
       run: |
-        cmake --build ${{github.workspace}}/build --parallel --config=${{env.BUILD_TYPE}}
+          cmake --build ${{github.workspace}}/build --parallel --config=${{env.BUILD_TYPE}}
     
     #- name: Install
     #  run: | 
@@ -346,7 +358,10 @@ jobs:
 
     - name: Build project with CMake
       run: |
-        cmake.exe -B build/ -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DWITH_QT6=ON
+        cmake.exe -B build/ -G "MinGW Makefiles" \
+                  -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+                  -DWITH_QT6=ON \
+                  -DCI_VERSION="${{env.VERSION}}"
         cmake.exe --build build/ -j$(nproc) --config ${{env.BUILD_TYPE}}
 
     - name: Make install
@@ -395,6 +410,7 @@ jobs:
       uses: Minionguyjpro/Inno-Setup-Action@v1.2.4
       with:
         path: contrib/InnoSetup/qucs.iss
+        options: /Qp /O"${{github.workspace}}" /DAPPNAME=${{ env.APP_NAME }} /DRELEASE="${{ env.VERSION }}"
         
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
@@ -405,12 +421,12 @@ jobs:
     - name: Upload exe artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: qucs-s-24.3.0-setup
-        path: contrib\InnoSetup\Output\qucs-s-24.3.0-setup.exe
+        name: ${{ env.APP_NAME }}-${{ env.VERSION }}-setup
+        path: ${{ env.APP_NAME }}-${{ env.VERSION }}-setup.exe
 
   create-release:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name != 'pull_request'
     needs:
      - setup
      - build-linux-appimage-qt6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,14 @@ endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 file (STRINGS "${qucs-suite_SOURCE_DIR}/VERSION" QUCS_VERSION)
-message(STATUS "Configuring Qucs: VERSION ${QUCS_VERSION}")
+
+if(DEFINED CI_VERSION)
+    set(PROJECT_VERSION "${CI_VERSION}")
+else()
+    set(PROJECT_VERSION "${QUCS_VERSION}")
+endif()
+
+message(STATUS "Configuring Qucs: VERSION ${PROJECT_VERSION}")
 
 set(GIT "")
 if(EXISTS ${CMAKE_SOURCE_DIR}/.git )

--- a/contrib/InnoSetup/qucs.iss
+++ b/contrib/InnoSetup/qucs.iss
@@ -19,28 +19,30 @@
 ; the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
 ; Boston, MA 02110-1301, USA.
 ;
+#ifndef RELEASE
+  #define RELEASE "24.3.0"
+#endif
 
+#ifndef APPNAME
+  #define APPNAME "Qucs-S"
+#endif
 
-#define RELEASE "24.3.0"
-#define BASENAME "qucs-s"
-#define APPNAME "Qucs-S"
-#define APPVERNAME "Quite Universal Circuit Simulator 24.3.0"
 #define URL "https://ra3xdh.github.io/"
-
+#define TREE "..\..\build\qucs-suite\"
 
 [Setup]
 AppName={# APPNAME}
-AppVerName={# APPVERNAME}
-AppPublisher=The Qucs Team
+AppVersion={# RELEASE}
+AppPublisher=The Qucs-S Team
 AppPublisherURL={# URL}
 AppSupportURL={# URL}
 AppUpdatesURL={# URL}
 DefaultDirName={pf}\Qucs-S
 DefaultGroupName=Qucs-S
 AllowNoIcons=yes
-LicenseFile=.\misc\gpl.rtf
-OutputBaseFilename={# BASENAME}-{# RELEASE}-setup
-Compression=lzma
+LicenseFile={# TREE}\misc\gpl.rtf
+OutputBaseFilename={# APPNAME}-{# RELEASE}-setup
+Compression=lzma2/max
 SolidCompression=yes
 ChangesEnvironment=yes
 UsePreviousAppDir=yes
@@ -53,12 +55,12 @@ WizardStyle=modern
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "..\..\build\qucs-suite\bin\*"; DestDir: "{app}\bin"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{# TREE}\bin\*"; DestDir: "{app}\bin"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; Source: "{# TREE}\include\*"; DestDir: "{app}\include"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; Source: "{# TREE}\lib\*"; DestDir: "{app}\lib"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: ".\misc\*"; DestDir: "{app}\misc"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "..\..\build\qucs-suite\lib\*"; DestDir: "{app}\lib"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "..\..\build\qucs-suite\share\*"; DestDir: "{app}\share"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{# TREE}\misc\*"; DestDir: "{app}\misc"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{# TREE}\lib\*"; DestDir: "{app}\lib"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{# TREE}\share\*"; DestDir: "{app}\share"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
 Name: "{group}\Qucs-S Simulator"; Filename: "{app}\bin\qucs-s.exe"; IconFilename: "{app}\misc\qucs64x64.ico"; WorkingDir: "{app}\bin"
@@ -66,7 +68,4 @@ Name: "{group}\Visit the Qucs Web Site"; Filename: "{app}\misc\website.url"
 Name: "{group}\Technical Online Documentation"; Filename: "{app}\misc\docsite.url"
 Name: "{group}\{cm:UninstallProgram,Qucs}"; Filename: "{uninstallexe}"
 Name: "{userdesktop}\Qucs-S"; Filename: "{app}\bin\qucs-s.exe"; IconFilename: "{app}\misc\qucs64x64.ico"; WorkingDir: "{app}\bin"; Tasks: desktopicon
-
-
-
 

--- a/qucs-activefilter/CMakeLists.txt
+++ b/qucs-activefilter/CMakeLists.txt
@@ -8,7 +8,11 @@ SET(QUCS_NAME "qucs-s")
 file (STRINGS ${PROJECT_SOURCE_DIR}/../VERSION QUCS_VERSION)
 message(STATUS "Configuring ${PROJECT_NAME} (GUI): VERSION ${QUCS_VERSION}")
 
-set(PROJECT_VERSION "${QUCS_VERSION}")
+if(DEFINED CI_VERSION)
+    set(PROJECT_VERSION "${CI_VERSION}")
+else()
+    set(PROJECT_VERSION "${QUCS_VERSION}")
+endif()
 
 set(PROJECT_VENDOR "Qucs team. This program is licensed under the GNU GPL")
 set(PROJECT_COPYRIGHT_YEAR "2014")

--- a/qucs-attenuator/CMakeLists.txt
+++ b/qucs-attenuator/CMakeLists.txt
@@ -6,9 +6,14 @@ SET(QUCS_NAME "qucs-s")
 
 # use top VERSION file
 file (STRINGS ${PROJECT_SOURCE_DIR}/../VERSION QUCS_VERSION)
-message(STATUS "Configuring ${PROJECT_NAME} (GUI): VERSION ${QUCS_VERSION}")
 
-set(PROJECT_VERSION "${QUCS_VERSION}")
+if(DEFINED CI_VERSION)
+    set(PROJECT_VERSION "${CI_VERSION}")
+else()
+    set(PROJECT_VERSION "${QUCS_VERSION}")
+endif()
+
+message(STATUS "Configuring ${PROJECT_NAME} (GUI): VERSION ${PROJECT_VERSION}")
 
 set(PROJECT_VENDOR "Qucs team. This program is licensed under the GNU GPL")
 set(PROJECT_COPYRIGHT_YEAR "2014")

--- a/qucs-filter/CMakeLists.txt
+++ b/qucs-filter/CMakeLists.txt
@@ -6,9 +6,14 @@ SET(QUCS_NAME "qucs-s")
 
 # use top VERSION file
 file (STRINGS ${PROJECT_SOURCE_DIR}/../VERSION QUCS_VERSION)
-message(STATUS "Configuring ${PROJECT_NAME} (GUI): VERSION ${QUCS_VERSION}")
 
-set(PROJECT_VERSION "${QUCS_VERSION}")
+if(DEFINED CI_VERSION)
+    set(PROJECT_VERSION "${CI_VERSION}")
+else()
+    set(PROJECT_VERSION "${QUCS_VERSION}")
+endif()
+
+message(STATUS "Configuring ${PROJECT_NAME} (GUI): VERSION ${PROJECT_VERSION}")
 
 set(PROJECT_VENDOR "Qucs team. This program is licensed under the GNU GPL")
 set(PROJECT_COPYRIGHT_YEAR "2014")

--- a/qucs-powercombining/CMakeLists.txt
+++ b/qucs-powercombining/CMakeLists.txt
@@ -6,9 +6,14 @@ SET(QUCS_NAME "qucs-s")
 
 # use top VERSION file
 file (STRINGS ${PROJECT_SOURCE_DIR}/../VERSION QUCS_VERSION)
-message(STATUS "Configuring ${PROJECT_NAME} (GUI): VERSION ${QUCS_VERSION}")
 
-set(PROJECT_VERSION "${QUCS_VERSION}")
+if(DEFINED CI_VERSION)
+    set(PROJECT_VERSION "${CI_VERSION}")
+else()
+    set(PROJECT_VERSION "${QUCS_VERSION}")
+endif()
+
+message(STATUS "Configuring ${PROJECT_NAME} (GUI): VERSION ${PROJECT_VERSION}")
 
 set(PROJECT_VENDOR "Qucs team. This program is licensed under the GNU GPL")
 set(PROJECT_COPYRIGHT_YEAR "2016")

--- a/qucs-transcalc/CMakeLists.txt
+++ b/qucs-transcalc/CMakeLists.txt
@@ -6,9 +6,14 @@ SET(QUCS_NAME "qucs-s")
 
 # use top VERSION file
 file (STRINGS ${PROJECT_SOURCE_DIR}/../VERSION QUCS_VERSION)
-message(STATUS "Configuring ${PROJECT_NAME} (GUI): VERSION ${QUCS_VERSION}")
 
-set(PROJECT_VERSION "${QUCS_VERSION}")
+if(DEFINED CI_VERSION)
+    set(PROJECT_VERSION "${CI_VERSION}")
+else()
+    set(PROJECT_VERSION "${QUCS_VERSION}")
+endif()
+
+message(STATUS "Configuring ${PROJECT_NAME} (GUI): VERSION ${PROJECT_VERSION}")
 
 set(PROJECT_VENDOR "Qucs team. This program is licensed under the GNU GPL")
 set(PROJECT_COPYRIGHT_YEAR "2014")

--- a/qucs/CMakeLists.txt
+++ b/qucs/CMakeLists.txt
@@ -17,9 +17,14 @@ SET(QUCS_NAME "${PROJECT_NAME}")
 
 # use top VERSION file
 file (STRINGS ${PROJECT_SOURCE_DIR}/../VERSION QUCS_VERSION)
-message(STATUS "Configuring ${PROJECT_NAME} (GUI): VERSION ${QUCS_VERSION}")
 
-set(PROJECT_VERSION "${QUCS_VERSION}")
+if(DEFINED CI_VERSION)
+    set(PROJECT_VERSION "${CI_VERSION}")
+else()
+    set(PROJECT_VERSION "${QUCS_VERSION}")
+endif()
+
+message(STATUS "Configuring ${PROJECT_NAME} (GUI): VERSION ${PROJECT_VERSION}")
 
 set(PROJECT_VENDOR "Qucs team. This program is licensed under the GNU GPL")
 set(PROJECT_COPYRIGHT_YEAR "2014")

--- a/qucs/misc.cpp
+++ b/qucs/misc.cpp
@@ -41,14 +41,16 @@
 
 QString misc::getWindowTitle()
 {
-    QString title = QUCS_NAME " " PACKAGE_VERSION;
+    QString title = QString("%1 %2").arg(QUCS_NAME,PACKAGE_VERSION);
     if (title.endsWith(".0")) {
         title.chop(2);
     }
-#if defined(GIT)
-    QString hash = GIT;
-    if (!hash.isEmpty()) {
-        title = title + "-" + hash;
+#if defined(GIT) && defined(CI_VERSION)
+    if (title.endsWith(".99")) {
+        QString hash = GIT;
+        if (!hash.isEmpty()) {
+            title.append("-").append(hash);
+        }
     }
 #endif
 


### PR DESCRIPTION
Hi, this PR make improvements for #871 

- changed version for snapshot build.
- use tag version for stable releases for created tag.
- hide git hash for stable release.
- changed .iss file and change version and app name on command line. 