### PR TITLE
Fixed crash on editing missing subcircuit

### DIFF
--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -1027,8 +1027,8 @@ bool Component::load(const QString &_s) {
         tmp = 5; // number of properties for the default MUTX (2 inductors)
     else tmp = counts + 1;    // "+1" because "counts" could be zero
 
-    for (; tmp <= (int) counts / 2; tmp++){
-      Props.append(new Property("p", "", true, " "));
+    for (int k=1; tmp <= (int) counts / 2; tmp++, k++){
+      Props.append(new Property("p" + QString::number(k), "", true, " "));
     }
 
 

--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -1586,6 +1586,10 @@ bool ComponentDialog::propChanged(Property *pp, const QString &value, const bool
 
 void ComponentDialog::updateProperty(Property *pp, const QString &value, const bool display)
 {
+  if (pp == nullptr) {
+    qDebug()<<__func__<<" Warning! Trying to update NULLPTR property";
+    return;
+  }
   if (propChanged(pp,value,display)) {
     pp->Value = value;
     pp->display = display;


### PR DESCRIPTION
This PR fixes #902. Crash on editing invalid subciruit doesn't appear anymore. 