### PR TITLE
Substutute relative library path when inserting component in schematic

### DIFF
--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -603,7 +603,7 @@ void QucsApp::fillLibrariesTreeView ()
 //    newitem->setBackground
     topitems.append (newitem);
 
-    populateLibTreeFromDir(QucsSettings.LibDir, topitems);
+    populateLibTreeFromDir(QucsSettings.LibDir, topitems, true);
 
     // make the user libraries section header
     newitem = new QTreeWidgetItem((QTreeWidget*)0, QStringList("User Libraries"));
@@ -620,14 +620,14 @@ void QucsApp::fillLibrariesTreeView ()
     newitem->setFont (0, sectionFont);
     topitems.append (newitem);
     if (!ProjName.isEmpty()) {
-        populateLibTreeFromDir(QucsSettings.QucsWorkDir.absolutePath(), topitems);
+        populateLibTreeFromDir(QucsSettings.QucsWorkDir.absolutePath(), topitems, true);
     }
 
     libTreeWidget->insertTopLevelItems(0, topitems);
 }
 
 
-bool QucsApp::populateLibTreeFromDir(const QString &LibDirPath, QList<QTreeWidgetItem *> &topitems)
+bool QucsApp::populateLibTreeFromDir(const QString &LibDirPath, QList<QTreeWidgetItem *> &topitems, bool relpath)
 {
     QDir LibDir(LibDirPath);
     QStringList LibFiles = LibDir.entryList(QStringList("*.lib"), QDir::Files, QDir::Name);
@@ -643,7 +643,7 @@ bool QucsApp::populateLibTreeFromDir(const QString &LibDirPath, QList<QTreeWidge
 
         ComponentLibrary parsedlibrary;
 
-        int result = parseComponentLibrary (libPath , parsedlibrary);
+        int result = parseComponentLibrary (libPath , parsedlibrary, QUCS_COMP_LIB_FULL, relpath);
         QStringList nameAndFileName;
         nameAndFileName.append (parsedlibrary.name);
         nameAndFileName.append (LibDirPath + *it);

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -277,7 +277,7 @@ private:
   void updateRecentFilesList(QString s);
   void successExportMessages(bool ok);
   void fillLibrariesTreeView (void);
-  bool populateLibTreeFromDir(const QString &LibDirPath, QList<QTreeWidgetItem *> &topitems);
+  bool populateLibTreeFromDir(const QString &LibDirPath, QList<QTreeWidgetItem *> &topitems, bool relpath = false);
   void saveSettings();
   QWidget *getSchematicWidget(QucsDoc *Doc);
 

--- a/qucs/qucslib_common.h
+++ b/qucs/qucslib_common.h
@@ -219,11 +219,14 @@ inline int makeModelString (QString libPath, QString compname, QString compstrin
 }
 
 
-inline int parseQucsComponentLibrary (QString libPath, ComponentLibrary &library, LIB_PARSE_WHAT what = QUCS_COMP_LIB_FULL)
+inline int parseQucsComponentLibrary (QString libPath, ComponentLibrary &library,
+                                     LIB_PARSE_WHAT what = QUCS_COMP_LIB_FULL, bool relpath = false)
 {
     int Start, End, NameStart, NameEnd;
 
     QString filename = getLibAbsPath(libPath);
+    QFileInfo inf(filename);
+    QString relName = inf.baseName();
 
     QFile file (filename);
 
@@ -309,7 +312,11 @@ inline int parseQucsComponentLibrary (QString libPath, ComponentLibrary &library
         component.definition = LibraryString.mid(Start, End-Start);
 
         // construct model string
-        int result = makeModelString (libPath, component.name, component.definition, component.modelString, library.defaultSymbol);
+        QString libName = libPath;
+        if (relpath) {
+          libName = relName;
+        }
+        int result = makeModelString (libName, component.name, component.definition, component.modelString, library.defaultSymbol);
         if (result != QUCS_COMP_LIB_OK) return result;
 
         library.components.append (component);
@@ -486,9 +493,10 @@ inline int parseSPICEComponentLibrary (QString libPath, ComponentLibrary &librar
     return QUCS_COMP_LIB_OK;
 }
 
-inline int parseComponentLibrary (QString filename, ComponentLibrary &library,  LIB_PARSE_WHAT what = QUCS_COMP_LIB_FULL)
+inline int parseComponentLibrary (QString filename, ComponentLibrary &library,
+                                 LIB_PARSE_WHAT what = QUCS_COMP_LIB_FULL, bool relpath = false)
 {
-    int r = parseQucsComponentLibrary(filename,library,what);
+    int r = parseQucsComponentLibrary(filename,library,what,relpath);
     if (r!=QUCS_COMP_LIB_OK) {
         r = parseSPICEComponentLibrary(filename,library);
     }


### PR DESCRIPTION
I have recently noticed that library manager always substitute the full library path when inserting component from the left panel. But Qucs-S supports relative library paths. This may create some difficulties when sharing schematics. See also #567 

This PR introduces the following logic:

* System library -- relative path
* User library -- full path
* Project library -- relative path 