### PR TITLE
Improve temperature sweep

### DIFF
--- a/qucs/components/bjt.cpp
+++ b/qucs/components/bjt.cpp
@@ -55,13 +55,17 @@ QString BJT::spice_netlist(bool)
     }
 
     QStringList spice_incompat,spice_tr;
-    spice_incompat<<"Type"<<"Area"<<"Temp"<<"Ffe"<<"Kb"<<"Ab"<<"Fb"; // spice-incompatible parameters
+    spice_incompat<<"Type"<<"Area"<<"Temp"<<"Ffe"<<"Kb"<<"Ab"<<"Fb"<<"UseGlobTemp"; // spice-incompatible parameters
     spice_tr.clear(); // parameters that need conversion of names
 
     QString par_str = form_spice_param_list(spice_incompat,spice_tr);
 
-    s += QString(" QMOD_%1 AREA=%2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
-            .arg(getProperty("Temp")->Value);
+    if (getProperty("UseGlobTemp")->Value == "yes") {
+      s += QString(" QMOD_%1 AREA=%2\n").arg(Name).arg(getProperty("Area")->Value);
+    } else {
+      s += QString(" QMOD_%1 AREA=%2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
+      .arg(getProperty("Temp")->Value);
+    }
     s += QString(".MODEL QMOD_%1 %2 (%3)\n").arg(Name).arg(getProperty("Type")->Value).arg(par_str);
 
     return s;

--- a/qucs/components/bjtsub.cpp
+++ b/qucs/components/bjtsub.cpp
@@ -119,6 +119,8 @@ Basic_BJT::Basic_BJT()
 	QObject::tr("temperature at which parameters were extracted")));
   Props.append(new Property("Area", "1.0", false,
 	QObject::tr("default area for bipolar transistor")));
+  Props.append(new Property("UseGlobTemp", "yes", false,
+                            QObject::tr("Use global SPICE temperature")+" [yes,no]"));
 
   Name  = "T";
 }
@@ -212,13 +214,18 @@ QString BJTsub::spice_netlist(bool)
     }
 
     QStringList spice_incompat,spice_tr;
-    spice_incompat<<"Type"<<"Area"<<"Temp"<<"Ffe"<<"Kb"<<"Ab"<<"Fb"; // spice-incompatible parameters
+    spice_incompat<<"Type"<<"Area"<<"Temp"<<"Ffe"<<"Kb"<<"Ab"<<"Fb"<<"UseGlobTemp"; // spice-incompatible parameters
     spice_tr.clear(); // parameters that need convertion of names
 
     QString par_str = form_spice_param_list(spice_incompat,spice_tr);
 
-    s += QString(" QMOD_%1 AREA=%2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
-            .arg(getProperty("Temp")->Value);
+    if (getProperty("UseGlobTemp")->Value == "yes") {
+      s += QString(" QMOD_%1 AREA=%2\n").arg(Name).arg(getProperty("Area")->Value);
+    } else {
+      s += QString(" QMOD_%1 AREA=%2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
+      .arg(getProperty("Temp")->Value);
+    }
+
     s += QString(".MODEL QMOD_%1 %2 (%3)\n").arg(Name).arg(getProperty("Type")->Value).arg(par_str);
 
     return s;

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -722,9 +722,13 @@ QString Component::netlist() {
         s += " " + p1->Connection->Name;   // node names
 
     // output all properties
-    for (Property *p2 : Props)
-        if (p2->Name != "Symbol")
-            s += " " + p2->Name + "=\"" + p2->Value + "\"";
+    QStringList no_sim_props;
+    no_sim_props<<"Symbol"<<"UseGlobTemp";
+    for (const auto &p2 : Props) {
+      if (!no_sim_props.contains(p2->Name)) {
+        s += " " + p2->Name + "=\"" + p2->Value + "\"";
+      }
+    }
 
     return s + '\n';
 }

--- a/qucs/components/diode.cpp
+++ b/qucs/components/diode.cpp
@@ -82,6 +82,8 @@ Diode::Diode()
 	QObject::tr("default area for diode")));
   Props.append(new Property("Symbol", "normal", false,
 	QObject::tr("schematic symbol")+" [normal, US, Schottky, Zener, Varactor]"));
+  Props.append(new Property("UseGlobTemp", "yes", false,
+        QObject::tr("Use global SPICE temperature")+" [yes,no]"));
 
   createSymbol();
   tx = x1+4;
@@ -114,10 +116,10 @@ QString Diode::spice_netlist(bool isXyce)
     if (isXyce) {
         spice_tr<<"Tbv"<<"Tbv1"<<"Trs"<<"Trs1"; // parameters that need conversion of names
         spice_incompat<<"Ttt1"<<"Ttt2"<<"Tm1"<<"Tm2"<<"Cp"<<"Isr"
-                     <<"Nr"<<"Ffe"<<"Temp"<<"Area"<<"Symbol"; // spice-incompatible parameters
+                     <<"Nr"<<"Ffe"<<"Temp"<<"Area"<<"Symbol"<<"UseGlobTemp"; // spice-incompatible parameters
     } else {
         spice_tr<<"Tbv"<<"Tcv";
-        spice_incompat<<"Cp"<<"Isr"<<"Nr"<<"Ffe"<<"Temp"<<"Area"<<"Symbol";
+        spice_incompat<<"Cp"<<"Isr"<<"Nr"<<"Ffe"<<"Temp"<<"Area"<<"Symbol"<<"UseGLobTemp";
     }
 
     QString par_str;
@@ -142,8 +144,13 @@ QString Diode::spice_netlist(bool isXyce)
 
     }
 
-    s += QString(" DMOD_%1 AREA=%2 Temp=%3\n").arg(Name).arg(getProperty("Area")->Value)
-            .arg(getProperty("Temp")->Value);
+    if (getProperty("UseGlobTemp")->Value == "yes") {
+      s += QString(" DMOD_%1 AREA=%2\n").arg(Name).arg(getProperty("Area")->Value);
+    } else {
+      s += QString(" DMOD_%1 AREA=%2 Temp=%3\n").arg(Name).arg(getProperty("Area")->Value)
+      .arg(getProperty("Temp")->Value);
+    }
+
     if (isXyce) {
         s += QString(".MODEL DMOD_%1 D (LEVEL = 2 %2)\n").arg(Name).arg(par_str);
     } else {

--- a/qucs/components/jfet.cpp
+++ b/qucs/components/jfet.cpp
@@ -72,6 +72,8 @@ JFET::JFET() {
                               QObject::tr("temperature at which parameters were extracted")));
     Props.append(new Property("Area", "1.0", false,
                               QObject::tr("default area for JFET")));
+    Props.append(new Property("UseGlobTemp", "yes", false,
+                              QObject::tr("Use global SPICE temperature")+" [yes,no]"));
 
     createSymbol();
     tx = x2 + 4;
@@ -108,11 +110,11 @@ QString JFET::spice_netlist(bool isXyce)
     QStringList spice_incompat,spice_tr;
     if (isXyce) {
         spice_incompat<<"Type"<<"Area"<<"Temp"<<"Ffe"<<"N"
-                     <<"Isr"<<"Nr"<<"M"<<"Xti"<<"Betatce"<<"Vt0tc";
+                     <<"Isr"<<"Nr"<<"M"<<"Xti"<<"Betatce"<<"Vt0tc"<<"UseGLobTemp";
                                   // spice-incompatible parameters
         spice_tr<<"Vt0"<<"VtO"; // parameters that need conversion of names
     } else {
-        spice_incompat<<"Type"<<"Area"<<"Temp"<<"Ffe"<<"N"<<"Isr"<<"Nr"<<"M"<<"Xti"<<"Betatce";
+        spice_incompat<<"Type"<<"Area"<<"Temp"<<"Ffe"<<"N"<<"Isr"<<"Nr"<<"M"<<"Xti"<<"Betatce"<<"UseGlobTemp";
                                   // spice-incompatible parameters
         spice_tr<<"Vt0tc"<<"Tcv"; // parameters that need conversion of names
     }
@@ -122,8 +124,13 @@ QString JFET::spice_netlist(bool isXyce)
 
     QString jfet_type = getProperty("Type")->Value.at(0).toUpper();
 
-    s += QString(" JMOD_%1 %2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
-            .arg(getProperty("Temp")->Value);
+    if (getProperty("UseGlobTemp")->Value == "yes") {
+      s += QString(" JMOD_%1 %2\n").arg(Name).arg(getProperty("Area")->Value);
+    } else {
+      s += QString(" JMOD_%1 %2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
+      .arg(getProperty("Temp")->Value);
+    }
+
     s += QString(".MODEL JMOD_%1 %2JF (%3)\n").arg(Name).arg(jfet_type).arg(par_str);
 
     return s;

--- a/qucs/components/mosfet.cpp
+++ b/qucs/components/mosfet.cpp
@@ -154,7 +154,7 @@ QString MOSFET::spice_netlist(bool isXyce)
 
     QStringList spice_incompat,spice_tr;
     spice_incompat<<"Type"<<"Temp"<<"L"<<"W"<<"Ad"<<"As"<<"Pd"<<"Ps"
-                 <<"Rg"<<"N"<<"Tt"<<"Nrd"<<"Nrs"<<"Ffe";
+                 <<"Rg"<<"N"<<"Tt"<<"Nrd"<<"Nrs"<<"Ffe"<<"UseGlobTemp";
                               // spice-incompatible parameters
     if (isXyce) {
         spice_tr<<"Vt0"<<"VtO"; // parameters that need conversion of names
@@ -192,8 +192,13 @@ QString MOSFET::spice_netlist(bool isXyce)
     misc::str2num(getProperty("Ps")->Value,ps,unit,fac);
     ps *= fac;
 
-    s += QString(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7 Temp=%8\n")
-            .arg(Name).arg(l).arg(w).arg(ad).arg(as).arg(pd).arg(ps).arg(getProperty("Temp")->Value);
+    if (getProperty("UseGlobTemp")->Value == "yes") {
+      s += QString(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7\n")
+      .arg(Name).arg(l).arg(w).arg(ad).arg(as).arg(pd).arg(ps);
+    } else {
+      s += QString(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7 Temp=%8\n")
+      .arg(Name).arg(l).arg(w).arg(ad).arg(as).arg(pd).arg(ps).arg(getProperty("Temp")->Value);
+    }
     s += QString(".MODEL MMOD_%1 %2MOS (%3)\n").arg(Name).arg(mosfet_type).arg(par_str);
 
     return s;

--- a/qucs/components/mosfet_sub.cpp
+++ b/qucs/components/mosfet_sub.cpp
@@ -121,6 +121,8 @@ Basic_MOSFET::Basic_MOSFET()
 	QObject::tr("simulation temperature in degree Celsius")));
   Props.append(new Property("Tnom", "26.85", false,
 	QObject::tr("parameter measurement temperature")));
+  Props.append(new Property("UseGlobTemp", "yes", false,
+        QObject::tr("Use global SPICE temperature")+" [yes,no]"));
 
   Name  = "T";
   SpiceModel = "M";
@@ -162,7 +164,7 @@ QString MOSFET_sub::spice_netlist(bool isXyce)
 
     QStringList spice_incompat,spice_tr;
     spice_incompat<<"Type"<<"Temp"<<"L"<<"W"<<"Ad"<<"As"<<"Pd"<<"Ps"
-                 <<"Rg"<<"N"<<"Tt"<<"Nrd"<<"Nrs"<<"Ffe";
+                 <<"Rg"<<"N"<<"Tt"<<"Nrd"<<"Nrs"<<"Ffe"<<"UseGlobTemp";
                               // spice-incompatible parameters
     if (isXyce) {
         spice_tr<<"Vt0"<<"VtO"; // parameters that need conversion of names
@@ -199,8 +201,13 @@ QString MOSFET_sub::spice_netlist(bool isXyce)
     misc::str2num(getProperty("Ps")->Value,ps,unit,fac);
     ps *= fac;
 
-    s += QString(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7 Temp=%8\n")
-            .arg(Name).arg(l).arg(w).arg(ad).arg(as).arg(pd).arg(ps).arg(getProperty("Temp")->Value);
+    if (getProperty("UseGlobTemp")->Value == "yes") {
+      s += QString(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7\n")
+      .arg(Name).arg(l).arg(w).arg(ad).arg(as).arg(pd).arg(ps);
+    } else {
+      s += QString(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7 Temp=%8\n")
+      .arg(Name).arg(l).arg(w).arg(ad).arg(as).arg(pd).arg(ps).arg(getProperty("Temp")->Value);
+    }
     s += QString(".MODEL MMOD_%1 %2MOS (%3)\n").arg(Name).arg(mosfet_type).arg(par_str);
 
     return s;


### PR DESCRIPTION
## The state of problem

If the schematic contains blue semiconductor devices (D,BJT,JFET,MOS), the SPICE simulation takes the device temperature from `Temp` property and ignores the SPICE global temperature. This makes temperature sweep with SPICE not a straightforward task. It is required to set `Temp=TEMPER` for every device. The explicit setting of `Temp` property is needed for Qucsator compatibility. 

## The solution

I have added the property `UseGlobTemp=yes/no` The default is `yes`. If set to `yes` it uses global temperature. Otherwise the device uses temperature defined in `Temp`. The temperature sweep will be possible for device using default parameters. 

![image](https://github.com/user-attachments/assets/91d2725f-f6f0-40cb-bd14-6d71a2e24107)

