### PR TITLE
Fix of BJTsub and Diode device

### DIFF
--- a/qucs/components/bjtsub.cpp
+++ b/qucs/components/bjtsub.cpp
@@ -128,7 +128,7 @@ Basic_BJT::Basic_BJT()
 BJTsub::BJTsub()
 {
   Description = QObject::tr("bipolar junction transistor with substrate");
-  Simulator = spicecompat::simQucsator;
+  Simulator = spicecompat::simAll;
   createSymbol();
   tx = x2+4;
   ty = y1+4;

--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -422,7 +422,7 @@ ComponentDialog::ComponentDialog(Component *c, Schematic *d)
   connect(ButtDown, SIGNAL(clicked()), SLOT(slotButtDown()));
 
   QStringList allowedFillFromSPICE;
-  allowedFillFromSPICE<<"_BJT"<<"JFET"<<"MOSFET"<<"_MOSFET"<<"Diode";
+  allowedFillFromSPICE<<"_BJT"<<"JFET"<<"MOSFET"<<"_MOSFET"<<"Diode"<<"BJT";
   ButtFillFromSpice = new QPushButton(tr("Fill from SPICE .MODEL"));
   if (!allowedFillFromSPICE.contains(Comp->Model)) {
     ButtFillFromSpice->setEnabled(false);

--- a/qucs/components/diode.cpp
+++ b/qucs/components/diode.cpp
@@ -119,7 +119,7 @@ QString Diode::spice_netlist(bool isXyce)
                      <<"Nr"<<"Ffe"<<"Temp"<<"Area"<<"Symbol"<<"UseGlobTemp"; // spice-incompatible parameters
     } else {
         spice_tr<<"Tbv"<<"Tcv";
-        spice_incompat<<"Cp"<<"Isr"<<"Nr"<<"Ffe"<<"Temp"<<"Area"<<"Symbol"<<"UseGLobTemp";
+        spice_incompat<<"Cp"<<"Isr"<<"Nr"<<"Ffe"<<"Temp"<<"Area"<<"Symbol"<<"UseGlobTemp";
     }
 
     QString par_str;


### PR DESCRIPTION
This PR contains the following improvements:

* Make BJTsub available for all simulators; Fixes #982 
* Fix `UseGlobTemp` parameter name typo in diode
* Allow fill from SPICE for BJTsub