### PR TITLE
Spar viewer: Fixes and New Features

### DIFF
--- a/qucs-s-spar-viewer/main.cpp
+++ b/qucs-s-spar-viewer/main.cpp
@@ -108,7 +108,7 @@ int main( int argc, char ** argv )
   qucs->move(QucsSettings.x, QucsSettings.y);  // position before "show" !!!
   qucs->show();
 
-  QScreen* primaryScreen = QGuiApplication::screens().first();
+  QScreen* primaryScreen = QGuiApplication::screens().constFirst();
 
   qucs->resize(primaryScreen->availableGeometry().size() * 0.9);
   qucs->setGeometry(

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -1,14 +1,25 @@
-/****************************************************************************
-**     Qucs Attenuator Synthesis
-**     qucsattenuator.cpp
-**
-**
-**
-**
-**
-**
-**
-*****************************************************************************/
+/*
+ * qucs-s-spar-viewer.cpp - S-parameter viewer for Qucs-S
+ *
+ * copyright (C) 2024 Andres Martinez-Mera <andresmartinezmera@gmail.com>
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this package; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ *
+ */
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -2858,6 +2858,8 @@ void Qucs_S_SPAR_Viewer::loadSession(QString session_file)
     return;
   }
 
+  savepath = session_file;
+
   QXmlStreamReader xml(&file);
 
   // Trace properties

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -2588,6 +2588,13 @@ void Qucs_S_SPAR_Viewer::addLimit(double f_limit1, QString f_limit1_unit, double
   List_Couple_Value.append(new_limit_CoupleButton);
   this->LimitsGrid->addWidget(new_limit_CoupleButton, limit_index+1, 2);
 
+  if (coupled){
+    new_limit_CoupleButton->setText("<--->");
+  } else {
+    new_limit_CoupleButton->setText("<-X->");
+  }
+  new_limit_CoupleButton->click();
+
 
   QString Separator_name = QString("Lmt_Separator%1").arg(n_limits);
   QFrame * new_Separator = new QFrame();
@@ -2745,7 +2752,7 @@ bool Qucs_S_SPAR_Viewer::save()
         xmlWriter.writeTextElement("val_stop", QString::number(value));
 
         // Couple values
-        Coupled_Limits = List_Couple_Value[i]->isChecked();
+        Coupled_Limits = (List_Couple_Value[i]->text() == "<-X->");
         xmlWriter.writeTextElement("couple_values", QString::number(Coupled_Limits));
 
         xmlWriter.writeEndElement(); // Limit

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -192,8 +192,8 @@ Qucs_S_SPAR_Viewer::Qucs_S_SPAR_Viewer()
   available_x_axis_div.clear();
   available_x_axis_div << 2000 << 1000 << 500 << 400 << 200 << 100 << 50 << 25 << 20 << 10 << 5 << 1 << 0.5 << 0.2 << 0.1;
 
-  for (const double &value : available_x_axis_div) {
-      QComboBox_x_axis_div->addItem(QString::number(value));
+  for (const double &value : qAsConst(available_x_axis_div)) {
+    QComboBox_x_axis_div->addItem(QString::number(value));
   }
 
   connect(QComboBox_x_axis_div, SIGNAL(currentIndexChanged(int)), SLOT(updatePlot()));
@@ -462,13 +462,6 @@ void Qucs_S_SPAR_Viewer::slotHelpAbout()
 
 void Qucs_S_SPAR_Viewer::slotQuit()
 {
-  int tmp;
-  tmp = x();
-  tmp = y();
-  tmp = width();
-  tmp = height();
-  Q_UNUSED(tmp);
-
   qApp->quit();
 }
 
@@ -743,7 +736,6 @@ void Qucs_S_SPAR_Viewer::addFiles(QStringList fileNames)
 
         // 4) Add new dataset to the trace selection combobox
         QCombobox_datasets->addItem(filename);
-        QString current_dataset = QCombobox_datasets->currentText();
         // Update traces
         updateTracesCombo();
     }
@@ -1415,9 +1407,10 @@ void Qucs_S_SPAR_Viewer::updateTraces()
     QList<QAbstractSeries *> seriesList = chart->series();
 
     // Remove series from the chart
-    for (QAbstractSeries *series : seriesList) {
-            chart->removeSeries(series);
-        }
+    for (QAbstractSeries *series : qAsConst(seriesList)) {
+      chart->removeSeries(series);
+    }
+
 
     double freq_scale = getFreqScale();
 
@@ -1431,7 +1424,7 @@ void Qucs_S_SPAR_Viewer::updateTraces()
     // Remove marker traces
     // Iterate through the series list
     QList<QAbstractSeries *> seriesToRemove;
-    for (QAbstractSeries *series : seriesList) {
+    for (QAbstractSeries *series : qAsConst(seriesList)) {
         //qDebug() << series->name();
         if (series->name().startsWith("Mkr", Qt::CaseInsensitive)) {
             seriesToRemove.append(series);
@@ -1934,7 +1927,7 @@ QPointF Qucs_S_SPAR_Viewer::findClosestPoint(QAbstractSeries* series, qreal targ
     qreal minDistance = qAbs(targetX - closestPoint.x());
 
     // Iterate through all points to find the closest one
-    for (const QPointF& point : points) {
+    for (const QPointF& point : qAsConst(points)) {
         qreal distance = qAbs(targetX - point.x());
         if (distance < minDistance) {
             minDistance = distance;
@@ -2168,7 +2161,7 @@ void Qucs_S_SPAR_Viewer::dropEvent(QDropEvent *event)
     QList<QUrl> urls = event->mimeData()->urls();
     QStringList fileList;
 
-    for (const QUrl &url : urls) {
+    for (const QUrl &url : qAsConst(urls)) {
         if (url.isLocalFile()) {
             fileList << url.toLocalFile();
         }

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -2095,6 +2095,11 @@ void Qucs_S_SPAR_Viewer::adjust_x_axis_div()
         disconnect(QComboBox_x_axis_div, SIGNAL(currentIndexChanged(int)), this, SLOT(updatePlot()));
         QComboBox_x_axis_div->setCurrentIndex(new_index);
         connect(QComboBox_x_axis_div, SIGNAL(currentIndexChanged(int)), SLOT(updatePlot()));
+
+        //Update the step of the spinboxes
+        double step = QComboBox_x_axis_div->currentText().toDouble()/10;
+        QSpinBox_x_axis_min->setSingleStep(step);
+        QSpinBox_x_axis_max->setSingleStep(step);
     }
 }
 

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -230,7 +230,7 @@ Qucs_S_SPAR_Viewer::Qucs_S_SPAR_Viewer()
   QComboBox_y_axis_div = new QComboBox();
   available_y_axis_div.clear();
   available_y_axis_div << 50 << 25 << 20 << 10 << 5 << 2 << 1 << 0.5 << 0.2 << 0.1;
-  for (const double &value : available_y_axis_div) {
+  for (const double &value : qAsConst(available_y_axis_div)) {
       QComboBox_y_axis_div->addItem(QString::number(value));
   }
   connect(QComboBox_y_axis_div, SIGNAL(currentIndexChanged(int)), SLOT(updatePlot()));
@@ -265,6 +265,14 @@ Qucs_S_SPAR_Viewer::Qucs_S_SPAR_Viewer()
   QSpinBox_y2_axis_max->hide();
   QSpinBox_y2_axis_div->hide();
  // QCombobox_y2_axis_units->hide();
+
+  // Lock axis settings button
+  Lock_axis_settings_Button =  new QPushButton("Lock Axes");
+  Lock_axis_settings_Button->setCheckable(true);
+  connect(Lock_axis_settings_Button, SIGNAL(clicked(bool)), SLOT(lock_unlock_axis_settings()));
+  lock_axis = false;
+
+  SettingsGrid->addWidget(Lock_axis_settings_Button, 0, 4);
 
   QWidget * TracesGroup = new QWidget();
   QVBoxLayout *Traces_VBox = new QVBoxLayout(TracesGroup);
@@ -1322,9 +1330,11 @@ void Qucs_S_SPAR_Viewer::changeTraceWidth()
 
 void Qucs_S_SPAR_Viewer::updatePlot()
 {
+  if (lock_axis == false){
     // Update axes
     update_X_axis();
     update_Y_axis();
+  }
 
     // Trim the traces according to the new settings
     updateTraces();
@@ -2169,4 +2179,33 @@ void Qucs_S_SPAR_Viewer::dropEvent(QDropEvent *event)
     if (!fileList.isEmpty()) {
         addFiles(fileList);
     }
+}
+
+
+void Qucs_S_SPAR_Viewer::lock_unlock_axis_settings()
+{
+  if (lock_axis == true){
+    lock_axis = false;
+    Lock_axis_settings_Button->setText("Lock Axes");
+    //Frozen axes inputs
+    QSpinBox_x_axis_min->setEnabled(true);
+    QSpinBox_x_axis_max->setEnabled(true);
+    QComboBox_x_axis_div->setEnabled(true);
+    QCombobox_x_axis_units->setEnabled(true);
+    QSpinBox_y_axis_min->setEnabled(true);
+    QSpinBox_y_axis_max->setEnabled(true);
+    QComboBox_y_axis_div->setEnabled(true);
+  }
+  else{
+    lock_axis = true;
+    Lock_axis_settings_Button->setText("Unlock Axes");
+    //Unfrozen axes inputs
+    QSpinBox_x_axis_min->setDisabled(true);
+    QSpinBox_x_axis_max->setDisabled(true);
+    QComboBox_x_axis_div->setDisabled(true);
+    QCombobox_x_axis_units->setDisabled(true);
+    QSpinBox_y_axis_min->setDisabled(true);
+    QSpinBox_y_axis_max->setDisabled(true);
+    QComboBox_y_axis_div->setDisabled(true);
+  }
 }

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -2502,6 +2502,7 @@ void Qucs_S_SPAR_Viewer::addLimit(double f_limit1, QString f_limit1_unit, double
   new_limit_fstart_Spinbox->setObjectName(SpinBox_fstart_name);
   new_limit_fstart_Spinbox->setMaximum(QSpinBox_x_axis_max->minimum());
   new_limit_fstart_Spinbox->setMaximum(QSpinBox_x_axis_max->maximum());
+  new_limit_fstart_Spinbox->setSingleStep(QComboBox_x_axis_div->currentText().toDouble()/5);
   new_limit_fstart_Spinbox->setValue(f_limit1);
   connect(new_limit_fstart_Spinbox, SIGNAL(valueChanged(double)), SLOT(updateTraces()));
   List_Limit_Start_Freq.append(new_limit_fstart_Spinbox);
@@ -2526,6 +2527,7 @@ void Qucs_S_SPAR_Viewer::addLimit(double f_limit1, QString f_limit1_unit, double
   new_limit_fstop_Spinbox->setObjectName(SpinBox_fstop_name);
   new_limit_fstop_Spinbox->setMaximum(QSpinBox_x_axis_max->minimum());
   new_limit_fstop_Spinbox->setMaximum(QSpinBox_x_axis_max->maximum());
+  new_limit_fstop_Spinbox->setSingleStep(QComboBox_x_axis_div->currentText().toDouble()/5);
   new_limit_fstop_Spinbox->setValue(f_limit2);
   connect(new_limit_fstop_Spinbox, SIGNAL(valueChanged(double)), SLOT(updateTraces()));
   List_Limit_Stop_Freq.append(new_limit_fstop_Spinbox);
@@ -2552,6 +2554,7 @@ void Qucs_S_SPAR_Viewer::addLimit(double f_limit1, QString f_limit1_unit, double
   new_limit_val_start_Spinbox->setMaximum(QSpinBox_y_axis_max->minimum());
   new_limit_val_start_Spinbox->setMaximum(QSpinBox_y_axis_max->maximum());
   new_limit_val_start_Spinbox->setValue(y_limit1);
+  new_limit_val_start_Spinbox->setSingleStep(QComboBox_y_axis_div->currentText().toDouble()/5);
   connect(new_limit_val_start_Spinbox, SIGNAL(valueChanged(double)), SLOT(updateLimits()));
   List_Limit_Start_Value.append(new_limit_val_start_Spinbox);
   this->LimitsGrid->addWidget(new_limit_val_start_Spinbox, limit_index+1, 1);
@@ -2562,6 +2565,7 @@ void Qucs_S_SPAR_Viewer::addLimit(double f_limit1, QString f_limit1_unit, double
   new_limit_val_stop_Spinbox->setMaximum(QSpinBox_y_axis_max->minimum());
   new_limit_val_stop_Spinbox->setMaximum(QSpinBox_y_axis_max->maximum());
   new_limit_val_stop_Spinbox->setValue(y_limit2);
+  new_limit_val_stop_Spinbox->setSingleStep(QComboBox_y_axis_div->currentText().toDouble()/5);
   connect(new_limit_val_stop_Spinbox, SIGNAL(valueChanged(double)), SLOT(updateLimits()));
   List_Limit_Stop_Value.append(new_limit_val_stop_Spinbox);
   this->LimitsGrid->addWidget(new_limit_val_stop_Spinbox, limit_index+1, 3);
@@ -2973,17 +2977,17 @@ void Qucs_S_SPAR_Viewer::loadSession(QString session_file)
             if (xml.name() == "file")
             {
               fileName = xml.attributes().value("file_name").toString();
-              qDebug() << "File name:" << fileName;
+              //qDebug() << "File name:" << fileName;
             }
             else if (xml.name() == "trace")
             {
               traceName = xml.attributes().value("trace_name").toString();
-              qDebug() << "Trace name:" << traceName;
+              //qDebug() << "Trace name:" << traceName;
             }
             else if (xml.name() == "value")
             {
               QString value = xml.readElementText();
-              qDebug() << "Value:" << value;
+              //qDebug() << "Value:" << value;
               datasets[fileName][traceName].append(value.toDouble());
             }
           }

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -2061,7 +2061,7 @@ void Qucs_S_SPAR_Viewer::updateMarkerTable(){
             };
             QString file = parts[0];
             QString trace = parts[1];
-            if (trace.at(0) == "S"){
+            if (trace.at(0) == 'S'){
               trace.append("_dB");
             }
             P = findClosestPoint(datasets[file]["frequency"], datasets[file][trace], targetX);
@@ -2896,17 +2896,17 @@ void Qucs_S_SPAR_Viewer::loadSession(QString session_file)
 
            // If token is StartElement, check element name
     if (token == QXmlStreamReader::StartElement) {
-      if (xml.name() == "trace") {
-        while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == "trace")) {
+      if (xml.name() == QStringLiteral("trace")) {
+        while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("trace"))) {
           xml.readNext();
           if (xml.tokenType() == QXmlStreamReader::StartElement) {
-            if (xml.name() == "trace_name") {
+            if (xml.name() == QStringLiteral("trace_name")) {
               trace_name.append(xml.readElementText());
-            } else if (xml.name() == "trace_width") {
+            } else if (xml.name() == QStringLiteral("trace_width")) {
               trace_width.append(xml.readElementText().toInt());
-            } else if (xml.name() == "trace_color") {
+            } else if (xml.name() == QStringLiteral("trace_color")) {
               trace_color.append(xml.readElementText());
-            } else if (xml.name() == "trace_style") {
+            } else if (xml.name() == QStringLiteral("trace_style")) {
               trace_style.append(xml.readElementText());
             }
           }
@@ -2938,53 +2938,53 @@ void Qucs_S_SPAR_Viewer::loadSession(QString session_file)
       } else if (xml.name().toString().contains("lock_status")) {
         lock_axis = xml.readElementText().toInt();
         lock_unlock_axis_settings();
-      } else if (xml.name() == "Limit") {
-        while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == "Limit")) {
+      } else if (xml.name() == QStringLiteral("Limit")) {
+        while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("Limit"))) {
           xml.readNext();
           if (xml.tokenType() == QXmlStreamReader::StartElement) {
-            if (xml.name() == "fstart") {
+            if (xml.name() == QStringLiteral("fstart")) {
               Limit_Start_Freq.append(xml.readElementText().toDouble());
-            } else if (xml.name() == "val_start") {
+            } else if (xml.name() == QStringLiteral("val_start")) {
               Limit_Start_Val.append(xml.readElementText().toDouble());
-            } else if (xml.name() == "fstop") {
+            } else if (xml.name() == QStringLiteral("fstop")) {
               Limit_Stop_Freq.append(xml.readElementText().toDouble());
-            } else if (xml.name() == "val_stop") {
+            } else if (xml.name() == QStringLiteral("val_stop")) {
               Limit_Stop_Val.append(xml.readElementText().toDouble());
-            } else if (xml.name() == "fstart_unit") {
+            } else if (xml.name() == QStringLiteral("fstart_unit")) {
               Limit_Start_Freq_Unit.append(xml.readElementText());
-            } else if (xml.name() == "fstop_unit") {
+            } else if (xml.name() == QStringLiteral("fstop_unit")) {
               Limit_Stop_Freq_Unit.append(xml.readElementText());
-            } else if (xml.name() == "couple_values") {
+            } else if (xml.name() == QStringLiteral("couple_values")) {
               Limit_Couple_Values.append(xml.readElementText().toInt());
             }
           }
         }
-      } else if (xml.name() == "MARKERS"){
-        while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == "MARKERS")) {
+      } else if (xml.name() == QStringLiteral("MARKERS")){
+        while (!(xml.tokenType() == QXmlStreamReader::EndElement && xml.name() == QStringLiteral("MARKERS"))) {
           xml.readNext();
           if (xml.tokenType() == QXmlStreamReader::StartElement) {
             double value = xml.readElementText().toDouble();
             Markers.append(value);
           }
         }
-      } else if (xml.name() == "file") {
+      } else if (xml.name() == QStringLiteral("file")) {
         // Load datasets
         QString fileName, traceName;
         while (!xml.atEnd() && !xml.hasError())
         {
           if (xml.tokenType() == QXmlStreamReader::StartElement)
           {
-            if (xml.name() == "file")
+            if (xml.name() == QStringLiteral("file"))
             {
               fileName = xml.attributes().value("file_name").toString();
               //qDebug() << "File name:" << fileName;
             }
-            else if (xml.name() == "trace")
+            else if (xml.name() == QStringLiteral("trace"))
             {
               traceName = xml.attributes().value("trace_name").toString();
               //qDebug() << "Trace name:" << traceName;
             }
-            else if (xml.name() == "value")
+            else if (xml.name() == QStringLiteral("value"))
             {
               QString value = xml.readElementText();
               //qDebug() << "Value:" << value;

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -601,7 +601,7 @@ void Qucs_S_SPAR_Viewer::addFiles(QStringList fileNames)
     for (int i = 0; i < fileNames.length(); i++){
       filename = QFileInfo(fileNames.at(i)).fileName();
       // Check if this file already exists
-      QString new_filename = filename.left(filename.indexOf('.'));
+      QString new_filename = filename.left(filename.lastIndexOf('.'));
       if (files_dataset.contains(new_filename)){
         // Remove it from the list of new files to load
         fileNames.removeAt(i);
@@ -621,7 +621,7 @@ void Qucs_S_SPAR_Viewer::addFiles(QStringList fileNames)
         // Create the file name label
         filename = QFileInfo(fileNames.at(i-existing_files)).fileName();
 
-        QLabel * Filename_Label = new QLabel(filename.left(filename.indexOf('.')));
+        QLabel * Filename_Label = new QLabel(filename.left(filename.lastIndexOf('.')));
         Filename_Label->setObjectName(QString("File_") + QString::number(i));
         List_FileNames.append(Filename_Label);
         this->FilesGrid->addWidget(List_FileNames.last(), i,0,1,1);
@@ -828,7 +828,7 @@ void Qucs_S_SPAR_Viewer::addFiles(QStringList fileNames)
            }
         }
         // 3) Add data to the dataset
-        filename = filename.left(filename.indexOf('.')); // Remove file extension
+        filename = filename.left(filename.lastIndexOf('.')); // Remove file extension
         datasets[filename] = file_data;
         file.close();
 
@@ -870,7 +870,7 @@ void Qucs_S_SPAR_Viewer::addFiles(QStringList fileNames)
             QString filename;
             for (int i = 0; i < fileNames.length(); i++){
                 filename = QFileInfo(fileNames.at(i)).fileName();
-                filename = filename.left(filename.indexOf('.'));
+                filename = filename.left(filename.lastIndexOf('.'));
                 // Pick a random color
                 QColor trace_color = QColor(QRandomGenerator::global()->bounded(256), QRandomGenerator::global()->bounded(256), QRandomGenerator::global()->bounded(256));
                 this->addTrace(filename, QString("S21"), trace_color);
@@ -926,7 +926,10 @@ void Qucs_S_SPAR_Viewer::removeFile(int index_to_delete)
     QList<int> indices_to_remove;
     for (int i = 0; i < List_TraceNames.size(); i++){
         QString trace_name = List_TraceNames.at(i)->text();
-        QStringList parts = trace_name.split(".");//Trace name = dataset + trace
+        QStringList parts = {
+            trace_name.section('.', 0, -2),
+            trace_name.section('.', -1)
+        };
         QString dataset_trace = parts[0];
         if (dataset_trace == dataset_to_remove ){
             QString Label_Object_Name = List_TraceNames.at(i)->objectName();
@@ -1557,7 +1560,10 @@ void Qucs_S_SPAR_Viewer::updateTraces()
         QString trace_name = series->name();
         qreal minX_trace, maxX_trace, minY_trace, maxY_trace;
 
-        QStringList trace_name_parts = trace_name.split('.');
+        QStringList trace_name_parts = {
+            trace_name.section('.', 0, -2),
+            trace_name.section('.', -1)
+        };
         QString data_file = trace_name_parts[0];
         QString trace_file = trace_name_parts[1];
 
@@ -2049,7 +2055,10 @@ void Qucs_S_SPAR_Viewer::updateMarkerTable(){
             // Look into dataset, traces may be clipped.
             // It is important to grab the data from the dataset, not from the displayed trace.
             QString trace_name = seriesList[c-1]->name();
-            QStringList parts = trace_name.split(".");
+            QStringList parts = {
+                trace_name.section('.', 0, -2),
+                trace_name.section('.', -1)
+            };
             QString file = parts[0];
             QString trace = parts[1];
             if (trace.at(0) == "S"){
@@ -3029,7 +3038,10 @@ void Qucs_S_SPAR_Viewer::loadSession(QString session_file)
 
   // Add traces to the display
   for (int i = 0; i < trace_name.size(); i++){
-    QStringList parts = trace_name.at(i).split(".");
+    QStringList parts = {
+        trace_name[i].section('.', 0, -2),
+        trace_name[i].section('.', -1)
+    };
     addTrace(parts[0], parts[1], trace_color.at(i), trace_width.at(i), trace_style.at(i));
   }
 

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.h
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.h
@@ -73,6 +73,7 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
 
   void update_X_axis();
   void update_Y_axis();
+  void lock_unlock_axis_settings();
 
   void addMarker();
   void removeMarker();
@@ -120,6 +121,8 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   QList<double> available_y_axis_div;
   QComboBox *QComboBox_y_axis_div;
   QDoubleSpinBox *QSpinBox_y2_axis_min, *QSpinBox_y2_axis_max, *QSpinBox_y2_axis_div;
+  QPushButton *Lock_axis_settings_Button;
+  bool lock_axis;
 
   // Trace management widgets
   QComboBox *QCombobox_datasets, *QCombobox_traces;

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.h
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.h
@@ -62,6 +62,7 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   void removeTrace(QList<int>);
 
   void updatePlot();
+  void updateTraces();
   void updateTracesCombo();
 
   void changeTraceColor();
@@ -80,6 +81,14 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   void removeMarker(int);
   void removeAllMarkers();
   void updateMarkerTable();
+
+  void addLimit();
+  void removeLimit();
+  void removeLimit(int);
+  void removeAllLimits();
+  void updateLimits();
+
+  void coupleSpinBoxes();
 
  protected:
   void dragEnterEvent(QDragEnterEvent *event) override;
@@ -150,7 +159,6 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   double f_min, f_max, y_min, y_max; // Minimum (maximum) values of the display
   QList<QColor> default_colors;
   bool removeSeriesByName(QChart*, const QString&);
-  void updateTraces();
 
   // Markers
   QDockWidget *dockMarkers;
@@ -164,6 +172,18 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   QList<QComboBox *> List_MarkerScale;
   QList<QToolButton*> List_Button_DeleteMarker;
 
+  // Limits
+  QDockWidget *dockLimits;
+  QWidget *Limits_Widget;
+  QGridLayout * LimitsGrid;
+  QPushButton *Button_add_Limit, *Button_Remove_All_Limits;
+  QList<QLabel *> List_LimitNames;
+  QList<QDoubleSpinBox *> List_Limit_Start_Freq, List_Limit_Stop_Freq;
+  QList<QDoubleSpinBox *> List_Limit_Start_Value, List_Limit_Stop_Value;
+  QList<QComboBox *> List_Limit_Start_Freq_Scale, List_Limit_Stop_Freq_Scale;
+  QList<QToolButton*> List_Button_Delete_Limit;
+  QList<QFrame*> List_Separators;
+  QList<QPushButton*> List_Couple_Value;
 
   // Utilities
   void convert_MA_RI_to_dB(double *, double *, double *, double *, QString);

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.h
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.h
@@ -48,6 +48,8 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   void slotHelpAbout();
   void slotHelpAboutQt();
   void slotQuit();
+  void slotSave();
+  void slotSaveAs();
 
   void addFile();
   void addFiles(QStringList);
@@ -184,6 +186,10 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   QList<QToolButton*> List_Button_Delete_Limit;
   QList<QFrame*> List_Separators;
   QList<QPushButton*> List_Couple_Value;
+
+  // Save
+  QString savepath;
+  bool save();
 
   // Utilities
   void convert_MA_RI_to_dB(double *, double *, double *, double *, QString);

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.h
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.h
@@ -172,7 +172,7 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   void adjust_x_axis_to_file(QString);
   void adjust_y_axis_to_trace(QString, QString);
   void adjust_x_axis_div();
-  QPointF findClosestPoint(QAbstractSeries*, qreal);
+  QPointF findClosestPoint(const QList<double>&, const QList<double>&, qreal);
   double getFreqFromText(QString);
 };
 

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.h
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.h
@@ -50,6 +50,7 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   void slotQuit();
   void slotSave();
   void slotSaveAs();
+  void slotLoadSession();
 
   void addFile();
   void addFiles(QStringList);
@@ -58,7 +59,7 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   void removeAllFiles();
 
   void addTrace();
-  void addTrace(QString, QString, QColor);
+  void addTrace(QString, QString, QColor, int trace_width = 1, QString trace_style = "Solid");
   void removeTrace();
   void removeTrace(int);
   void removeTrace(QList<int>);
@@ -78,13 +79,13 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   void update_Y_axis();
   void lock_unlock_axis_settings();
 
-  void addMarker();
+  void addMarker(double freq = -1);
   void removeMarker();
   void removeMarker(int);
   void removeAllMarkers();
   void updateMarkerTable();
 
-  void addLimit();
+  void addLimit(double f_limit1=-1, QString f_limit1_unit = "", double f_limit2=-1, QString f_limit2_unit = "", double y_limit1=-1, double y_limit2=-1, bool coupled=false);
   void removeLimit();
   void removeLimit(int);
   void removeAllLimits();
@@ -134,6 +135,7 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   QDoubleSpinBox *QSpinBox_y2_axis_min, *QSpinBox_y2_axis_max, *QSpinBox_y2_axis_div;
   QPushButton *Lock_axis_settings_Button;
   bool lock_axis;
+  QStringList frequency_units;
 
   // Trace management widgets
   QComboBox *QCombobox_datasets, *QCombobox_traces;
@@ -190,6 +192,7 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   // Save
   QString savepath;
   bool save();
+  void loadSession(QString);
 
   // Utilities
   void convert_MA_RI_to_dB(double *, double *, double *, double *, QString);


### PR DESCRIPTION
Hi there.

I've been using the tool and found some issues. While I was at it, I added some features:

### Fixed issues

- Fixed several warnings
- I've noticed that before this PR the marker data was taken from the displayed traces and not from the dataset. This caused the marker data to be clipped when the trace was clipped by the chart limits.
- Before this PR, the tool considers that everything after the first "." is the file extension. Now the tool can handle files with several "."

### New Features

- **Lock button**: A button has been added to freeze the axis settings. This is necessary because the tool automatically adjusts the axes when the user adds a new trace. This behavior is correct and makes the tool more dynamic, but it can be annoying when the user is focused on a specific band and wants to add and remove traces.

- **Limit line:** Most network analyzers I have worked with have this feature. This is used to check if your measurement meets the gain mask, RL, etc.

- **Save / Open Session**: This feature saves the current state of the tool to an XML file. This saves time as the user does not have to enter the limits and marker stuff every time he/she uses the tool.

Here is a screencast:

[https://drive.google.com/file/d/1ZdGebMBIh8tHjbdxuHGOIi8Ydwcz4yNz/view?usp=sharing](https://drive.google.com/file/d/1ZdGebMBIh8tHjbdxuHGOIi8Ydwcz4yNz/view?usp=sharing)
