### PR TITLE
Fixed crash when no simulators found on first start

### DIFF
--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -1787,7 +1787,7 @@ Component *getComponentFromName(QString &Line, Schematic *p) {
 
     if (!c) {
         /// \todo enable user to load partial schematic, skip unknown components
-        if (QucsMain != 0) {
+        if (QucsMain != nullptr) {
             QMessageBox *msg = new QMessageBox(QMessageBox::Warning, QObject::tr("Warning"),
                                                QObject::tr("Format Error:\nUnknown component!\n"
                                                            "%1\n\n"

--- a/qucs/components/spicefile.cpp
+++ b/qucs/components/spicefile.cpp
@@ -388,7 +388,7 @@ bool SpiceFile::recreateSubNetlist(QString *SpiceFile, QString *FileName)
   (*filstream) << NetText;
 
   // only interact with the GUI if it was launched
-  if (QucsMain) {
+  if (QucsMain != nullptr) {
     QucsMain->statusBar()->showMessage(tr("Converting SPICE file \"%1\".").arg(*SpiceFile), 2000);
   }
   else

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -486,7 +486,7 @@ void Ngspice::slotSimulate()
     QString ngsp_cmd = cmd_args.at(0);
     cmd_args.removeAt(0);
     SimProcess->start(ngsp_cmd,cmd_args);
-    if (QucsMain)
+    if (QucsMain != nullptr)
     emit started();
 }
 

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -179,7 +179,9 @@ bool saveApplSettings()
     qs.setItem<QString>("font", QucsSettings.font.toString());
     qs.setItem<QString>("appFont", QucsSettings.appFont.toString());
     qs.setItem<QString>("textFont", QucsSettings.textFont.toString());
-    qs.setItem<QByteArray>("MainWindowGeometry", QucsMain->saveGeometry());
+    if (QucsMain != 0) {
+      qs.setItem<QByteArray>("MainWindowGeometry", QucsMain->saveGeometry());
+    }
     
     // store LargeFontSize as a string, so it will be also human-readable in the settings file (will be a @Variant() otherwise)
     qs.setItem<QString>("LargeFontSize", QString::number(QucsSettings.largeFontSize));

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -63,7 +63,7 @@
 
 tQucsSettings QucsSettings;
 
-QucsApp *QucsMain = 0;  // the Qucs application itself
+QucsApp *QucsMain = nullptr;  // the Qucs application itself
 QString lastDir;    // to remember last directory for several dialogs
 QStringList qucsPathList;
 VersionTriplet QucsVersion; // Qucs version string
@@ -179,7 +179,7 @@ bool saveApplSettings()
     qs.setItem<QString>("font", QucsSettings.font.toString());
     qs.setItem<QString>("appFont", QucsSettings.appFont.toString());
     qs.setItem<QString>("textFont", QucsSettings.textFont.toString());
-    if (QucsMain != 0) {
+    if (QucsMain != nullptr) {
       qs.setItem<QByteArray>("MainWindowGeometry", QucsMain->saveGeometry());
     }
     

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -1070,7 +1070,7 @@ bool Schematic::loadDocument()
   QFile file(DocName);
   if(!file.open(QIODevice::ReadOnly)) {
     /// \todo implement unified error/warning handling GUI and CLI
-    if (QucsMain)
+    if (QucsMain != nullptr)
       QMessageBox::critical(0, QObject::tr("Error"),
                  QObject::tr("Cannot load document: ")+DocName);
     else
@@ -1509,7 +1509,7 @@ bool Schematic::throughAllComps(QTextStream *stream, int& countInit,
           delete d;
           /// \todo implement error/warning message dispatcher for GUI and CLI modes.
           QString message = QObject::tr("ERROR: Cannot load subcircuit \"%1\".").arg(s);
-          if (QucsMain) // GUI is running
+          if (QucsMain != nullptr) // GUI is running
             ErrText->appendPlainText(message);
           else // command line
             qCritical() << "Schematic::throughAllComps" << message;


### PR DESCRIPTION
This PR fixes the following issues:

* Fixed crash when no simulator found on the first start #979 
* The comparison of `QucsMain` pointer to zero replaced by `nullptr`