### PR TITLE
Fix missing text in schematic after upgrading to Qt-6.8.0

### DIFF
--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -252,7 +252,7 @@ void Component::paint(QPainter *p) {
     QRect text_br{tx, ty, 0, 0};
 
     if (showName) {
-        p->drawText(tx, ty, 0, 0, Qt::TextDontClip, Name, &text_br);
+        p->drawText(tx, ty, 1, 1, Qt::TextDontClip, Name, &text_br);
     }
 
     for (auto *prop : Props) {

--- a/qucs/components/simulation.cpp
+++ b/qucs/components/simulation.cpp
@@ -119,7 +119,7 @@ void SimulationComponent::drawSymbol(QPainter *p)
     p->setPen(pen());
     p->setFont(label_font);
     QRect label_bounds;
-    p->drawText(0, 0, 0, 0, Qt::TextDontClip, label_text, &label_bounds);
+    p->drawText(0, 0, 1, 1, Qt::TextDontClip, label_text, &label_bounds);
 
     // Simulation component look like an isometric box
     // or a brick, with a label on its top side, being

--- a/qucs/diagrams/marker.cpp
+++ b/qucs/diagrams/marker.cpp
@@ -425,7 +425,7 @@ void Marker::paint(QPainter* painter) {
   }
 
   painter->setPen(QPen(Qt::black, 1));
-  painter->drawText(x1, y1, 0, 0, Qt::TextDontClip, Text);
+  painter->drawText(x1, y1, 1, 1, Qt::TextDontClip, Text);
 
   painter->setPen(QPen(Qt::darkMagenta, 0));
   painter->drawRect(text_box);

--- a/qucs/diagrams/tabdiagram.cpp
+++ b/qucs/diagrams/tabdiagram.cpp
@@ -110,7 +110,7 @@ void TabDiagram::paintDiagram(QPainter *painter) {
 
   painter->setPen(Qt::black);
   for (Text *pt : Texts) {
-    painter->drawText(pt->x, -pt->y, 0, 0, Qt::TextDontClip, pt->s);
+    painter->drawText(pt->x, -pt->y, 1, 1, Qt::TextDontClip, pt->s);
   }
 
   if (isSelected) {

--- a/qucs/diagrams/timingdiagram.cpp
+++ b/qucs/diagrams/timingdiagram.cpp
@@ -62,7 +62,7 @@ void TimingDiagram::paintDiagram(QPainter *painter) {
   painter->setPen(Qt::black);
 
   for (Text *pt : Texts) {
-    painter->drawText(pt->x, -pt->y, 0, 0, Qt::TextDontClip, pt->s);
+    painter->drawText(pt->x, -pt->y, 1, 1, Qt::TextDontClip, pt->s);
   }
 
   if (y1 > 0) {  // paint scroll bar ?

--- a/qucs/element.cpp
+++ b/qucs/element.cpp
@@ -100,7 +100,7 @@ double Text::angle() const {
 // x and y are relative to component's x and y
 void Property::paint(int x, int y, QPainter* p)
 {
-  p->drawText(x, y, 0, 0, Qt::TextDontClip, Name + "=" + Value, &br);
+  p->drawText(x, y, 1, 1, Qt::TextDontClip, Name + "=" + Value, &br);
 }
 
 Element::Element()

--- a/qucs/misc.cpp
+++ b/qucs/misc.cpp
@@ -791,7 +791,7 @@ void misc::draw_richtext(QPainter* painter, int x, int y, const QString &text, Q
       QRect fragment_br;
       painter->drawText(
         current_text_x, current_text_y + (is_sub ? subscript_offset : superscript_offset),
-        0, 0,
+        1, 1,
         Qt::TextDontClip,
         text.mid(i, len ? len : 1),
         &fragment_br);
@@ -811,7 +811,7 @@ void misc::draw_richtext(QPainter* painter, int x, int y, const QString &text, Q
 
       QRect fragment_br;
       painter->drawText(
-        current_text_x, current_text_y, 0, 0,
+        current_text_x, current_text_y, 1, 1,
         Qt::TextDontClip,
         text.mid(i, len),
         &fragment_br);

--- a/qucs/paintings/id_text.cpp
+++ b/qucs/paintings/id_text.cpp
@@ -42,18 +42,18 @@ void ID_Text::paint(QPainter* painter) {
   painter->setPen(QPen(Qt::black,1));
 
   QRect r;
-  painter->drawText(QRect(0, 0, 0, 0), Qt::TextDontClip, Prefix, &r);
+  painter->drawText(QRect(0, 0, 1, 1), Qt::TextDontClip, Prefix, &r);
   x2 = r.width();
   y2 = r.height();
 
-  painter->drawText(QRect(0, y2, 0, 0), Qt::TextDontClip, "File=name", &r);
+  painter->drawText(QRect(0, y2, 1, 1), Qt::TextDontClip, "File=name", &r);
   x2 = std::max(x2, r.width());
   y2 += r.height();
 
   QList<SubParameter *>::const_iterator it;
   for(it = Parameter.constBegin(); it != Parameter.constEnd(); it++) {
     if((*it)->display) {
-      painter->drawText(QRect(0, y2, 0, 0), Qt::TextDontClip, (*it)->Name, &r);
+      painter->drawText(QRect(0, y2, 1, 1), Qt::TextDontClip, (*it)->Name, &r);
       x2 = std::max(x2, r.width());
       y2 += r.height();
     }

--- a/qucs/paintings/portsymbol.cpp
+++ b/qucs/paintings/portsymbol.cpp
@@ -88,7 +88,7 @@ void PortSymbol::paint(QPainter *painter) {
     }
 
     painter->setPen(Qt::black);
-    painter->drawText(0, 0, 0, 0, Qt::TextDontClip, nameStr.isEmpty() ? numberStr : nameStr);
+    painter->drawText(0, 0, 1, 1, Qt::TextDontClip, nameStr.isEmpty() ? numberStr : nameStr);
   }
   painter->restore();
 

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -386,8 +386,8 @@ void Schematic::paintFrame(QPainter* painter) {
 
         auto cn = QString::number(column_number);
         auto tx = x - h_step / 2 + 5;
-        painter->drawText(tx, 3, 0, 0, Qt::TextDontClip, cn);
-        painter->drawText(tx, frame_height - frame_margin + 3, 0, 0, Qt::TextDontClip, cn);
+        painter->drawText(tx, 3, 1, 1, Qt::TextDontClip, cn);
+        painter->drawText(tx, frame_height - frame_margin + 3, 1, 1, Qt::TextDontClip, cn);
 
 	column_number++;
       }
@@ -421,15 +421,15 @@ void Schematic::paintFrame(QPainter* painter) {
     const double z = 200.0;
     y1_ -= painter->fontMetrics().lineSpacing() + d;
     painter->drawLine(x1_, y1_, x2_, y1_);
-    painter->drawText(x1_ + d, y1_ + (d >> 1), 0, 0, Qt::TextDontClip, Frame_Text2);
+    painter->drawText(x1_ + d, y1_ + (d >> 1), 1, 1, Qt::TextDontClip, Frame_Text2);
     painter->drawLine(x1_ + z, y1_, x1_ + z, y1_ + painter->fontMetrics().lineSpacing() + d);
-    painter->drawText(x1_ + d + z, y1_ + (d >> 1), 0, 0, Qt::TextDontClip, Frame_Text3);
+    painter->drawText(x1_ + d + z, y1_ + (d >> 1), 1, 1, Qt::TextDontClip, Frame_Text3);
     y1_ -= painter->fontMetrics().lineSpacing() + d;
     painter->drawLine(x1_, y1_, x2_, y1_);
-    painter->drawText(x1_ + d, y1_ + (d >> 1), 0, 0, Qt::TextDontClip, Frame_Text1);
+    painter->drawText(x1_ + d, y1_ + (d >> 1), 1, 1, Qt::TextDontClip, Frame_Text1);
     y1_ -= (Frame_Text0.count('\n') + 1) * painter->fontMetrics().lineSpacing() + d;
     painter->drawRect(x2_, y2_, x1_ - x2_ - 1, y1_ - y2_ - 1);
-    painter->drawText(x1_ + d, y1_ + (d >> 1), 0, 0, Qt::TextDontClip, Frame_Text0);
+    painter->drawText(x1_ + d, y1_ + (d >> 1), 1, 1, Qt::TextDontClip, Frame_Text0);
 
     painter->restore();
 }

--- a/qucs/symbolwidget.cpp
+++ b/qucs/symbolwidget.cpp
@@ -123,14 +123,14 @@ void SymbolWidget::mouseMoveEvent(QMouseEvent* event)
 void SymbolWidget::paintEvent(QPaintEvent*)
 {
   QPainter Painter(this);
-  Painter.drawText(2, 2, 0, 0, Qt::AlignLeft | Qt::TextDontClip, PaintText);
+  Painter.drawText(2, 2, 1, 1, Qt::AlignLeft | Qt::TextDontClip, PaintText);
 
   QFontMetrics metrics(QucsSettings.font, 0);
-  Painter.drawText(2, metrics.height(), 0, 0, Qt::AlignLeft | Qt::TextDontClip, Warning);
+  Painter.drawText(2, metrics.height(), 1, 1, Qt::AlignLeft | Qt::TextDontClip, Warning);
 
   int dx = (x2-x1)/2 + TextWidth - DragNDropWidth/2;
   if(dx < 2)  dx = 2;
-  Painter.drawText(dx, y2-y1+2, 0, 0, Qt::AlignLeft | Qt::TextDontClip, DragNDropText);
+  Painter.drawText(dx, y2-y1+2, 1, 1, Qt::AlignLeft | Qt::TextDontClip, DragNDropText);
 
   // paint all lines
   for(int i=0; i<Lines.size(); i++) {
@@ -171,7 +171,7 @@ void SymbolWidget::paintEvent(QPaintEvent*)
     Font.setPointSizeF(pt->Size);
     Painter.setFont(Font);
     Painter.setPen(pt->Color);
-    Painter.drawText(cx+pt->x, cy+pt->y, 0, 0, Qt::TextDontClip, pt->s);
+    Painter.drawText(cx+pt->x, cy+pt->y, 1, 1, Qt::TextDontClip, pt->s);
   }
 }
 

--- a/qucs/wirelabel.cpp
+++ b/qucs/wirelabel.cpp
@@ -116,7 +116,7 @@ void WireLabel::paint(QPainter *p) const {
   });
 
   QRect text_br;
-  p->drawText(x1, y1, 0, 0, Qt::TextDontClip, Name, &text_br);
+  p->drawText(x1, y1, 1, 1, Qt::TextDontClip, Name, &text_br);
 
   bool right = text_br.right() < cx;
   bool bottom = text_br.bottom() < cy;


### PR DESCRIPTION
After upgrading to Qt-6.8 calling [QPainter::drawText](https://doc.qt.io/qt-6/qpainter.html#drawText-6) with zero width, zero height and Qt::TextDontClip flag doesn't draw any text.
![image](https://github.com/user-attachments/assets/a1d047ca-a117-452b-8564-bce3ed748301)
Setting width and height to 1 fixes it.
![image](https://github.com/user-attachments/assets/074e2f21-eb6b-4308-b814-798c6918a508)
