### PR TITLE
Fix diode symbol setting

### DIFF
--- a/qucs/components/diode.cpp
+++ b/qucs/components/diode.cpp
@@ -174,12 +174,14 @@ Element* Diode::info(QString& Name, char* &BitmapFile, bool getNewOne)
 // -------------------------------------------------------
 void Diode::createSymbol()
 {
-  if(Props.back()->Value.at(0) == 'V') {
+  auto pp = getProperty("Symbol");
+  if (pp == nullptr) return;
+  if(pp->Value.at(0) == 'V') {
     Lines.append(new qucs::Line(-30,  0, -9,  0,QPen(Qt::darkBlue,2)));
     Lines.append(new qucs::Line( -6,  0, 30,  0,QPen(Qt::darkBlue,2)));
     Lines.append(new qucs::Line( -9, -9, -9,  9,QPen(Qt::darkBlue,2)));
   }
-  else if(Props.back()->Value.at(0) == 'U') {
+  else if(pp->Value.at(0) == 'U') {
     Lines.append(new qucs::Line(-30,  0, -6,  0,QPen(Qt::darkBlue,2)));
     Lines.append(new qucs::Line(  6,  0, 30,  0,QPen(Qt::darkBlue,2)));
   }
@@ -191,11 +193,11 @@ void Diode::createSymbol()
   Lines.append(new qucs::Line( -6,  0,  6, -9,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line( -6,  0,  6,  9,QPen(Qt::darkBlue,2)));
 
-  if(Props.back()->Value.at(0) == 'S') {
+  if(pp->Value.at(0) == 'S') {
     Lines.append(new qucs::Line( -6, -9,-12,-12,QPen(Qt::darkBlue,2)));
     Lines.append(new qucs::Line( -6,  9,  0, 12,QPen(Qt::darkBlue,2)));
   }
-  else if(Props.back()->Value.at(0) == 'Z') {
+  else if(pp->Value.at(0) == 'Z') {
     Lines.append(new qucs::Line( -6, 9, -1, 9,QPen(Qt::darkBlue,2)));
   }
 


### PR DESCRIPTION
Fixed diode symbol setting. This has appeared after `UseGlobTemp` property introduction. The `Symbol` is not the last property anymore. 