### PR TITLE
Add SPICE entry for VCresitor

### DIFF
--- a/qucs/components/vcresistor.cpp
+++ b/qucs/components/vcresistor.cpp
@@ -16,13 +16,14 @@
  ***************************************************************************/
 
 #include "vcresistor.h"
+#include "node.h"
 #include "extsimkernels/spicecompat.h"
 
 
 vcresistor::vcresistor()
 {
   Description = QObject::tr("voltage controlled resistor");
-  Simulator = spicecompat::simQucsator;
+  Simulator = spicecompat::simAll;
 
   // The resistor shape
   Lines.append(new qucs::Line(5, 18, 5, -18, QPen(Qt::darkBlue,2)));
@@ -67,6 +68,7 @@ vcresistor::vcresistor()
   ty = y2+4;
   Model = "vcresistor";
   Name  = "VCR";
+  SpiceModel = "R";
 
   Props.append(new Property("gain", "1", true,
 		QObject::tr("resistance gain")));
@@ -88,5 +90,35 @@ Element* vcresistor::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
   if(getNewOne)  return new vcresistor();
   return 0;
+}
+
+QString vcresistor::netlist()
+{
+  QString s;
+  QString EDD_Name = "EDD" + Name;
+  QString in1 = Ports.at(0)->Connection->Name;
+  QString in2 = Ports.at(1)->Connection->Name;
+  QString out1 = Ports.at(2)->Connection->Name;
+  QString out2 = Ports.at(3)->Connection->Name;
+  QString gain = getProperty("gain")->Value;
+  s = QString("EDD:%1 %2 %3 %4 %5 I1=\"%1.I1\" Q1=\"%1.Q1\" I2=\"%1.I2\" Q2=\"%1.Q2\"\n").arg(EDD_Name,in1,in2,out1,out2);
+  s += QString("Eqn:Eqn%1I1 %1.I1=\"0\" Export=\"no\"\n").arg(EDD_Name);
+  s += QString("Eqn:Eqn%1Q1 %1.Q1=\"0\" Export=\"no\"\n").arg(EDD_Name);
+  s += QString("Eqn:Eqn%1I2 %1.I2=\"V2/(1e-20+abs(V1*(%2)))\" Export=\"no\"\n").arg(EDD_Name,gain);
+  s += QString("Eqn:Eqn%1Q2 %1.Q2=\"0\" Export=\"no\"\n").arg(EDD_Name);
+  return s;
+}
+
+QString vcresistor::spice_netlist(bool isXyce)
+{
+  Q_UNUSED(isXyce);
+  QString s;
+  QString gain = spicecompat::normalize_value(getProperty("gain")->Value);
+  QString in1 = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
+  QString in2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
+  QString out1 = spicecompat::normalize_node_name(Ports.at(2)->Connection->Name);
+  QString out2 = spicecompat::normalize_node_name(Ports.at(3)->Connection->Name);
+  s = QString("R%1 %2 %3 R='1e-15+abs(V(%4,%5)*(%6))'\n").arg(Name, out1, out2, in1, in2, gain);
+  return s;
 }
 

--- a/qucs/components/vcresistor.h
+++ b/qucs/components/vcresistor.h
@@ -27,6 +27,9 @@ public:
   ~vcresistor();
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
+protected:
+  QString netlist();
+  QString spice_netlist(bool isXyce);
 };
 
 #endif

--- a/qucs/module.cpp
+++ b/qucs/module.cpp
@@ -422,6 +422,7 @@ void Module::registerModules (void) {
 
   REGISTER_NONLINEAR_1 (OpAmp);
   REGISTER_NONLINEAR_1 (EqnDefined);
+  REGISTER_NONLINEAR_1 (vcresistor);
 
   //if (QucsSettings.DefaultSimulator == spicecompat::simQucsator) {
       REGISTER_NONLINEAR_1 (Diac);
@@ -455,7 +456,6 @@ void Module::registerModules (void) {
       REGISTER_VERILOGA_1 (photodiode);
       REGISTER_VERILOGA_1 (phototransistor);
       REGISTER_VERILOGA_1 (nigbt);
-      REGISTER_VERILOGA_1 (vcresistor);
   //}
 
   // digital components


### PR DESCRIPTION
This PR fixes #959

* Added SPICE entry for VCRES. This device is represented by behavioral resistor
* Qucsator device made SPICE-independent and represented by equivalent EDD
* VCRES device moved from *verilog-a* category to *nonlinear devices*

![image](https://github.com/user-attachments/assets/651a71a1-e3fc-4d0a-808d-05039d020724)
![image](https://github.com/user-attachments/assets/9df72ff7-18de-4ba0-87c2-bda164d7fb82)

