### PR TITLE
Apply path conversion only for saved schematic or schematic in projects

### DIFF
--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -1088,12 +1088,20 @@ void ComponentDialog::slotBrowseFile()
     // snip path if file in current directory
     QFileInfo file(s);
     lastDir = file.absolutePath();
-    currDir = schematicFileInfo.canonicalPath();
-    if ( file.canonicalFilePath().startsWith(currDir) ) {
-      s = QDir(currDir).relativeFilePath(s);
-    } else if(QucsSettings.QucsWorkDir.exists(file.fileName()) &&
-        QucsSettings.QucsWorkDir.absolutePath() == file.absolutePath()) {
-      s = file.fileName();
+    if (!schematicFileName.isEmpty()) {
+      currDir = schematicFileInfo.canonicalPath();
+    }
+
+    if (!(schematicFileName.isEmpty() &&
+          QucsMain->ProjName.isEmpty())) {
+      // unsaved schematic outside project; only absolute file name
+      // the schematic could be saved elsewhere and working directory may be changed
+      if ( file.canonicalFilePath().startsWith(currDir) ) {
+        s = QDir(currDir).relativeFilePath(s);
+      } else if(QucsSettings.QucsWorkDir.exists(file.fileName()) &&
+                 QucsSettings.QucsWorkDir.absolutePath() == file.absolutePath()) {
+        s = file.fileName();
+      }
     }
     edit->setText(s);
     int row = prop->currentRow();

--- a/qucs/components/spicedialog.cpp
+++ b/qucs/components/spicedialog.cpp
@@ -316,13 +316,23 @@ void SpiceDialog::slotButtBrowse()
     // snip path if file in current directory
     QFileInfo file(s);
     lastDir = file.absolutePath();
-    currDir = schematicFileInfo.canonicalPath();
-    if ( file.canonicalFilePath().startsWith(currDir) ) {
-      s = QDir(currDir).relativeFilePath(s);
-    } else if(QucsSettings.QucsWorkDir.exists(file.fileName()) &&
-        QucsSettings.QucsWorkDir.absolutePath() == file.absolutePath()) {
-      s = file.fileName();
+
+    if (!schematicFileName.isEmpty()) {
+      currDir = schematicFileInfo.canonicalPath();
     }
+
+    if (!(schematicFileName.isEmpty() &&
+          QucsMain->ProjName.isEmpty())) {
+      // unsaved schematic outside project; only absolute file name
+      // the schematic could be saved elsewhere and working directory may be changed
+      if ( file.canonicalFilePath().startsWith(currDir) ) {
+        s = QDir(currDir).relativeFilePath(s);
+      } else if(QucsSettings.QucsWorkDir.exists(file.fileName()) &&
+                 QucsSettings.QucsWorkDir.absolutePath() == file.absolutePath()) {
+        s = file.fileName();
+      }
+    }
+
     FileEdit->setText(s);
     Comp->Props.at(1)->Value = "";
     loadSpiceNetList(s);


### PR DESCRIPTION
This PR fixes #951. The path conversion is applied only for saved schematics or schematics that belong to some projects. If schematic is not saved only full path may be substituted, because the schematic could be moved elsewhere. 

The better solution would be to automatically convert relative paths when schematic is saved. May be implemented only after #974 because there is no reliable way to distinguish file and non-file properties. 