### PR TITLE
Schottly diode symbol fix and update library tree after creating new library

### DIFF
--- a/qucs/components/diode.cpp
+++ b/qucs/components/diode.cpp
@@ -192,8 +192,12 @@ void Diode::createSymbol()
   Lines.append(new qucs::Line( -6,  0,  6,  9,QPen(Qt::darkBlue,2)));
 
   if(pp->Value.at(0) == 'S') {
-    Lines.append(new qucs::Line( -6, -9,-12,-12,QPen(Qt::darkBlue,2)));
-    Lines.append(new qucs::Line( -6,  9,  0, 12,QPen(Qt::darkBlue,2)));
+    //Lines.append(new qucs::Line( -6, -9,-12,-12,QPen(Qt::darkBlue,2)));
+    //Lines.append(new qucs::Line( -6,  9,  0, 12,QPen(Qt::darkBlue,2)));
+    Lines.append(new qucs::Line( -6, -9, -10, -9,QPen(Qt::darkBlue,2)));
+    Lines.append(new qucs::Line( -6, 9, -2, 9,QPen(Qt::darkBlue,2)));
+    Lines.append(new qucs::Line( -10, -9, -10, -7,QPen(Qt::darkBlue,2)));
+    Lines.append(new qucs::Line( -2, 9, -2, 7,QPen(Qt::darkBlue,2)));
   }
   else if(pp->Value.at(0) == 'Z') {
     Lines.append(new qucs::Line( -6, 9, -1, 9,QPen(Qt::darkBlue,2)));

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -1310,7 +1310,10 @@ void QucsApp::slotCreateLib()
 
   LibraryDialog *d = new LibraryDialog(this);
   d->fillSchematicList(Content->exportSchematic());
-  d->exec();
+  auto r = d->exec();
+  if (r != QDialog::Accepted) {
+    fillLibrariesTreeView();
+  }
 }
 
 // -----------------------------------------------------------


### PR DESCRIPTION
This PR fixes the following issues:

* Update library tree after new user library added from *Project->Create library* #1010 
* Fix Schottky diode symbol. It uses IEC Schottky now #1024