### PR TITLE
Fixed context menu for tab diagram and ASCO execution error

### DIFF
--- a/qucs/dialogs/simmessage.cpp
+++ b/qucs/dialogs/simmessage.cpp
@@ -627,7 +627,6 @@ void SimMessage::startSimulator()
     QFile::link(target, tmp_qucsator);
 
     // Modify environment variable
-    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     QString sep = ":";
     env.insert("PATH", env.value("PATH") + sep + tmpdir);
 #endif

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -2157,7 +2157,8 @@ void MouseActions::editElement(Schematic *Doc, QMouseEvent *Event)
 
     case isDiagram:
         dia = (Diagram *) focusElement;
-        if (dia->Name.at(0) == 'T') { // don't open dialog on scrollbar
+        if (dia->Name.at(0) == 'T' // check only on double click
+            && Event->type() == QMouseEvent::MouseButtonDblClick) { // don't open dialog on scrollbar
             if (dia->Name == "Time") {
                 if (dia->cy < int(fY)) {
                     if (((TimingDiagram *) focusElement)->scroll(MAx1))


### PR DESCRIPTION
This PR fixes the following bugs:

* Fixes #1033. The problem was the context menu execution on TabDiagram was not allowed. 
* Fixes ASCO execution error on Linux reported by mailing list https://sourceforge.net/p/qucs/mailman/message/58834975/