### PR TITLE
refactor: replace non-empty QString constructors with QStringLiteral()

### DIFF
--- a/qucs-activefilter/filter.cpp
+++ b/qucs-activefilter/filter.cpp
@@ -235,7 +235,7 @@ void Filter::calcFirstOrder()
 
 void Filter::createPartList(QStringList &lst) {
     lst << QObject::tr("Part list");
-    lst << QString("%1%2%3%4%5%6%7%8%9").arg("Stage#",6)
+    lst << QStringLiteral("%1%2%3%4%5%6%7%8%9").arg("Stage#",6)
            .arg("C1",12).arg("C2",12).arg("R1(kOhm)",10).arg("R2(kOhm)",10).arg("R3(kOhm)",10).arg("R4(kOhm)",10)
            .arg("R5(kOhm)",10).arg("R6(kOhm)",10);
 
@@ -244,7 +244,7 @@ void Filter::createPartList(QStringList &lst) {
         double C1 = autoscaleCapacitor(stage.C1, suff1);
         double C2 = autoscaleCapacitor(stage.C2, suff2);
 
-        lst << QString("%1%2%3%4%5%6%7%8%9%10%11")
+        lst << QStringLiteral("%1%2%3%4%5%6%7%8%9%10%11")
                 .arg(stage.N, 6)
                 .arg(C1, 10, 'f', 3)
                 .arg(suff1)
@@ -283,13 +283,13 @@ void Filter::createFirstOrderComponentsHPF(QString &s,RC_elements stage,int dx)
 {
     QString suf;
     double  C1 = autoscaleCapacitor(stage.C1,suf);
-    s += QString("<OpAmp OP%1 1 %2 160 -26 42 0 0 \"1e6\" 1 \"15 V\" 0>\n").arg(Nopamp+1).arg(270+dx);
-    s += QString("<GND * 1 %1 270 0 0 0 0>\n").arg(170+dx);
-    s += QString("<GND * 1 %1 370 0 0 0 0>\n").arg(220+dx);
-    s += QString("<R R%1 1 %2 340 15 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(Nr+2).arg(220+dx).arg(stage.R2,0,'f',3);
-    s += QString("<R R%1 1 %2 240 -75 -26 1 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(Nr+1).arg(170+dx).arg(stage.R1,0,'f',3);
-    s += QString("<R R%1 1 %2 260 -26 15 1 2 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(Nr+3).arg(310+dx).arg(stage.R3,0,'f',3);
-    s += QString("<C C%1 1 %2 190 -26 -45 1 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(Nc+1).arg(100+dx).arg(C1,0,'f',3).arg(suf);
+    s += QStringLiteral("<OpAmp OP%1 1 %2 160 -26 42 0 0 \"1e6\" 1 \"15 V\" 0>\n").arg(Nopamp+1).arg(270+dx);
+    s += QStringLiteral("<GND * 1 %1 270 0 0 0 0>\n").arg(170+dx);
+    s += QStringLiteral("<GND * 1 %1 370 0 0 0 0>\n").arg(220+dx);
+    s += QStringLiteral("<R R%1 1 %2 340 15 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(Nr+2).arg(220+dx).arg(stage.R2,0,'f',3);
+    s += QStringLiteral("<R R%1 1 %2 240 -75 -26 1 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(Nr+1).arg(170+dx).arg(stage.R1,0,'f',3);
+    s += QStringLiteral("<R R%1 1 %2 260 -26 15 1 2 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(Nr+3).arg(310+dx).arg(stage.R3,0,'f',3);
+    s += QStringLiteral("<C C%1 1 %2 190 -26 -45 1 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(Nc+1).arg(100+dx).arg(C1,0,'f',3).arg(suf);
 }
 
 
@@ -297,32 +297,32 @@ void Filter::createFirstOrderComponentsLPF(QString &s,RC_elements stage,int dx)
 {
     QString suf;
     double  C1 = autoscaleCapacitor(stage.C1,suf);
-    s += QString("<OpAmp OP%1 1 %2 160 -26 42 0 0 \"1e6\" 1 \"15 V\" 0>\n").arg(Nopamp+1).arg(270+dx);
-    s += QString("<GND * 1 %1 270 0 0 0 0>\n").arg(170+dx);
-    s += QString("<GND * 1 %1 370 0 0 0 0>\n").arg(220+dx);
-    s += QString("<R R%1 1 %2 340 15 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(Nr+2).arg(220+dx).arg(stage.R2,0,'f',3);
-    s += QString("<R R%1 1 %2 190 -75 -52 1 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(Nr+1).arg(100+dx).arg(stage.R1,0,'f',3);
-    s += QString("<R R%1 1 %2 260 -26 15 1 2 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(Nr+3).arg(310+dx).arg(stage.R3,0,'f',3);
-    s += QString("<C C%1 1 %2 240 26 -45 1 1 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(Nc+1).arg(170+dx).arg(C1,0,'f',3).arg(suf);
+    s += QStringLiteral("<OpAmp OP%1 1 %2 160 -26 42 0 0 \"1e6\" 1 \"15 V\" 0>\n").arg(Nopamp+1).arg(270+dx);
+    s += QStringLiteral("<GND * 1 %1 270 0 0 0 0>\n").arg(170+dx);
+    s += QStringLiteral("<GND * 1 %1 370 0 0 0 0>\n").arg(220+dx);
+    s += QStringLiteral("<R R%1 1 %2 340 15 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(Nr+2).arg(220+dx).arg(stage.R2,0,'f',3);
+    s += QStringLiteral("<R R%1 1 %2 190 -75 -52 1 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(Nr+1).arg(100+dx).arg(stage.R1,0,'f',3);
+    s += QStringLiteral("<R R%1 1 %2 260 -26 15 1 2 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(Nr+3).arg(310+dx).arg(stage.R3,0,'f',3);
+    s += QStringLiteral("<C C%1 1 %2 240 26 -45 1 1 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(Nc+1).arg(170+dx).arg(C1,0,'f',3).arg(suf);
 }
 
 void Filter::createFirstOrderWires(QString &s, int dx, int y)
 {
-    s += QString("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(70+dx);
-    s += QString("<%1 190 %2 %3 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(dx-20).arg(y);
-    s += QString("<%1 %2 %3 %4 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(y).arg(dx-50).arg(y);
+    s += QStringLiteral("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(70+dx);
+    s += QStringLiteral("<%1 190 %2 %3 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(dx-20).arg(y);
+    s += QStringLiteral("<%1 %2 %3 %4 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(y).arg(dx-50).arg(y);
 
-    s += QString("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(130+dx).arg(170+dx);
-    s += QString("<%1 160 %2 160 \"out\" %3 130 39 \"\">\n").arg(310+dx).arg(360+dx).arg(380+dx);
-    s += QString("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(340+dx).arg(360+dx);
-    s += QString("<%1 160 %2 260 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(360+dx);
-    s += QString("<%1 190 %2 210 \"\" 0 0 0 \"\">\n").arg(170+dx).arg(170+dx);
-    s += QString("<%1 140 %2 190 \"\" 0 0 0 \"\">\n").arg(170+dx).arg(170+dx);
-    s += QString("<%1 140 %2 140 \"\" 0 0 0 \"\">\n").arg(170+dx).arg(240+dx);
-    s += QString("<%1 180 %2 260 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(220+dx);
-    s += QString("<%1 180 %2 180 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(240+dx);
-    s += QString("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(280+dx);
-    s += QString("<%1 260 %2 310 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(220+dx);
+    s += QStringLiteral("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(130+dx).arg(170+dx);
+    s += QStringLiteral("<%1 160 %2 160 \"out\" %3 130 39 \"\">\n").arg(310+dx).arg(360+dx).arg(380+dx);
+    s += QStringLiteral("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(340+dx).arg(360+dx);
+    s += QStringLiteral("<%1 160 %2 260 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(360+dx);
+    s += QStringLiteral("<%1 190 %2 210 \"\" 0 0 0 \"\">\n").arg(170+dx).arg(170+dx);
+    s += QStringLiteral("<%1 140 %2 190 \"\" 0 0 0 \"\">\n").arg(170+dx).arg(170+dx);
+    s += QStringLiteral("<%1 140 %2 140 \"\" 0 0 0 \"\">\n").arg(170+dx).arg(240+dx);
+    s += QStringLiteral("<%1 180 %2 260 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(220+dx);
+    s += QStringLiteral("<%1 180 %2 180 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(240+dx);
+    s += QStringLiteral("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(280+dx);
+    s += QStringLiteral("<%1 260 %2 310 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(220+dx);
 }
 
 

--- a/qucs-activefilter/main.cpp
+++ b/qucs-activefilter/main.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
     QString Lang = QucsSettings.Language;
     if(Lang.isEmpty())
       Lang = QString(QLocale::system().name());
-    tor.load( QString("qucs_") + Lang, LangDir);
+    tor.load( QStringLiteral("qucs_") + Lang, LangDir);
     a.installTranslator( &tor );
 
     QucsActiveFilter *w = new QucsActiveFilter();

--- a/qucs-activefilter/mfbfilter.cpp
+++ b/qucs-activefilter/mfbfilter.cpp
@@ -59,24 +59,24 @@ void MFBfilter::createLowPassSchematic(QString &s)
     s += PACKAGE_VERSION;
     s += ">\n";
     s += "<Components>\n";
-    s += QString("<.AC AC1 1 300 440 0 61 0 0 \"lin\" 1 \"1 Hz\" 1 \"%1 kHz\" 1 \"501\" 1 \"no\" 0>\n").arg((10.0*Fc)/1000.0);
+    s += QStringLiteral("<.AC AC1 1 300 440 0 61 0 0 \"lin\" 1 \"1 Hz\" 1 \"%1 kHz\" 1 \"501\" 1 \"no\" 0>\n").arg((10.0*Fc)/1000.0);
     s += "<.DC DC1 1 60 440 0 61 0 0 \"26.85\" 0 \"0.001\" 0 \"1 pA\" 0 \"1 uV\" 0 \"no\" 0 \"150\" 0 \"no\" 0 \"none\" 0 \"CroutLU\" 0>\n";
     s += "<Eqn Eqn1 1 610 450 -30 14 0 0 \"K=dB(out.v/in.v)\" 1 \"yes\" 0>\n";
-    s += QString("<Vac V1 1 %1 330 18 -26 0 1 \"1 V\" 1 \"1 kHz\" 0 \"0\" 0 \"0\" 0>\n").arg(70+dx);
-    s += QString("<GND * 1 %1 360 0 0 0 0>\n").arg(70+dx);
+    s += QStringLiteral("<Vac V1 1 %1 330 18 -26 0 1 \"1 V\" 1 \"1 kHz\" 0 \"0\" 0 \"0\" 0>\n").arg(70+dx);
+    s += QStringLiteral("<GND * 1 %1 360 0 0 0 0>\n").arg(70+dx);
     for (int i=1; i<=N2ord; i++) {
         stage = Sections.at(i-1);
         QString suffix1, suffix2;
         double  C1 = autoscaleCapacitor(stage.C1,suffix1);
         double  C2 = autoscaleCapacitor(stage.C2,suffix2);
-        s += QString("<GND * 1 %1 380 0 0 0 0>\n").arg(200+dx);
-        s += QString("<GND * 1 %1 350 0 0 0 0>\n").arg(360+dx);
-        s += QString("<OpAmp OP%1 1 %2 270 -26 -70 1 0 \"1e6\" 1 \"15 V\" 0>\n").arg(1+(i-1)*Nop1).arg(390+dx);
-        s += QString("<C C%1 1 %2 350 17 -26 0 1 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(2+(i-1)*Nc1).arg(200+dx).arg(C2,0,'f',3).arg(suffix2);
-        s += QString("<C C%1 1 %2 180 17 -26 0 1 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(1+(i-1)*Nc1).arg(320+dx).arg(C1,0,'f',3).arg(suffix1);
-        s += QString("<R R%1 1 %2 180 15 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(1+(i-1)*Nr1).arg(200+dx).arg(stage.R1,0,'f',3);
-        s += QString("<R R%1 1 %2 250 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(2+(i-1)*Nr1).arg(150+dx).arg(stage.R2,0,'f',3);
-        s += QString("<R R%1 1 %2 250 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(3+(i-1)*Nr1).arg(250+dx).arg(stage.R3,0,'f',3);
+        s += QStringLiteral("<GND * 1 %1 380 0 0 0 0>\n").arg(200+dx);
+        s += QStringLiteral("<GND * 1 %1 350 0 0 0 0>\n").arg(360+dx);
+        s += QStringLiteral("<OpAmp OP%1 1 %2 270 -26 -70 1 0 \"1e6\" 1 \"15 V\" 0>\n").arg(1+(i-1)*Nop1).arg(390+dx);
+        s += QStringLiteral("<C C%1 1 %2 350 17 -26 0 1 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(2+(i-1)*Nc1).arg(200+dx).arg(C2,0,'f',3).arg(suffix2);
+        s += QStringLiteral("<C C%1 1 %2 180 17 -26 0 1 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(1+(i-1)*Nc1).arg(320+dx).arg(C1,0,'f',3).arg(suffix1);
+        s += QStringLiteral("<R R%1 1 %2 180 15 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(1+(i-1)*Nr1).arg(200+dx).arg(stage.R1,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 250 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(2+(i-1)*Nr1).arg(150+dx).arg(stage.R2,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 250 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(3+(i-1)*Nr1).arg(250+dx).arg(stage.R3,0,'f',3);
         dx += 510;
     }
 
@@ -91,26 +91,26 @@ void MFBfilter::createLowPassSchematic(QString &s)
     s += "<70 250 70 300 \"\" 0 0 0 \"\">\n";
     for (int i=1; i<=N2ord; i++) {
         if (i!=1) {
-            s += QString("<%1 250 %2 270 \"\" 0 0 0 \"\">\n").arg(120+dx).arg(120+dx);
-            s += QString("<%1 270 %2 270 \"\" 0 0 0 \"\">\n").arg(dx-40).arg(120+dx);
+            s += QStringLiteral("<%1 250 %2 270 \"\" 0 0 0 \"\">\n").arg(120+dx).arg(120+dx);
+            s += QStringLiteral("<%1 270 %2 270 \"\" 0 0 0 \"\">\n").arg(dx-40).arg(120+dx);
         }
-        s += QString("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(180+dx).arg(200+dx);
-        s += QString("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(220+dx);
-        s += QString("<%1 210 %2 250 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
-        s += QString("<%1 250 %2 320 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
-        s += QString("<%1 290 %2 350 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(360+dx);
-        s += QString("<%1 130 %2 150 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
-        s += QString("<%1 130 %2 130 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(320+dx);
-        s += QString("<%1 130 %2 150 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
-        s += QString("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(280+dx).arg(320+dx);
-        s += QString("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(360+dx);
-        s += QString("<%1 210 %2 250 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
-        s += QString("<%1 130 %2 130 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(470+dx);
-        s += QString("<%1 270 %2 270 \"\" 0 0 0 \"\">\n").arg(430+dx).arg(470+dx);
+        s += QStringLiteral("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(180+dx).arg(200+dx);
+        s += QStringLiteral("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(220+dx);
+        s += QStringLiteral("<%1 210 %2 250 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
+        s += QStringLiteral("<%1 250 %2 320 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
+        s += QStringLiteral("<%1 290 %2 350 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(360+dx);
+        s += QStringLiteral("<%1 130 %2 150 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
+        s += QStringLiteral("<%1 130 %2 130 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(320+dx);
+        s += QStringLiteral("<%1 130 %2 150 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
+        s += QStringLiteral("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(280+dx).arg(320+dx);
+        s += QStringLiteral("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(360+dx);
+        s += QStringLiteral("<%1 210 %2 250 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
+        s += QStringLiteral("<%1 130 %2 130 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(470+dx);
+        s += QStringLiteral("<%1 270 %2 270 \"\" 0 0 0 \"\">\n").arg(430+dx).arg(470+dx);
         if ((2*i)==order) {
-            s += QString("<%1 130 %2 270 \"out\" %3 170 70 \"\">\n").arg(470+dx).arg(470+dx).arg(500+dx);
+            s += QStringLiteral("<%1 130 %2 270 \"out\" %3 170 70 \"\">\n").arg(470+dx).arg(470+dx).arg(500+dx);
         } else {
-            s += QString("<%1 130 %2 270 \"\" 0 0 0 \"\">\n").arg(470+dx).arg(470+dx);
+            s += QStringLiteral("<%1 130 %2 270 \"\" 0 0 0 \"\">\n").arg(470+dx).arg(470+dx);
         }
         dx += 510;
     }
@@ -133,24 +133,24 @@ void MFBfilter::createHighPassSchematic(QString &s)
     s += PACKAGE_VERSION;
     s += ">\n";
     s += "<Components>\n";
-    s += QString("<.AC AC1 1 300 440 0 61 0 0 \"lin\" 1 \"1 Hz\" 1 \"%1 kHz\" 1 \"501\" 1 \"no\" 0>\n").arg((10.0*Fc)/1000.0);
+    s += QStringLiteral("<.AC AC1 1 300 440 0 61 0 0 \"lin\" 1 \"1 Hz\" 1 \"%1 kHz\" 1 \"501\" 1 \"no\" 0>\n").arg((10.0*Fc)/1000.0);
     s += "<.DC DC1 1 60 440 0 61 0 0 \"26.85\" 0 \"0.001\" 0 \"1 pA\" 0 \"1 uV\" 0 \"no\" 0 \"150\" 0 \"no\" 0 \"none\" 0 \"CroutLU\" 0>\n";
     s += "<Eqn Eqn1 1 610 450 -30 14 0 0 \"K=dB(out.v/in.v)\" 1 \"yes\" 0>\n";
-    s += QString("<Vac V1 1 %1 330 18 -26 0 1 \"1 V\" 1 \"1 kHz\" 0 \"0\" 0 \"0\" 0>\n").arg(70+dx);
-    s += QString("<GND * 1 %1 360 0 0 0 0>\n").arg(70+dx);
+    s += QStringLiteral("<Vac V1 1 %1 330 18 -26 0 1 \"1 V\" 1 \"1 kHz\" 0 \"0\" 0 \"0\" 0>\n").arg(70+dx);
+    s += QStringLiteral("<GND * 1 %1 360 0 0 0 0>\n").arg(70+dx);
     for (int i=1; i<=N2ord; i++) {
         stage = Sections.at(i-1);
         QString suffix1, suffix2;
         double  C1 = autoscaleCapacitor(stage.C1,suffix1);
         double  C2 = autoscaleCapacitor(stage.C2,suffix2);
-        s += QString("<GND * 1 %1 380 0 0 0 0>\n").arg(200+dx);
-        s += QString("<GND * 1 %1 350 0 0 0 0>\n").arg(360+dx);
-        s += QString("<OpAmp OP%1 1 %2 270 -26 -70 1 0 \"1e6\" 1 \"15 V\" 0>\n").arg(1+(i-1)*Nop1).arg(390+dx);
-        s += QString("<R R%1 1 %2 350 17 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(1+(i-1)*Nr1).arg(200+dx).arg(stage.R1,0,'f',3);
-        s += QString("<R R%1 1 %2 180 17 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(2+(i-1)*Nr1).arg(320+dx).arg(stage.R2,0,'f',3);
-        s += QString("<C C%1 1 %2 180 15 -26 0 1 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(1+(i-1)*Nc1).arg(200+dx).arg(C1,0,'f',3).arg(suffix1);
-        s += QString("<C C%1 1 %2 250 -26 15 0 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(2+(i-1)*Nc1).arg(150+dx).arg(C2,0,'f',3).arg(suffix2);
-        s += QString("<C C%1 1 %2 250 -26 15 0 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(3+(i-1)*Nc1).arg(250+dx).arg(C1,0,'f',3).arg(suffix1);
+        s += QStringLiteral("<GND * 1 %1 380 0 0 0 0>\n").arg(200+dx);
+        s += QStringLiteral("<GND * 1 %1 350 0 0 0 0>\n").arg(360+dx);
+        s += QStringLiteral("<OpAmp OP%1 1 %2 270 -26 -70 1 0 \"1e6\" 1 \"15 V\" 0>\n").arg(1+(i-1)*Nop1).arg(390+dx);
+        s += QStringLiteral("<R R%1 1 %2 350 17 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(1+(i-1)*Nr1).arg(200+dx).arg(stage.R1,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 180 17 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(2+(i-1)*Nr1).arg(320+dx).arg(stage.R2,0,'f',3);
+        s += QStringLiteral("<C C%1 1 %2 180 15 -26 0 1 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(1+(i-1)*Nc1).arg(200+dx).arg(C1,0,'f',3).arg(suffix1);
+        s += QStringLiteral("<C C%1 1 %2 250 -26 15 0 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(2+(i-1)*Nc1).arg(150+dx).arg(C2,0,'f',3).arg(suffix2);
+        s += QStringLiteral("<C C%1 1 %2 250 -26 15 0 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(3+(i-1)*Nc1).arg(250+dx).arg(C1,0,'f',3).arg(suffix1);
         dx += 510;
     }
 
@@ -165,26 +165,26 @@ void MFBfilter::createHighPassSchematic(QString &s)
     s += "<70 250 70 300 \"\" 0 0 0 \"\">\n";
     for (int i=1; i<=N2ord; i++) {
         if (i!=1) {
-            s += QString("<%1 250 %2 270 \"\" 0 0 0 \"\">\n").arg(120+dx).arg(120+dx);
-            s += QString("<%1 270 %2 270 \"\" 0 0 0 \"\">\n").arg(dx-40).arg(120+dx);
+            s += QStringLiteral("<%1 250 %2 270 \"\" 0 0 0 \"\">\n").arg(120+dx).arg(120+dx);
+            s += QStringLiteral("<%1 270 %2 270 \"\" 0 0 0 \"\">\n").arg(dx-40).arg(120+dx);
         }
-        s += QString("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(180+dx).arg(200+dx);
-        s += QString("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(220+dx);
-        s += QString("<%1 210 %2 250 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
-        s += QString("<%1 250 %2 320 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
-        s += QString("<%1 290 %2 350 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(360+dx);
-        s += QString("<%1 130 %2 150 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
-        s += QString("<%1 130 %2 130 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(320+dx);
-        s += QString("<%1 130 %2 150 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
-        s += QString("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(280+dx).arg(320+dx);
-        s += QString("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(360+dx);
-        s += QString("<%1 210 %2 250 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
-        s += QString("<%1 130 %2 130 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(470+dx);
-        s += QString("<%1 270 %2 270 \"\" 0 0 0 \"\">\n").arg(430+dx).arg(470+dx);
+        s += QStringLiteral("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(180+dx).arg(200+dx);
+        s += QStringLiteral("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(220+dx);
+        s += QStringLiteral("<%1 210 %2 250 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
+        s += QStringLiteral("<%1 250 %2 320 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
+        s += QStringLiteral("<%1 290 %2 350 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(360+dx);
+        s += QStringLiteral("<%1 130 %2 150 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
+        s += QStringLiteral("<%1 130 %2 130 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(320+dx);
+        s += QStringLiteral("<%1 130 %2 150 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
+        s += QStringLiteral("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(280+dx).arg(320+dx);
+        s += QStringLiteral("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(360+dx);
+        s += QStringLiteral("<%1 210 %2 250 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
+        s += QStringLiteral("<%1 130 %2 130 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(470+dx);
+        s += QStringLiteral("<%1 270 %2 270 \"\" 0 0 0 \"\">\n").arg(430+dx).arg(470+dx);
         if ((2*i)==order) {
-            s += QString("<%1 130 %2 270 \"out\" %3 170 70 \"\">\n").arg(470+dx).arg(470+dx).arg(500+dx);
+            s += QStringLiteral("<%1 130 %2 270 \"out\" %3 170 70 \"\">\n").arg(470+dx).arg(470+dx).arg(500+dx);
         } else {
-            s += QString("<%1 130 %2 270 \"\" 0 0 0 \"\">\n").arg(470+dx).arg(470+dx);
+            s += QStringLiteral("<%1 130 %2 270 \"\" 0 0 0 \"\">\n").arg(470+dx).arg(470+dx);
         }
         dx += 510;
     }
@@ -205,24 +205,24 @@ void MFBfilter::createBandPassSchematic(QString &s)
     s += PACKAGE_VERSION;
     s += ">\n";
     s += "<Components>\n";
-    s += QString("<.AC AC1 1 300 440 0 61 0 0 \"lin\" 1 \"1 Hz\" 1 \"%1 kHz\" 1 \"501\" 1 \"no\" 0>\n").arg((Fu+1000)/1000.0);
+    s += QStringLiteral("<.AC AC1 1 300 440 0 61 0 0 \"lin\" 1 \"1 Hz\" 1 \"%1 kHz\" 1 \"501\" 1 \"no\" 0>\n").arg((Fu+1000)/1000.0);
     s += "<.DC DC1 1 60 440 0 61 0 0 \"26.85\" 0 \"0.001\" 0 \"1 pA\" 0 \"1 uV\" 0 \"no\" 0 \"150\" 0 \"no\" 0 \"none\" 0 \"CroutLU\" 0>\n";
     s += "<Eqn Eqn1 1 610 450 -30 14 0 0 \"K=dB(out.v/in.v)\" 1 \"yes\" 0>\n";
-    s += QString("<Vac V1 1 %1 330 18 -26 0 1 \"1 V\" 1 \"1 kHz\" 0 \"0\" 0 \"0\" 0>\n").arg(70+dx);
-    s += QString("<GND * 1 %1 360 0 0 0 0>\n").arg(70+dx);
+    s += QStringLiteral("<Vac V1 1 %1 330 18 -26 0 1 \"1 V\" 1 \"1 kHz\" 0 \"0\" 0 \"0\" 0>\n").arg(70+dx);
+    s += QStringLiteral("<GND * 1 %1 360 0 0 0 0>\n").arg(70+dx);
     for (int i=1; i<=Sections.count(); i++) {
         stage = Sections.at(i-1);
         QString suffix1, suffix2;
         double  C1 = autoscaleCapacitor(stage.C1,suffix1);
         double  C2 = autoscaleCapacitor(stage.C2,suffix2);
-        s += QString("<GND * 1 %1 380 0 0 0 0>\n").arg(200+dx);
-        s += QString("<GND * 1 %1 350 0 0 0 0>\n").arg(360+dx);
-        s += QString("<OpAmp OP%1 1 %2 270 -26 -70 1 0 \"1e6\" 1 \"15 V\" 0>\n").arg(1+(i-1)*Nop1).arg(390+dx);
-        s += QString("<C C%1 1 %2 180 15 -26 0 1 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(1+(i-1)*Nc1).arg(200+dx).arg(C1,0,'f',3).arg(suffix1);
-        s += QString("<C C%1 1 %2 250 -26 15 0 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(2+(i-1)*Nc1).arg(250+dx).arg(C2,0,'f',3).arg(suffix2);
-        s += QString("<R R%1 1 %2 250 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(1+(i-1)*Nr1).arg(150+dx).arg(stage.R1,0,'f',3);
-        s += QString("<R R%1 1 %2 350 17 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(2+(i-1)*Nr1).arg(200+dx).arg(stage.R2,0,'f',3);
-        s += QString("<R R%1 1 %2 180 17 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(3+(i-1)*Nr1).arg(320+dx).arg(stage.R3,0,'f',3);
+        s += QStringLiteral("<GND * 1 %1 380 0 0 0 0>\n").arg(200+dx);
+        s += QStringLiteral("<GND * 1 %1 350 0 0 0 0>\n").arg(360+dx);
+        s += QStringLiteral("<OpAmp OP%1 1 %2 270 -26 -70 1 0 \"1e6\" 1 \"15 V\" 0>\n").arg(1+(i-1)*Nop1).arg(390+dx);
+        s += QStringLiteral("<C C%1 1 %2 180 15 -26 0 1 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(1+(i-1)*Nc1).arg(200+dx).arg(C1,0,'f',3).arg(suffix1);
+        s += QStringLiteral("<C C%1 1 %2 250 -26 15 0 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(2+(i-1)*Nc1).arg(250+dx).arg(C2,0,'f',3).arg(suffix2);
+        s += QStringLiteral("<R R%1 1 %2 250 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(1+(i-1)*Nr1).arg(150+dx).arg(stage.R1,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 350 17 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(2+(i-1)*Nr1).arg(200+dx).arg(stage.R2,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 180 17 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(3+(i-1)*Nr1).arg(320+dx).arg(stage.R3,0,'f',3);
         dx += 400;
     }
 
@@ -234,26 +234,26 @@ void MFBfilter::createBandPassSchematic(QString &s)
     s += "<70 250 70 300 \"\" 0 0 0 \"\">\n";
     for (int i=1; i<=Sections.count(); i++) {
         if (i!=1) {
-            s += QString("<%1 250 %2 270 \"\" 0 0 0 \"\">\n").arg(120+dx).arg(120+dx);
-            s += QString("<%1 270 %2 270 \"\" 0 0 0 \"\">\n").arg(dx+70).arg(120+dx);
+            s += QStringLiteral("<%1 250 %2 270 \"\" 0 0 0 \"\">\n").arg(120+dx).arg(120+dx);
+            s += QStringLiteral("<%1 270 %2 270 \"\" 0 0 0 \"\">\n").arg(dx+70).arg(120+dx);
         }
-        s += QString("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(180+dx).arg(200+dx);
-        s += QString("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(220+dx);
-        s += QString("<%1 210 %2 250 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
-        s += QString("<%1 250 %2 320 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
-        s += QString("<%1 290 %2 350 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(360+dx);
-        s += QString("<%1 130 %2 150 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
-        s += QString("<%1 130 %2 130 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(320+dx);
-        s += QString("<%1 130 %2 150 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
-        s += QString("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(280+dx).arg(320+dx);
-        s += QString("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(360+dx);
-        s += QString("<%1 210 %2 250 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
-        s += QString("<%1 130 %2 130 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(470+dx);
-        s += QString("<%1 270 %2 270 \"\" 0 0 0 \"\">\n").arg(430+dx).arg(470+dx);
+        s += QStringLiteral("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(180+dx).arg(200+dx);
+        s += QStringLiteral("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(220+dx);
+        s += QStringLiteral("<%1 210 %2 250 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
+        s += QStringLiteral("<%1 250 %2 320 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
+        s += QStringLiteral("<%1 290 %2 350 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(360+dx);
+        s += QStringLiteral("<%1 130 %2 150 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(200+dx);
+        s += QStringLiteral("<%1 130 %2 130 \"\" 0 0 0 \"\">\n").arg(200+dx).arg(320+dx);
+        s += QStringLiteral("<%1 130 %2 150 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
+        s += QStringLiteral("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(280+dx).arg(320+dx);
+        s += QStringLiteral("<%1 250 %2 250 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(360+dx);
+        s += QStringLiteral("<%1 210 %2 250 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
+        s += QStringLiteral("<%1 130 %2 130 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(470+dx);
+        s += QStringLiteral("<%1 270 %2 270 \"\" 0 0 0 \"\">\n").arg(430+dx).arg(470+dx);
         if (i==order) {
-            s += QString("<%1 130 %2 270 \"out\" %3 170 70 \"\">\n").arg(470+dx).arg(470+dx).arg(500+dx);
+            s += QStringLiteral("<%1 130 %2 270 \"out\" %3 170 70 \"\">\n").arg(470+dx).arg(470+dx).arg(500+dx);
         } else {
-            s += QString("<%1 130 %2 270 \"\" 0 0 0 \"\">\n").arg(470+dx).arg(470+dx);
+            s += QStringLiteral("<%1 130 %2 270 \"\" 0 0 0 \"\">\n").arg(470+dx).arg(470+dx);
         }
         dx += 400;
     }

--- a/qucs-activefilter/sallenkey.cpp
+++ b/qucs-activefilter/sallenkey.cpp
@@ -267,25 +267,25 @@ void SallenKey::createHighPassSchematic(QString &s)
     s += PACKAGE_VERSION;
     s += ">\n";
     s += "<Components>\n";
-    s += QString("<.AC AC1 1 30 410 0 61 0 0 \"lin\" 1 \"1 Hz\" 1 \"%1 kHz\" 1 \"501\" 1 \"no\" 0>\n").arg((10.0*Fc)/1000.0);
+    s += QStringLiteral("<.AC AC1 1 30 410 0 61 0 0 \"lin\" 1 \"1 Hz\" 1 \"%1 kHz\" 1 \"501\" 1 \"no\" 0>\n").arg((10.0*Fc)/1000.0);
     s += "<.DC DC1 1 280 410 0 61 0 0 \"26.85\" 0 \"0.001\" 0 \"1 pA\" 0 \"1 uV\" 0 \"no\" 0 \"150\" 0 \"no\" 0 \"none\" 0 \"CroutLU\" 0>\n";
     s += "<Eqn Eqn1 1 270 540 -30 14 0 0 \"K=(out.v/in.v)\" 1 \"yes\" 0>\n";
-    s += QString("<Vac V1 1 %1 260 18 -26 0 1 \"1 V\" 1 \"1 kHz\" 0 \"0\" 0 \"0\" 0>\n").arg(20+dx);
-    s += QString("<GND * 1 %1 290 0 0 0 0>\n").arg(20+dx);
+    s += QStringLiteral("<Vac V1 1 %1 260 18 -26 0 1 \"1 V\" 1 \"1 kHz\" 0 \"0\" 0 \"0\" 0>\n").arg(20+dx);
+    s += QStringLiteral("<GND * 1 %1 290 0 0 0 0>\n").arg(20+dx);
     for (int i=1; i<=N2ord; i++) {
         stage = Sections.at(i-1);
         QString suffix1, suffix2;
         double  C1 = autoscaleCapacitor(stage.C1,suffix1);
         double  C2 = autoscaleCapacitor(stage.C2,suffix2);
-        s += QString("<OpAmp OP%1 1 %2 160 -26 42 0 0 \"1e6\" 1 \"15 V\" 0>\n").arg(stage.N).arg(370+dx);
-        s += QString("<GND * 1 %1 270 0 0 0 0>\n").arg(270+dx);
-        s += QString("<GND * 1 %1 370 0 0 0 0>\n").arg(320+dx);
-        s += QString("<R R%1 1 %2 340 15 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(3+(i-1)*N_R).arg(320+dx).arg(stage.R3,0,'f',3);
-        s += QString("<C C%1 1 %2 190 -26 -45 1 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(2+(i-1)*N_C).arg(200+dx).arg(C2,0,'f',3).arg(suffix2);
-        s += QString("<C C%1 1 %2 190 -26 17 0 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(1+(i-1)*N_C).arg(100+dx).arg(C1,0,'f',3).arg(suffix1);
-        s += QString("<R R%1 1 %2 240 -75 -26 1 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(2+(i-1)*N_R).arg(270+dx).arg(stage.R2,0,'f',3);
-        s += QString("<R R%1 1 %2 70 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(1+(i-1)*N_R).arg(330+dx).arg(stage.R1,0,'f',3);
-        s += QString("<R R%1 1 %2 260 -26 15 1 2 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(4+(i-1)*N_R).arg(410+dx).arg(stage.R4,0,'f',3);
+        s += QStringLiteral("<OpAmp OP%1 1 %2 160 -26 42 0 0 \"1e6\" 1 \"15 V\" 0>\n").arg(stage.N).arg(370+dx);
+        s += QStringLiteral("<GND * 1 %1 270 0 0 0 0>\n").arg(270+dx);
+        s += QStringLiteral("<GND * 1 %1 370 0 0 0 0>\n").arg(320+dx);
+        s += QStringLiteral("<R R%1 1 %2 340 15 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(3+(i-1)*N_R).arg(320+dx).arg(stage.R3,0,'f',3);
+        s += QStringLiteral("<C C%1 1 %2 190 -26 -45 1 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(2+(i-1)*N_C).arg(200+dx).arg(C2,0,'f',3).arg(suffix2);
+        s += QStringLiteral("<C C%1 1 %2 190 -26 17 0 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(1+(i-1)*N_C).arg(100+dx).arg(C1,0,'f',3).arg(suffix1);
+        s += QStringLiteral("<R R%1 1 %2 240 -75 -26 1 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(2+(i-1)*N_R).arg(270+dx).arg(stage.R2,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 70 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(1+(i-1)*N_R).arg(330+dx).arg(stage.R1,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 260 -26 15 1 2 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(4+(i-1)*N_R).arg(410+dx).arg(stage.R4,0,'f',3);
         dx += 510;
     }
 
@@ -296,35 +296,35 @@ void SallenKey::createHighPassSchematic(QString &s)
     s += "</Components>\n";
     s += "<Wires>\n";
     dx = 0;
-    s += QString("<%1 190 %2 230 \"\" 0 0 0 \"\">\n").arg(20+dx).arg(20+dx);
-    s += QString("<%1 190 %2 190 \"in\" %3 160 18 \"\">\n").arg(20+dx).arg(70+dx).arg(70+dx);
+    s += QStringLiteral("<%1 190 %2 230 \"\" 0 0 0 \"\">\n").arg(20+dx).arg(20+dx);
+    s += QStringLiteral("<%1 190 %2 190 \"in\" %3 160 18 \"\">\n").arg(20+dx).arg(70+dx).arg(70+dx);
     for (int i=1; i<=N2ord; i++) {
         if (i!=1) {
-            s += QString("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(70+dx);
-            s += QString("<%1 190 %2 160 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(dx-20);
-            s += QString("<%1 160 %2 160 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(dx-50);
+            s += QStringLiteral("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(70+dx);
+            s += QStringLiteral("<%1 190 %2 160 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(dx-20);
+            s += QStringLiteral("<%1 160 %2 160 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(dx-50);
         }
-        s += QString("<%1 70 %2 70 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(460+dx);
+        s += QStringLiteral("<%1 70 %2 70 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(460+dx);
         if ((2*i)==order) {
-            s += QString("<%1 70 %2 160 \"out\" %3 90 51 \"\">\n").arg(460+dx).arg(460+dx).arg(490+dx);
+            s += QStringLiteral("<%1 70 %2 160 \"out\" %3 90 51 \"\">\n").arg(460+dx).arg(460+dx).arg(490+dx);
         } else {
-            s += QString("<%1 70 %2 160 \"\" 0 0 0 \"\">\n").arg(460+dx).arg(460+dx);
+            s += QStringLiteral("<%1 70 %2 160 \"\" 0 0 0 \"\">\n").arg(460+dx).arg(460+dx);
         }
-        s += QString("<%1 160 %2 160 \"\" 0 0 0 \"\">\n").arg(410+dx).arg(460+dx);
-        s += QString("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(440+dx).arg(460+dx);
-        s += QString("<%1 160 %2 260 \"\" 0 0 0 \"\">\n").arg(460+dx).arg(460+dx);
-        s += QString("<%1 190 %2 210 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(270+dx);
-        s += QString("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(230+dx).arg(270+dx);
-        s += QString("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(130+dx).arg(150+dx);
-        s += QString("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(170+dx);
-        s += QString("<%1 70 %2 190 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(150+dx);
-        s += QString("<%1 70 %2 70 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(300+dx);
-        s += QString("<%1 140 %2 190 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(270+dx);
-        s += QString("<%1 140 %2 140 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(340+dx);
-        s += QString("<%1 180 %2 260 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
-        s += QString("<%1 180 %2 180 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(340+dx);
-        s += QString("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(380+dx);
-        s += QString("<%1 260 %2 310 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
+        s += QStringLiteral("<%1 160 %2 160 \"\" 0 0 0 \"\">\n").arg(410+dx).arg(460+dx);
+        s += QStringLiteral("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(440+dx).arg(460+dx);
+        s += QStringLiteral("<%1 160 %2 260 \"\" 0 0 0 \"\">\n").arg(460+dx).arg(460+dx);
+        s += QStringLiteral("<%1 190 %2 210 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(270+dx);
+        s += QStringLiteral("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(230+dx).arg(270+dx);
+        s += QStringLiteral("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(130+dx).arg(150+dx);
+        s += QStringLiteral("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(170+dx);
+        s += QStringLiteral("<%1 70 %2 190 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(150+dx);
+        s += QStringLiteral("<%1 70 %2 70 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(300+dx);
+        s += QStringLiteral("<%1 140 %2 190 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(270+dx);
+        s += QStringLiteral("<%1 140 %2 140 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(340+dx);
+        s += QStringLiteral("<%1 180 %2 260 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
+        s += QStringLiteral("<%1 180 %2 180 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(340+dx);
+        s += QStringLiteral("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(380+dx);
+        s += QStringLiteral("<%1 260 %2 310 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
         dx += 510;
     }
 
@@ -348,26 +348,26 @@ void SallenKey::createLowPassSchematic(QString &s)
     s += PACKAGE_VERSION;
     s += ">\n";
     s += "<Components>\n";
-    s += QString("<.AC AC1 1 30 410 0 61 0 0 \"lin\" 1 \"1 Hz\" 1 \"%1 kHz\" 1 \"501\" 1 \"no\" 0>\n").arg((10.0*Fc)/1000.0);
+    s += QStringLiteral("<.AC AC1 1 30 410 0 61 0 0 \"lin\" 1 \"1 Hz\" 1 \"%1 kHz\" 1 \"501\" 1 \"no\" 0>\n").arg((10.0*Fc)/1000.0);
     s += "<.DC DC1 1 280 410 0 61 0 0 \"26.85\" 0 \"0.001\" 0 \"1 pA\" 0 \"1 uV\" 0 \"no\" 0 \"150\" 0 \"no\" 0 \"none\" 0 \"CroutLU\" 0>\n";
     s += "<Eqn Eqn1 1 270 540 -30 14 0 0 \"K=(out.v/in.v)\" 1 \"yes\" 0>\n";
-    s += QString("<Vac V1 1 %1 260 18 -26 0 1 \"1 V\" 1 \"1 kHz\" 0 \"0\" 0 \"0\" 0>\n").arg(20+dx);
-    s += QString("<GND * 1 %1 290 0 0 0 0>\n").arg(20+dx);
+    s += QStringLiteral("<Vac V1 1 %1 260 18 -26 0 1 \"1 V\" 1 \"1 kHz\" 0 \"0\" 0 \"0\" 0>\n").arg(20+dx);
+    s += QStringLiteral("<GND * 1 %1 290 0 0 0 0>\n").arg(20+dx);
     for (int i=1; i<=N2ord; i++) {
         stage = Sections.at(i-1);
         //qDebug()<<stage.N;
         QString suffix1, suffix2;
         double  C1 = autoscaleCapacitor(stage.C1,suffix1);
         double  C2 = autoscaleCapacitor(stage.C2,suffix2);
-        s += QString("<OpAmp OP%1 1 %2 160 -26 42 0 0 \"1e6\" 1 \"15 V\" 0>\n").arg(stage.N).arg(370+dx);
-        s += QString("<GND * 1 %1 270 0 0 0 0>\n").arg(270+dx);
-        s += QString("<GND * 1 %1 370 0 0 0 0>\n").arg(320+dx);
-        s += QString("<C C%1 1 %2 70 -26 15 0 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(2+(i-1)*N_C).arg(330+dx).arg(C2,0,'f',3).arg(suffix2);
-        s += QString("<C C%1 1 %2 240 -75 -26 1 1 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(1+(i-1)*N_C).arg(270+dx).arg(C1,0,'f',3).arg(suffix1);
-        s += QString("<R R%1 1 %2 190 -26 -45 1 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(2+(i-1)*N_R).arg(200+dx).arg(stage.R2,0,'f',3);
-        s += QString("<R R%1 1 %2 190 -26 17 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(1+(i-1)*N_R).arg(100+dx).arg(stage.R1,0,'f',3);
-        s += QString("<R R%1 1 %2 340 15 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(3+(i-1)*N_R).arg(320+dx).arg(stage.R3,0,'f',3);
-        s += QString("<R R%1 1 %2 260 -26 15 1 2 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(4+(i-1)*N_R).arg(410+dx).arg(stage.R4,0,'f',3);
+        s += QStringLiteral("<OpAmp OP%1 1 %2 160 -26 42 0 0 \"1e6\" 1 \"15 V\" 0>\n").arg(stage.N).arg(370+dx);
+        s += QStringLiteral("<GND * 1 %1 270 0 0 0 0>\n").arg(270+dx);
+        s += QStringLiteral("<GND * 1 %1 370 0 0 0 0>\n").arg(320+dx);
+        s += QStringLiteral("<C C%1 1 %2 70 -26 15 0 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(2+(i-1)*N_C).arg(330+dx).arg(C2,0,'f',3).arg(suffix2);
+        s += QStringLiteral("<C C%1 1 %2 240 -75 -26 1 1 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(1+(i-1)*N_C).arg(270+dx).arg(C1,0,'f',3).arg(suffix1);
+        s += QStringLiteral("<R R%1 1 %2 190 -26 -45 1 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(2+(i-1)*N_R).arg(200+dx).arg(stage.R2,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 190 -26 17 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(1+(i-1)*N_R).arg(100+dx).arg(stage.R1,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 340 15 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(3+(i-1)*N_R).arg(320+dx).arg(stage.R3,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 260 -26 15 1 2 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(4+(i-1)*N_R).arg(410+dx).arg(stage.R4,0,'f',3);
         dx += 510;
     }
 
@@ -378,35 +378,35 @@ void SallenKey::createLowPassSchematic(QString &s)
     s += "</Components>\n";
     s += "<Wires>\n";
     dx = 0;
-    s += QString("<%1 190 %2 230 \"\" 0 0 0 \"\">\n").arg(20+dx).arg(20+dx);
-    s += QString("<%1 190 %2 190 \"in\" %3 160 18 \"\">\n").arg(20+dx).arg(70+dx).arg(70+dx);
+    s += QStringLiteral("<%1 190 %2 230 \"\" 0 0 0 \"\">\n").arg(20+dx).arg(20+dx);
+    s += QStringLiteral("<%1 190 %2 190 \"in\" %3 160 18 \"\">\n").arg(20+dx).arg(70+dx).arg(70+dx);
     for (int i=1; i<=N2ord; i++) {
         if (i!=1) {
-            s += QString("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(70+dx);
-            s += QString("<%1 190 %2 160 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(dx-20);
-            s += QString("<%1 160 %2 160 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(dx-50);
+            s += QStringLiteral("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(70+dx);
+            s += QStringLiteral("<%1 190 %2 160 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(dx-20);
+            s += QStringLiteral("<%1 160 %2 160 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(dx-50);
         }
-        s += QString("<%1 70 %2 70 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(460+dx);
+        s += QStringLiteral("<%1 70 %2 70 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(460+dx);
         if ((2*i)==order) {
-            s += QString("<%1 70 %2 160 \"out\" %3 90 51 \"\">\n").arg(460+dx).arg(460+dx).arg(490+dx);
+            s += QStringLiteral("<%1 70 %2 160 \"out\" %3 90 51 \"\">\n").arg(460+dx).arg(460+dx).arg(490+dx);
         } else {
-            s += QString("<%1 70 %2 160 \"\" 0 0 0 \"\">\n").arg(460+dx).arg(460+dx);
+            s += QStringLiteral("<%1 70 %2 160 \"\" 0 0 0 \"\">\n").arg(460+dx).arg(460+dx);
         }
-        s += QString("<%1 160 %2 160 \"\" 0 0 0 \"\">\n").arg(410+dx).arg(460+dx);
-        s += QString("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(440+dx).arg(460+dx);
-        s += QString("<%1 160 %2 260 \"\" 0 0 0 \"\">\n").arg(460+dx).arg(460+dx);
-        s += QString("<%1 190 %2 210 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(270+dx);
-        s += QString("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(230+dx).arg(270+dx);
-        s += QString("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(130+dx).arg(150+dx);
-        s += QString("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(170+dx);
-        s += QString("<%1 70 %2 190 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(150+dx);
-        s += QString("<%1 70 %2 70 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(300+dx);
-        s += QString("<%1 140 %2 190 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(270+dx);
-        s += QString("<%1 140 %2 140 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(340+dx);
-        s += QString("<%1 180 %2 260 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
-        s += QString("<%1 180 %2 180 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(340+dx);
-        s += QString("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(380+dx);
-        s += QString("<%1 260 %2 310 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
+        s += QStringLiteral("<%1 160 %2 160 \"\" 0 0 0 \"\">\n").arg(410+dx).arg(460+dx);
+        s += QStringLiteral("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(440+dx).arg(460+dx);
+        s += QStringLiteral("<%1 160 %2 260 \"\" 0 0 0 \"\">\n").arg(460+dx).arg(460+dx);
+        s += QStringLiteral("<%1 190 %2 210 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(270+dx);
+        s += QStringLiteral("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(230+dx).arg(270+dx);
+        s += QStringLiteral("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(130+dx).arg(150+dx);
+        s += QStringLiteral("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(170+dx);
+        s += QStringLiteral("<%1 70 %2 190 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(150+dx);
+        s += QStringLiteral("<%1 70 %2 70 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(300+dx);
+        s += QStringLiteral("<%1 140 %2 190 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(270+dx);
+        s += QStringLiteral("<%1 140 %2 140 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(340+dx);
+        s += QStringLiteral("<%1 180 %2 260 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
+        s += QStringLiteral("<%1 180 %2 180 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(340+dx);
+        s += QStringLiteral("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(380+dx);
+        s += QStringLiteral("<%1 260 %2 310 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
         dx += 510;
     }
 
@@ -426,28 +426,28 @@ void SallenKey::createBandPassSchematic(QString &s)
     s += PACKAGE_VERSION;
     s += ">\n";
     s += "<Components>\n";
-    s += QString("<.AC AC1 1 30 410 0 61 0 0 \"lin\" 1 \"1 Hz\" 1 \"%1 kHz\" 1 \"501\" 1 \"no\" 0>\n").arg((Fu+1000)/1000.0);
+    s += QStringLiteral("<.AC AC1 1 30 410 0 61 0 0 \"lin\" 1 \"1 Hz\" 1 \"%1 kHz\" 1 \"501\" 1 \"no\" 0>\n").arg((Fu+1000)/1000.0);
     s += "<.DC DC1 1 280 410 0 61 0 0 \"26.85\" 0 \"0.001\" 0 \"1 pA\" 0 \"1 uV\" 0 \"no\" 0 \"150\" 0 \"no\" 0 \"none\" 0 \"CroutLU\" 0>\n";
     s += "<Eqn Eqn1 1 270 540 -30 14 0 0 \"K=(out.v/in.v)\" 1 \"yes\" 0>\n";
-    s += QString("<Vac V1 1 %1 260 18 -26 0 1 \"1 V\" 1 \"1 kHz\" 0 \"0\" 0 \"0\" 0>\n").arg(20+dx);
-    s += QString("<GND * 1 %1 290 0 0 0 0>\n").arg(20+dx);
+    s += QStringLiteral("<Vac V1 1 %1 260 18 -26 0 1 \"1 V\" 1 \"1 kHz\" 0 \"0\" 0 \"0\" 0>\n").arg(20+dx);
+    s += QStringLiteral("<GND * 1 %1 290 0 0 0 0>\n").arg(20+dx);
     for (int i=1; i<=Sections.count(); i++) {
         stage = Sections.at(i-1);
         //qDebug()<<stage.N;
         QString suffix1, suffix2;
         double  C1 = autoscaleCapacitor(stage.C1,suffix1);
         double  C2 = autoscaleCapacitor(stage.C2,suffix2);
-        s += QString("<OpAmp OP%1 1 %2 160 -26 42 0 0 \"1e6\" 1 \"15 V\" 0>\n").arg(stage.N).arg(370+dx);
-        s += QString("<GND * 1 %1 270 0 0 0 0>\n").arg(270+dx);
-        s += QString("<GND * 1 %1 370 0 0 0 0>\n").arg(320+dx);
-        s += QString("<GND * 1 %1 310 0 0 0 0>\n").arg(150+dx);
-        s += QString("<C C%1 1 %2 280 17 -26 0 1 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(1+(i-1)*Nc1).arg(150+dx).arg(C1,0,'f',3).arg(suffix1);
-        s += QString("<C C%1 1 %2 190 -26 -45 1 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(2+(i-1)*Nr1).arg(200+dx).arg(C2,0,'f',3).arg(suffix2);
-        s += QString("<R R%1 1 %2 190 -26 17 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(1+(i-1)*Nr1).arg(100+dx).arg(stage.R1,0,'f',3);
-        s += QString("<R R%1 1 %2 70 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(2+(i-1)*Nr1).arg(330+dx).arg(stage.R2,0,'f',3);
-        s += QString("<R R%1 1 %2 240 -75 -26 1 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(3+(i-1)*Nr1).arg(270+dx).arg(stage.R3,0,'f',3);
-        s += QString("<R R%1 1 %2 340 15 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(4+(i-1)*Nr1).arg(320+dx).arg(stage.R4,0,'f',3);
-        s += QString("<R R%1 1 %2 260 -26 15 1 2 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(5+(i-1)*Nr1).arg(410+dx).arg(stage.R4,0,'f',3);
+        s += QStringLiteral("<OpAmp OP%1 1 %2 160 -26 42 0 0 \"1e6\" 1 \"15 V\" 0>\n").arg(stage.N).arg(370+dx);
+        s += QStringLiteral("<GND * 1 %1 270 0 0 0 0>\n").arg(270+dx);
+        s += QStringLiteral("<GND * 1 %1 370 0 0 0 0>\n").arg(320+dx);
+        s += QStringLiteral("<GND * 1 %1 310 0 0 0 0>\n").arg(150+dx);
+        s += QStringLiteral("<C C%1 1 %2 280 17 -26 0 1 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(1+(i-1)*Nc1).arg(150+dx).arg(C1,0,'f',3).arg(suffix1);
+        s += QStringLiteral("<C C%1 1 %2 190 -26 -45 1 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(2+(i-1)*Nr1).arg(200+dx).arg(C2,0,'f',3).arg(suffix2);
+        s += QStringLiteral("<R R%1 1 %2 190 -26 17 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(1+(i-1)*Nr1).arg(100+dx).arg(stage.R1,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 70 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(2+(i-1)*Nr1).arg(330+dx).arg(stage.R2,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 240 -75 -26 1 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(3+(i-1)*Nr1).arg(270+dx).arg(stage.R3,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 340 15 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(4+(i-1)*Nr1).arg(320+dx).arg(stage.R4,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 260 -26 15 1 2 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(5+(i-1)*Nr1).arg(410+dx).arg(stage.R4,0,'f',3);
         dx += 510;
     }
 
@@ -455,36 +455,36 @@ void SallenKey::createBandPassSchematic(QString &s)
     s += "</Components>\n";
     s += "<Wires>\n";
     dx = 0;
-    s += QString("<%1 190 %2 230 \"\" 0 0 0 \"\">\n").arg(20+dx).arg(20+dx);
-    s += QString("<%1 190 %2 190 \"in\" %3 160 18 \"\">\n").arg(20+dx).arg(70+dx).arg(70+dx);
+    s += QStringLiteral("<%1 190 %2 230 \"\" 0 0 0 \"\">\n").arg(20+dx).arg(20+dx);
+    s += QStringLiteral("<%1 190 %2 190 \"in\" %3 160 18 \"\">\n").arg(20+dx).arg(70+dx).arg(70+dx);
     for (int i=1; i<=Sections.count(); i++) {
         if (i!=1) {
-            s += QString("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(70+dx);
-            s += QString("<%1 190 %2 160 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(dx-20);
-            s += QString("<%1 160 %2 160 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(dx-50);
+            s += QStringLiteral("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(70+dx);
+            s += QStringLiteral("<%1 190 %2 160 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(dx-20);
+            s += QStringLiteral("<%1 160 %2 160 \"\" 0 0 0 \"\">\n").arg(dx-20).arg(dx-50);
         }
-        s += QString("<%1 70 %2 70 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(460+dx);
+        s += QStringLiteral("<%1 70 %2 70 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(460+dx);
         if (i==order) {
-            s += QString("<%1 70 %2 160 \"out\" %3 90 51 \"\">\n").arg(460+dx).arg(460+dx).arg(490+dx);
+            s += QStringLiteral("<%1 70 %2 160 \"out\" %3 90 51 \"\">\n").arg(460+dx).arg(460+dx).arg(490+dx);
         } else {
-            s += QString("<%1 70 %2 160 \"\" 0 0 0 \"\">\n").arg(460+dx).arg(460+dx);
+            s += QStringLiteral("<%1 70 %2 160 \"\" 0 0 0 \"\">\n").arg(460+dx).arg(460+dx);
         }
-        s += QString("<%1 160 %2 160 \"\" 0 0 0 \"\">\n").arg(410+dx).arg(460+dx);
-        s += QString("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(440+dx).arg(460+dx);
-        s += QString("<%1 160 %2 260 \"\" 0 0 0 \"\">\n").arg(460+dx).arg(460+dx);
-        s += QString("<%1 190 %2 210 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(270+dx);
-        s += QString("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(230+dx).arg(270+dx);
-        s += QString("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(130+dx).arg(150+dx);
-        s += QString("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(170+dx);
-        s += QString("<%1 70 %2 190 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(150+dx);
-        s += QString("<%1 70 %2 70 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(300+dx);
-        s += QString("<%1 140 %2 190 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(270+dx);
-        s += QString("<%1 140 %2 140 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(340+dx);
-        s += QString("<%1 180 %2 260 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
-        s += QString("<%1 180 %2 180 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(340+dx);
-        s += QString("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(380+dx);
-        s += QString("<%1 260 %2 310 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
-        s += QString("<%1 190 %2 250 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(150+dx);
+        s += QStringLiteral("<%1 160 %2 160 \"\" 0 0 0 \"\">\n").arg(410+dx).arg(460+dx);
+        s += QStringLiteral("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(440+dx).arg(460+dx);
+        s += QStringLiteral("<%1 160 %2 260 \"\" 0 0 0 \"\">\n").arg(460+dx).arg(460+dx);
+        s += QStringLiteral("<%1 190 %2 210 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(270+dx);
+        s += QStringLiteral("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(230+dx).arg(270+dx);
+        s += QStringLiteral("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(130+dx).arg(150+dx);
+        s += QStringLiteral("<%1 190 %2 190 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(170+dx);
+        s += QStringLiteral("<%1 70 %2 190 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(150+dx);
+        s += QStringLiteral("<%1 70 %2 70 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(300+dx);
+        s += QStringLiteral("<%1 140 %2 190 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(270+dx);
+        s += QStringLiteral("<%1 140 %2 140 \"\" 0 0 0 \"\">\n").arg(270+dx).arg(340+dx);
+        s += QStringLiteral("<%1 180 %2 260 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
+        s += QStringLiteral("<%1 180 %2 180 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(340+dx);
+        s += QStringLiteral("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(380+dx);
+        s += QStringLiteral("<%1 260 %2 310 \"\" 0 0 0 \"\">\n").arg(320+dx).arg(320+dx);
+        s += QStringLiteral("<%1 190 %2 250 \"\" 0 0 0 \"\">\n").arg(150+dx).arg(150+dx);
         dx += 510;
     }
 

--- a/qucs-activefilter/schcauer.cpp
+++ b/qucs-activefilter/schcauer.cpp
@@ -318,7 +318,7 @@ void SchCauer::createGenericSchematic(QString &s)
     s += "<Vac V1 1 80 290 18 -26 0 1 \"1 V\" 0 \"1 kHz\" 0 \"0\" 0 \"0\" 0>\n";
     s += "<.DC DC1 1 40 510 0 61 0 0 \"26.85\" 0 \"0.001\" 0 \"1 pA\" 0 \"1 uV\" 0 \"no\" 0 \"150\" 0 \"no\" 0 \"none\" 0 \"CroutLU\" 0>\n";
     s += "<Eqn Eqn1 1 640 520 -30 14 0 0 \"K=dB(out.v/in.v)\" 1 \"yes\" 0>\n";
-    s += QString("<.AC AC1 1 320 510 0 61 0 0 \"lin\" 1 \"1 Hz\" 1 \"%1 kHz\" 1 \"1001\" 1 \"no\" 0>\n").arg(Fac);
+    s += QStringLiteral("<.AC AC1 1 320 510 0 61 0 0 \"lin\" 1 \"1 Hz\" 1 \"%1 kHz\" 1 \"1001\" 1 \"no\" 0>\n").arg(Fac);
     s += "<GND * 1 80 320 0 0 0 0>\n";
 
     for (int i=1; i<=N2ord; i++) {
@@ -326,23 +326,23 @@ void SchCauer::createGenericSchematic(QString &s)
         QString suffix1, suffix2;
         double  C1 = autoscaleCapacitor(stage.C1,suffix1);
         double  C2 = autoscaleCapacitor(stage.C2,suffix2);
-        s += QString("<OpAmp OP%1 1 %2 240 -26 -70 1 0 \"1e6\" 1 \"15 V\" 0>\n").arg(1+(i-1)*Nop1).arg(270+dx);
-        s += QString("<OpAmp OP%1 1 %2 400 -26 -70 1 0 \"1e6\" 1 \"15 V\" 0>\n").arg(2+(i-1)*Nop1).arg(300+dx);
-        s += QString("<OpAmp OP%1 1 %2 260 -26 42 0 0 \"1e6\" 1 \"15 V\" 0>\n").arg(3+(i-1)*Nop1).arg(560+dx);
-        s += QString("<C C%1 1 %2 150 -26 17 0 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(1+(i-1)*Nc1).arg(330+dx).arg(C1,0,'f',3).arg(suffix1);
-        s += QString("<C C%1 1 %2 400 -26 17 0 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(2+(i-1)*Nc1).arg(450+dx).arg(C2,0,'f',3).arg(suffix2);
-        s += QString("<R R%1 1 %2 220 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(1+(i-1)*Nr1).arg(180+dx).arg(stage.R1,0,'f',3);
-        s += QString("<R R%1 1 %2 240 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(2+(i-1)*Nr1).arg(410+dx).arg(stage.R2,0,'f',3);
-        s += QString("<R R%1 1 %2 110 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(3+(i-1)*Nr1).arg(440+dx).arg(stage.R3,0,'f',3);
-        s += QString("<R R%1 1 %2 320 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(4+(i-1)*Nr1).arg(360+dx).arg(stage.R4,0,'f',3);
-        s += QString("<R R%1 1 %2 380 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(5+(i-1)*Nr1).arg(190+dx).arg(stage.R5,0,'f',3);
-        s += QString("<GND * 1 %1 290 0 0 0 0>\n").arg(240+dx);
-        s += QString("<GND * 1 %1 440 0 0 0 0>\n").arg(250+dx);
+        s += QStringLiteral("<OpAmp OP%1 1 %2 240 -26 -70 1 0 \"1e6\" 1 \"15 V\" 0>\n").arg(1+(i-1)*Nop1).arg(270+dx);
+        s += QStringLiteral("<OpAmp OP%1 1 %2 400 -26 -70 1 0 \"1e6\" 1 \"15 V\" 0>\n").arg(2+(i-1)*Nop1).arg(300+dx);
+        s += QStringLiteral("<OpAmp OP%1 1 %2 260 -26 42 0 0 \"1e6\" 1 \"15 V\" 0>\n").arg(3+(i-1)*Nop1).arg(560+dx);
+        s += QStringLiteral("<C C%1 1 %2 150 -26 17 0 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(1+(i-1)*Nc1).arg(330+dx).arg(C1,0,'f',3).arg(suffix1);
+        s += QStringLiteral("<C C%1 1 %2 400 -26 17 0 0 \"%3%4\" 1 \"\" 0 \"neutral\" 0>\n").arg(2+(i-1)*Nc1).arg(450+dx).arg(C2,0,'f',3).arg(suffix2);
+        s += QStringLiteral("<R R%1 1 %2 220 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(1+(i-1)*Nr1).arg(180+dx).arg(stage.R1,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 240 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(2+(i-1)*Nr1).arg(410+dx).arg(stage.R2,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 110 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(3+(i-1)*Nr1).arg(440+dx).arg(stage.R3,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 320 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(4+(i-1)*Nr1).arg(360+dx).arg(stage.R4,0,'f',3);
+        s += QStringLiteral("<R R%1 1 %2 380 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(5+(i-1)*Nr1).arg(190+dx).arg(stage.R5,0,'f',3);
+        s += QStringLiteral("<GND * 1 %1 290 0 0 0 0>\n").arg(240+dx);
+        s += QStringLiteral("<GND * 1 %1 440 0 0 0 0>\n").arg(250+dx);
 
         if ((ftype==Filter::BandPass)||(ftype==Filter::BandStop)) {
-            s += QString("<GND * 1 %1 470 0 0 0 0>\n").arg(500+dx);
-            s += QString("<R R%1 1 %2 370 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(6+(i-1)*Nr1).arg(570+dx).arg(stage.R6,0,'f',3);
-            s += QString("<R R%1 1 %2 440 15 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(7+(i+1)*Nr1).arg(500+dx).arg(stage.R6,0,'f',3);
+            s += QStringLiteral("<GND * 1 %1 470 0 0 0 0>\n").arg(500+dx);
+            s += QStringLiteral("<R R%1 1 %2 370 -26 15 0 0 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(6+(i-1)*Nr1).arg(570+dx).arg(stage.R6,0,'f',3);
+            s += QStringLiteral("<R R%1 1 %2 440 15 -26 0 1 \"%3k\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"european\" 0>\n").arg(7+(i+1)*Nr1).arg(500+dx).arg(stage.R6,0,'f',3);
         }
 
         dx += 580;
@@ -369,32 +369,32 @@ void SchCauer::createGenericSchematic(QString &s)
 
     for (int i=1; i<=N2ord; i++) {
         if (i!=1) {
-            s += QString("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(dx+30).arg(140+dx);
+            s += QStringLiteral("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(dx+30).arg(140+dx);
         }
 
-        s += QString("<%1 220 %2 220 \"\" 0 0 0 \"\">\n").arg(210+dx).arg(220+dx);
-        s += QString("<%1 280 %2 370 \"\" 0 0 0 \"\">\n").arg(500+dx).arg(500+dx);
-        s += QString("<%1 280 %2 280 \"\" 0 0 0 \"\">\n").arg(500+dx).arg(530+dx);
-        s += QString("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(600+dx).arg(610+dx);
-        s += QString("<%1 260 %2 370 \"\" 0 0 0 \"\">\n").arg(610+dx).arg(610+dx);
+        s += QStringLiteral("<%1 220 %2 220 \"\" 0 0 0 \"\">\n").arg(210+dx).arg(220+dx);
+        s += QStringLiteral("<%1 280 %2 370 \"\" 0 0 0 \"\">\n").arg(500+dx).arg(500+dx);
+        s += QStringLiteral("<%1 280 %2 280 \"\" 0 0 0 \"\">\n").arg(500+dx).arg(530+dx);
+        s += QStringLiteral("<%1 260 %2 260 \"\" 0 0 0 \"\">\n").arg(600+dx).arg(610+dx);
+        s += QStringLiteral("<%1 260 %2 370 \"\" 0 0 0 \"\">\n").arg(610+dx).arg(610+dx);
         if ((ftype==Filter::BandPass)||(ftype==Filter::BandStop)) {
-            s += QString("<%1 370 %2 410 \"\" 0 0 0 \"\">\n").arg(500+dx).arg(500+dx);
-            s += QString("<%1 370 %2 370 \"\" 0 0 0 \"\">\n").arg(600+dx).arg(610+dx);
-            s += QString("<%1 370 %2 370 \"\" 0 0 0 \"\">\n").arg(500+dx).arg(540+dx);
+            s += QStringLiteral("<%1 370 %2 410 \"\" 0 0 0 \"\">\n").arg(500+dx).arg(500+dx);
+            s += QStringLiteral("<%1 370 %2 370 \"\" 0 0 0 \"\">\n").arg(600+dx).arg(610+dx);
+            s += QStringLiteral("<%1 370 %2 370 \"\" 0 0 0 \"\">\n").arg(500+dx).arg(540+dx);
         } else {
-            s += QString("<%1 370 %2 370 \"\" 0 0 0 \"\">\n").arg(500+dx).arg(610+dx);
+            s += QStringLiteral("<%1 370 %2 370 \"\" 0 0 0 \"\">\n").arg(500+dx).arg(610+dx);
         }
-        s += QString("<%1 240 %2 240 \"\" 0 0 0 \"\">\n").arg(440+dx).arg(480+dx);
-        s += QString("<%1 400 %2 400 \"\" 0 0 0 \"\">\n").arg(340+dx).arg(420+dx);
-        s += QString("<%1 380 %2 380 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(260+dx);
-        s += QString("<%1 380 %2 380 \"\" 0 0 0 \"\">\n").arg(260+dx).arg(270+dx);
-        s += QString("<%1 150 %2 220 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(220+dx);
-        s += QString("<%1 150 %2 150 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(300+dx);
-        s += QString("<%1 240 %2 240 \"\" 0 0 0 \"\">\n").arg(310+dx).arg(380+dx);
-        s += QString("<%1 260 %2 290 \"\" 0 0 0 \"\">\n").arg(240+dx).arg(240+dx);
-        s += QString("<%1 220 %2 220 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(240+dx);
-        s += QString("<%1 420 %2 420 \"\" 0 0 0 \"\">\n").arg(250+dx).arg(270+dx);
-        s += QString("<%1 420 %2 440 \"\" 0 0 0 \"\">\n").arg(250+dx).arg(250+dx);
+        s += QStringLiteral("<%1 240 %2 240 \"\" 0 0 0 \"\">\n").arg(440+dx).arg(480+dx);
+        s += QStringLiteral("<%1 400 %2 400 \"\" 0 0 0 \"\">\n").arg(340+dx).arg(420+dx);
+        s += QStringLiteral("<%1 380 %2 380 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(260+dx);
+        s += QStringLiteral("<%1 380 %2 380 \"\" 0 0 0 \"\">\n").arg(260+dx).arg(270+dx);
+        s += QStringLiteral("<%1 150 %2 220 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(220+dx);
+        s += QStringLiteral("<%1 150 %2 150 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(300+dx);
+        s += QStringLiteral("<%1 240 %2 240 \"\" 0 0 0 \"\">\n").arg(310+dx).arg(380+dx);
+        s += QStringLiteral("<%1 260 %2 290 \"\" 0 0 0 \"\">\n").arg(240+dx).arg(240+dx);
+        s += QStringLiteral("<%1 220 %2 220 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(240+dx);
+        s += QStringLiteral("<%1 420 %2 420 \"\" 0 0 0 \"\">\n").arg(250+dx).arg(270+dx);
+        s += QStringLiteral("<%1 420 %2 440 \"\" 0 0 0 \"\">\n").arg(250+dx).arg(250+dx);
 
         int n;
         if ((ftype==Filter::BandPass)||(ftype==Filter::BandStop)) {
@@ -403,25 +403,25 @@ void SchCauer::createGenericSchematic(QString &s)
             n = 2*i;
         }
         if (n==order) {
-            s += QString("<%1 110 %2 260 \"out\" %3 160 101 \"\">\n").arg(610+dx).arg(610+dx).arg(540+dx);
+            s += QStringLiteral("<%1 110 %2 260 \"out\" %3 160 101 \"\">\n").arg(610+dx).arg(610+dx).arg(540+dx);
         } else {
-            s += QString("<%1 110 %2 260 \"\" 0 0 0 \"\">\n").arg(610+dx).arg(610+dx);
+            s += QStringLiteral("<%1 110 %2 260 \"\" 0 0 0 \"\">\n").arg(610+dx).arg(610+dx);
         }
-        s += QString("<%1 110 %2 110 \"\" 0 0 0 \"\">\n").arg(470+dx).arg(610+dx);
-        s += QString("<%1 110 %2 150 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(220+dx);
-        s += QString("<%1 110 %2 110 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(410+dx);
-        s += QString("<%1 220 %2 220 \"\" 0 0 0 \"\">\n").arg(140+dx).arg(150+dx);
-        s += QString("<%1 220 %2 260 \"\" 0 0 0 \"\">\n").arg(140+dx).arg(140+dx);
-        s += QString("<%1 260 %2 380 \"\" 0 0 0 \"\">\n").arg(140+dx).arg(140+dx);
-        s += QString("<%1 380 %2 380 \"\" 0 0 0 \"\">\n").arg(140+dx).arg(160+dx);
-        s += QString("<%1 240 %2 240 \"\" 0 0 0 \"\">\n").arg(480+dx).arg(530+dx);
-        s += QString("<%1 240 %2 400 \"\" 0 0 0 \"\">\n").arg(480+dx).arg(480+dx);
-        s += QString("<%1 320 %2 400 \"\" 0 0 0 \"\">\n").arg(420+dx).arg(420+dx);
-        s += QString("<%1 320 %2 320 \"\" 0 0 0 \"\">\n").arg(390+dx).arg(420+dx);
-        s += QString("<%1 320 %2 380 \"\" 0 0 0 \"\">\n").arg(260+dx).arg(260+dx);
-        s += QString("<%1 320 %2 320 \"\" 0 0 0 \"\">\n").arg(260+dx).arg(330+dx);
-        s += QString("<%1 150 %2 150 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(380+dx);
-        s += QString("<%1 150 %2 240 \"\" 0 0 0 \"\">\n").arg(380+dx).arg(380+dx);
+        s += QStringLiteral("<%1 110 %2 110 \"\" 0 0 0 \"\">\n").arg(470+dx).arg(610+dx);
+        s += QStringLiteral("<%1 110 %2 150 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(220+dx);
+        s += QStringLiteral("<%1 110 %2 110 \"\" 0 0 0 \"\">\n").arg(220+dx).arg(410+dx);
+        s += QStringLiteral("<%1 220 %2 220 \"\" 0 0 0 \"\">\n").arg(140+dx).arg(150+dx);
+        s += QStringLiteral("<%1 220 %2 260 \"\" 0 0 0 \"\">\n").arg(140+dx).arg(140+dx);
+        s += QStringLiteral("<%1 260 %2 380 \"\" 0 0 0 \"\">\n").arg(140+dx).arg(140+dx);
+        s += QStringLiteral("<%1 380 %2 380 \"\" 0 0 0 \"\">\n").arg(140+dx).arg(160+dx);
+        s += QStringLiteral("<%1 240 %2 240 \"\" 0 0 0 \"\">\n").arg(480+dx).arg(530+dx);
+        s += QStringLiteral("<%1 240 %2 400 \"\" 0 0 0 \"\">\n").arg(480+dx).arg(480+dx);
+        s += QStringLiteral("<%1 320 %2 400 \"\" 0 0 0 \"\">\n").arg(420+dx).arg(420+dx);
+        s += QStringLiteral("<%1 320 %2 320 \"\" 0 0 0 \"\">\n").arg(390+dx).arg(420+dx);
+        s += QStringLiteral("<%1 320 %2 380 \"\" 0 0 0 \"\">\n").arg(260+dx).arg(260+dx);
+        s += QStringLiteral("<%1 320 %2 320 \"\" 0 0 0 \"\">\n").arg(260+dx).arg(330+dx);
+        s += QStringLiteral("<%1 150 %2 150 \"\" 0 0 0 \"\">\n").arg(360+dx).arg(380+dx);
+        s += QStringLiteral("<%1 150 %2 240 \"\" 0 0 0 \"\">\n").arg(380+dx).arg(380+dx);
 
         dx +=580;
     }

--- a/qucs-attenuator/attenuatorfunc.cpp
+++ b/qucs-attenuator/attenuatorfunc.cpp
@@ -199,9 +199,9 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
   switch(ATT->Topology)
     {
     case PI_TYPE:
-      *s += QString("<R R1 1 180 200 -15 60 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
-      *s += QString("<R R2 1 255 130 -35 -45 0 0 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R2, 'f', 1));
-      *s += QString("<R R3 1 330 200 -15 60 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R3, 'f', 1));
+      *s += QStringLiteral("<R R1 1 180 200 -15 60 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
+      *s += QStringLiteral("<R R2 1 255 130 -35 -45 0 0 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R2, 'f', 1));
+      *s += QStringLiteral("<R R3 1 330 200 -15 60 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R3, 'f', 1));
       *s += "<GND * 1 180 230 0 0 0 0>\n";
       *s += "<GND * 1 330 230 0 0 0 0>\n";
       if (SP_box)
@@ -216,11 +216,11 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
          *s += "<Eqn Eqn1 1 360 350 -32 19 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"yes\" 0>\n";
 
          // Input term
-         *s += QString("<Pac P1 1 50 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
+         *s += QStringLiteral("<Pac P1 1 50 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
          *s += "<GND * 1 50 230 0 0 0 0>\n";
 
          // Output term
-         *s += QString("<Pac P1 1 460 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
+         *s += QStringLiteral("<Pac P1 1 460 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
          *s += "<GND * 1 460 230 0 0 0 0>\n";
        }
       *s += "</Components>\n";
@@ -244,20 +244,20 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
       *s += "<Diagrams>\n";
       *s += "</Diagrams>\n";
       *s += "<Paintings>\n";
-      *s += QString("<Text 160 60 12 #000000 0 \"%1 dB Pi-Type Attenuator\">\n").arg(ATT->Attenuation);
+      *s += QStringLiteral("<Text 160 60 12 #000000 0 \"%1 dB Pi-Type Attenuator\">\n").arg(ATT->Attenuation);
       if (!SP_box)
          {// If the SP simulation box option is activated, then the input and output ports are attached.
           // Thus, it doesn't make sense to have a text field indicating the input/output impedance
-            *s += QString("<Text 50 122 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
-            *s += QString("<Text 360 122 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(ATT->Zout);
+            *s += QStringLiteral("<Text 50 122 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
+            *s += QStringLiteral("<Text 360 122 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(ATT->Zout);
          }
       *s += "</Paintings>\n";
       break;
 
     case TEE_TYPE:
-      *s += QString("<R R1 1 180 130 -40 20 0 2 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
-      *s += QString("<R R2 1 270 200 -20 60 0 3 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R2, 'f', 1));
-      *s += QString("<R R3 1 350 130 -40 20 0 2 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R3, 'f', 1));
+      *s += QStringLiteral("<R R1 1 180 130 -40 20 0 2 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
+      *s += QStringLiteral("<R R2 1 270 200 -20 60 0 3 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R2, 'f', 1));
+      *s += QStringLiteral("<R R3 1 350 130 -40 20 0 2 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R3, 'f', 1));
       *s += "<GND * 1 270 230 0 0 0 0>\n";
       if (SP_box)
       {
@@ -271,11 +271,11 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
         *s += "<Eqn Eqn1 1 360 350 -32 19 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"yes\" 0>\n";
 
         // Input term
-        *s += QString("<Pac P1 1 70 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
+        *s += QStringLiteral("<Pac P1 1 70 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
         *s += "<GND * 1 70 230 0 0 0 0>\n";
 
         // Output term
-        *s += QString("<Pac P1 1 460 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
+        *s += QStringLiteral("<Pac P1 1 460 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
         *s += "<GND * 1 460 230 0 0 0 0>\n";
       }
       *s +="</Components>\n";
@@ -298,21 +298,21 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
       *s += "<Diagrams>\n";
       *s += "</Diagrams>\n";
       *s += "<Paintings>\n";
-      *s += QString("<Text 170 60 12 #000000 0 \"%1 dB Tee-Type Attenuator\">\n").arg(ATT->Attenuation);
+      *s += QStringLiteral("<Text 170 60 12 #000000 0 \"%1 dB Tee-Type Attenuator\">\n").arg(ATT->Attenuation);
       if (!SP_box)
       {// If the SP simulation box option is activated, then the input and output ports are attached.
        // Thus, it doesn't make sense to have a text field indicating the input/output impedance
-          *s += QString("<Text 50 122 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
-          *s += QString("<Text 390 122 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(ATT->Zout);
+          *s += QStringLiteral("<Text 50 122 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
+          *s += QStringLiteral("<Text 390 122 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(ATT->Zout);
       }
       *s += "</Paintings>\n";
       break;
 
     case BRIDGE_TYPE:
-      *s += QString("<R R1 1 260 130 -30 -45 0 0 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
-      *s += QString("<R R2 1 180 200 -90 -30 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(ATT->Zin);
-      *s += QString("<R R3 1 340 200 11 -30 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(ATT->Zout);
-      *s += QString("<R R4 1 260 260 11 -14 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R2, 'f', 1));
+      *s += QStringLiteral("<R R1 1 260 130 -30 -45 0 0 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
+      *s += QStringLiteral("<R R2 1 180 200 -90 -30 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(ATT->Zin);
+      *s += QStringLiteral("<R R3 1 340 200 11 -30 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(ATT->Zout);
+      *s += QStringLiteral("<R R4 1 260 260 11 -14 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R2, 'f', 1));
       *s += "<GND * 1 260 290 0 0 0 0>\n";
       if (SP_box)
       {
@@ -326,11 +326,11 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
         *s += "<Eqn Eqn1 1 360 350 -32 19 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"yes\" 0>\n";
 
         // Input term
-        *s += QString("<Pac P1 1 50 200 -100 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
+        *s += QStringLiteral("<Pac P1 1 50 200 -100 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
         *s += "<GND * 1 50 230 0 0 0 0>\n";
 
         // Output term
-        *s += QString("<Pac P1 1 460 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
+        *s += QStringLiteral("<Pac P1 1 460 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
         *s += "<GND * 1 460 230 0 0 0 0>\n";
       }
       *s += "</Components>\n";
@@ -355,21 +355,21 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
       *s += "<Diagrams>\n";
       *s += "</Diagrams>\n";
       *s += "<Paintings>\n";
-      *s += QString("<Text 140 60 12 #000000 0 \"%1 dB Bridged-Tee-Type Attenuator\">\n").arg(ATT->Attenuation);
+      *s += QStringLiteral("<Text 140 60 12 #000000 0 \"%1 dB Bridged-Tee-Type Attenuator\">\n").arg(ATT->Attenuation);
       if (!SP_box)
       {// If the SP simulation box option is activated, then the input and output ports are attached.
        // Thus, it doesn't make sense to have a text field indicating the input/output impedance
-          *s += QString("<Text 50 122 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
-          *s += QString("<Text 400 122 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(ATT->Zout);
+          *s += QStringLiteral("<Text 50 122 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
+          *s += QStringLiteral("<Text 400 122 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(ATT->Zout);
       }
       *s += "</Paintings>\n";
       break;
 
       case REFLECTION_TYPE:
-        *s += QString("<R R1 1 130 300 15 -26 0 1 \"%1\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
+        *s += QStringLiteral("<R R1 1 130 300 15 -26 0 1 \"%1\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
         *s += "<GND * 1 130 330 0 0 0 0>\n";
-        *s += QString("<Coupler X1 5 200 200 29 -26 0 1 \"0.7071\" 0 \"90\" 0 \"%1\" 0>\n").arg(ATT->Zin);
-        *s += QString("<R R1 1 270 300 15 -26 0 1 \"%1\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
+        *s += QStringLiteral("<Coupler X1 5 200 200 29 -26 0 1 \"0.7071\" 0 \"90\" 0 \"%1\" 0>\n").arg(ATT->Zin);
+        *s += QStringLiteral("<R R1 1 270 300 15 -26 0 1 \"%1\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
         *s += "<GND * 1 270 330 0 0 0 0>\n";
 
         if (SP_box)
@@ -378,17 +378,17 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
           //-----------------------------
           // Resistor attenuators are broadband ckts, so it's pointless to ask the user to input the analysis freq sweep. Let's do a wideband
           // sweep and then the user can modify that in the schematic
-          *s += QString("<.SP SP1 1 80 400 0 83 0 0 \"lin\" 1 \"50 MHz\" 1 \"3 GHz\" 1 \"200\" 1 \"no\" 0 \"1\" 0 \"2\" 0 \"no\" 0 \"no\" 0>\n");
+          *s += QStringLiteral("<.SP SP1 1 80 400 0 83 0 0 \"lin\" 1 \"50 MHz\" 1 \"3 GHz\" 1 \"200\" 1 \"no\" 0 \"1\" 0 \"2\" 0 \"no\" 0 \"no\" 0>\n");
 
           // Equations
           *s += "<Eqn Eqn1 1 300 400 -32 19 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"yes\" 0>\n";
 
           // Input term
-          *s += QString("<Pac P1 1 50 200 -100 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
+          *s += QStringLiteral("<Pac P1 1 50 200 -100 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
           *s += "<GND * 1 50 230 0 0 0 0>\n";
 
           // Output term
-          *s += QString("<Pac P1 1 350 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
+          *s += QStringLiteral("<Pac P1 1 350 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
           *s += "<GND * 1 350 230 0 0 0 0>\n";
         }
         *s += "</Components>\n";
@@ -421,12 +421,12 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
         *s += "<Diagrams>\n";
         *s += "</Diagrams>\n";
         *s += "<Paintings>\n";
-        *s += QString("<Text 100 100 12 #000000 0 \"%1 dB Reflection Attenuator\">\n").arg(ATT->Attenuation);
+        *s += QStringLiteral("<Text 100 100 12 #000000 0 \"%1 dB Reflection Attenuator\">\n").arg(ATT->Attenuation);
         if (!SP_box)
         {// If the SP simulation box option is activated, then the input and output ports are attached.
          // Thus, it doesn't make sense to have a text field indicating the input/output impedance
-            *s += QString("<Text 70 135 10 #000000 0 \"Z0: %1 Ohm\">\n").arg(ATT->Zin);
-            *s += QString("<Text 270 135 10 #000000 0 \"Z0: %1 Ohm\">\n").arg(ATT->Zout);
+            *s += QStringLiteral("<Text 70 135 10 #000000 0 \"Z0: %1 Ohm\">\n").arg(ATT->Zin);
+            *s += QStringLiteral("<Text 270 135 10 #000000 0 \"Z0: %1 Ohm\">\n").arg(ATT->Zout);
         }
         *s += "</Paintings>\n";
 
@@ -436,20 +436,20 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
         if (ATT->useLumped)
         {
           double w = 2*PI*ATT->freq;
-          *s += QString("<L L1 1 250 0 -40 -60 0 0 \"%1H\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(num2str(ATT->Zin/w));
-          *s += QString("<C C1 1 180 -60 -90 -20 0 1 \"%1F\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(1/(ATT->Zin*w)));
+          *s += QStringLiteral("<L L1 1 250 0 -40 -60 0 0 \"%1H\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(num2str(ATT->Zin/w));
+          *s += QStringLiteral("<C C1 1 180 -60 -90 -20 0 1 \"%1F\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(1/(ATT->Zin*w)));
           *s += "<GND * 1 180 -90 0 0 1 0>\n";
-          *s += QString("<C C1 1 320 -60 20 -20 0 1 \"%1F\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(1/(ATT->Zin*w)));
+          *s += QStringLiteral("<C C1 1 320 -60 20 -20 0 1 \"%1F\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(1/(ATT->Zin*w)));
           *s += "<GND * 1 320 -90 0 0 1 0>\n";
         }
         else
         {
-            *s += QString("<TLIN Line1 1 250 0 -38 -75 0 0 \"%1 Ohm\" 1 \"%2 mm\" 1 \"0 dB\" 0 \"26.85\" 0>\n").arg(ATT->Zin).arg(QString::number(ATT->L*1e3, 'f', 1));
+            *s += QStringLiteral("<TLIN Line1 1 250 0 -38 -75 0 0 \"%1 Ohm\" 1 \"%2 mm\" 1 \"0 dB\" 0 \"26.85\" 0>\n").arg(ATT->Zin).arg(QString::number(ATT->L*1e3, 'f', 1));
         }
-        *s += QString("<R R1 1 100 50 15 -26 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
-        *s += QString("<R R1 1 100 150 15 -26 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(ATT->Zin);
+        *s += QStringLiteral("<R R1 1 100 50 15 -26 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
+        *s += QStringLiteral("<R R1 1 100 150 15 -26 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(ATT->Zin);
         *s += "<GND * 1 100 180 0 0 0 0>\n";
-        *s += QString("<R R1 1 400 150 -100 -15 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
+        *s += QStringLiteral("<R R1 1 400 150 -100 -15 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
         *s += "<GND * 1 400 180 0 0 0 0>\n";
 
         if (SP_box)
@@ -457,19 +457,19 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
           // S-parameter simulation block
           //-----------------------------
           // The quarter-wave line is a narrowband device... so let's set the SP sweep from f0/2 to 3*f0/2
-          QString freq_start = QString("%1").arg(0.5*ATT->freq*1e-6);//MHz
-          QString freq_stop = QString("%1").arg(1.5*ATT->freq*1e-6);//MHz
-          *s += QString("<.SP SP1 1 100 270 0 83 0 0 \"lin\" 1 \"%1 MHz\" 1 \"%2 MHz\" 1 \"200\" 1 \"no\" 0 \"1\" 0 \"2\" 0 \"no\" 0 \"no\" 0>\n").arg(freq_start).arg(freq_stop);
+          QString freq_start = QStringLiteral("%1").arg(0.5*ATT->freq*1e-6);//MHz
+          QString freq_stop = QStringLiteral("%1").arg(1.5*ATT->freq*1e-6);//MHz
+          *s += QStringLiteral("<.SP SP1 1 100 270 0 83 0 0 \"lin\" 1 \"%1 MHz\" 1 \"%2 MHz\" 1 \"200\" 1 \"no\" 0 \"1\" 0 \"2\" 0 \"no\" 0 \"no\" 0>\n").arg(freq_start).arg(freq_stop);
 
           // Equations
           *s += "<Eqn Eqn1 1 320 270 -32 19 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"yes\" 0>\n";
 
           // Input term
-          *s += QString("<Pac P1 1 0 150 -100 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
+          *s += QStringLiteral("<Pac P1 1 0 150 -100 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
           *s += "<GND * 1 0 180 0 0 0 0>\n";
 
           // Output term
-          *s += QString("<Pac P1 1 500 150 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
+          *s += QStringLiteral("<Pac P1 1 500 150 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
           *s += "<GND * 1 500 180 0 0 0 0>\n";
         }
         *s += "</Components>\n";
@@ -502,14 +502,14 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
         *s += "<Paintings>\n";
 
         //In the case of the Pi-equivalent of the quarter wavelength line it is needed to put the title slighly higher.
-        if (ATT->useLumped) *s += QString("<Text 80 -140 12 #000000 0 \"%1 dB @ %2Hz Quarter-Wave series attenuator\">\n").arg(ATT->Attenuation).arg(num2str(ATT->freq));
-        else *s += QString("<Text 80 -120 12 #000000 0 \"%1 dB @ %2Hz Quarter-Wave series attenuator\">\n").arg(ATT->Attenuation).arg(num2str(ATT->freq));
+        if (ATT->useLumped) *s += QStringLiteral("<Text 80 -140 12 #000000 0 \"%1 dB @ %2Hz Quarter-Wave series attenuator\">\n").arg(ATT->Attenuation).arg(num2str(ATT->freq));
+        else *s += QStringLiteral("<Text 80 -120 12 #000000 0 \"%1 dB @ %2Hz Quarter-Wave series attenuator\">\n").arg(ATT->Attenuation).arg(num2str(ATT->freq));
 
         if (!SP_box)
         {// If the SP simulation box option is activated, then the input and output ports are attached.
          // Thus, it doesn't make sense to have a text field indicating the input/output impedance
-            *s += QString("<Text 50 -30 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
-            *s += QString("<Text 390 -30 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(ATT->Zout);
+            *s += QStringLiteral("<Text 50 -30 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
+            *s += QStringLiteral("<Text 390 -30 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(ATT->Zout);
         }
         *s += "</Paintings>\n";
         break;
@@ -517,40 +517,40 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
         if (ATT->useLumped)
         {
            double w = 2*PI*ATT->freq;
-           *s += QString("<L L1 1 200 60 20 -35 0 1 \"%1H\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(num2str(ATT->Zin/w));
-           *s += QString("<C C1 1 200 -60 -90 -20 0 1 \"%1F\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(1/(ATT->Zin*w)));
+           *s += QStringLiteral("<L L1 1 200 60 20 -35 0 1 \"%1H\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(num2str(ATT->Zin/w));
+           *s += QStringLiteral("<C C1 1 200 -60 -90 -20 0 1 \"%1F\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(1/(ATT->Zin*w)));
            *s += "<GND * 1 200 -90 0 0 1 0>\n";
-           *s += QString("<C C1 1 320 150 0 60 0 1 \"%1F\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(1/(ATT->Zin*w)));
+           *s += QStringLiteral("<C C1 1 320 150 0 60 0 1 \"%1F\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(1/(ATT->Zin*w)));
            *s += "<GND * 1 320 180 0 0 0 0>\n";
         }
         else
         {
-           *s += QString("<TLIN Line1 1 200 60 20 -35 0 1 \"%1 Ohm\" 1 \"%2 mm\" 1 \"0 dB\" 0 \"26.85\" 0>\n").arg(ATT->Zin).arg(QString::number(ATT->L*1e3, 'f', 1));
+           *s += QStringLiteral("<TLIN Line1 1 200 60 20 -35 0 1 \"%1 Ohm\" 1 \"%2 mm\" 1 \"0 dB\" 0 \"26.85\" 0>\n").arg(ATT->Zin).arg(QString::number(ATT->L*1e3, 'f', 1));
         }
-        *s += QString("<R R1 1 160 150 -40 60 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
+        *s += QStringLiteral("<R R1 1 160 150 -40 60 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
         *s += "<GND * 1 160 180 0 0 0 0>\n";
-        *s += QString("<R R1 1 240 150 -20 60 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(ATT->Zin);
+        *s += QStringLiteral("<R R1 1 240 150 -20 60 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(ATT->Zin);
         *s += "<GND * 1 240 180 0 0 0 0>\n";
-        *s += QString("<R R1 1 300 0 -30 -60 0 0 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
+        *s += QStringLiteral("<R R1 1 300 0 -30 -60 0 0 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
 
         if (SP_box)
         {
            // S-parameter simulation block
            //-----------------------------
            // The quarter-wave line is a narrowband device... so let's set the SP sweep from f0/2 to 3*f0/2
-           QString freq_start = QString("%1").arg(0.5*ATT->freq*1e-6);//MHz
-           QString freq_stop = QString("%1").arg(1.5*ATT->freq*1e-6);//MHz
-           *s += QString("<.SP SP1 1 100 270 0 83 0 0 \"lin\" 1 \"%1 MHz\" 1 \"%2 MHz\" 1 \"200\" 1 \"no\" 0 \"1\" 0 \"2\" 0 \"no\" 0 \"no\" 0>\n").arg(freq_start).arg(freq_stop);
+           QString freq_start = QStringLiteral("%1").arg(0.5*ATT->freq*1e-6);//MHz
+           QString freq_stop = QStringLiteral("%1").arg(1.5*ATT->freq*1e-6);//MHz
+           *s += QStringLiteral("<.SP SP1 1 100 270 0 83 0 0 \"lin\" 1 \"%1 MHz\" 1 \"%2 MHz\" 1 \"200\" 1 \"no\" 0 \"1\" 0 \"2\" 0 \"no\" 0 \"no\" 0>\n").arg(freq_start).arg(freq_stop);
 
            // Equations
            *s += "<Eqn Eqn1 1 320 270 -32 19 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"yes\" 0>\n";
 
            // Input term
-           *s += QString("<Pac P1 1 0 150 -100 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
+           *s += QStringLiteral("<Pac P1 1 0 150 -100 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
            *s += "<GND * 1 0 180 0 0 0 0>\n";
 
            // Output term
-           *s += QString("<Pac P1 1 500 150 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
+           *s += QStringLiteral("<Pac P1 1 500 150 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
            *s += "<GND * 1 500 180 0 0 0 0>\n";
         }
         *s += "</Components>\n";
@@ -594,20 +594,20 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
         *s += "<Paintings>\n";
 
         //Put the title a little bit higher because of the shunt cpa
-        if (ATT->useLumped) *s += QString("<Text 80 -140 12 #000000 0 \"%1 dB @ %2Hz Quarter-Wave shunt attenuator\">\n").arg(ATT->Attenuation).arg(num2str(ATT->freq));
-        else *s += QString("<Text 80 -120 12 #000000 0 \"%1 dB @ %2Hz Quarter-Wave shunt attenuator\">\n").arg(ATT->Attenuation).arg(num2str(ATT->freq));
+        if (ATT->useLumped) *s += QStringLiteral("<Text 80 -140 12 #000000 0 \"%1 dB @ %2Hz Quarter-Wave shunt attenuator\">\n").arg(ATT->Attenuation).arg(num2str(ATT->freq));
+        else *s += QStringLiteral("<Text 80 -120 12 #000000 0 \"%1 dB @ %2Hz Quarter-Wave shunt attenuator\">\n").arg(ATT->Attenuation).arg(num2str(ATT->freq));
 
         if (!SP_box)
         {// If the SP simulation box option is activated, then the input and output ports are attached.
          // Thus, it doesn't make sense to have a text field indicating the input/output impedance
-            *s += QString("<Text 50 -30 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
-            *s += QString("<Text 390 -30 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(ATT->Zout);
+            *s += QStringLiteral("<Text 50 -30 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
+            *s += QStringLiteral("<Text 390 -30 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(ATT->Zout);
         }
         *s += "</Paintings>\n";
         break;
       case L_PAD_1ST_SERIES:
-          *s += QString("<R R1 1 255 130 -35 -45 0 0 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
-          *s += QString("<R R2 1 330 200 -15 60 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R2, 'f', 1));
+          *s += QStringLiteral("<R R1 1 255 130 -35 -45 0 0 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
+          *s += QStringLiteral("<R R2 1 330 200 -15 60 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R2, 'f', 1));
           *s += "<GND * 1 330 230 0 0 0 0>\n";
           if (SP_box)
            {
@@ -621,11 +621,11 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
              *s += "<Eqn Eqn1 1 360 350 -32 19 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"yes\" 0>\n";
 
              // Input term
-             *s += QString("<Pac P1 1 50 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
+             *s += QStringLiteral("<Pac P1 1 50 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
              *s += "<GND * 1 50 230 0 0 0 0>\n";
 
              // Output term
-             *s += QString("<Pac P1 1 460 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
+             *s += QStringLiteral("<Pac P1 1 460 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
              *s += "<GND * 1 460 230 0 0 0 0>\n";
            }
           *s += "</Components>\n";
@@ -648,19 +648,19 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
           *s += "<Diagrams>\n";
           *s += "</Diagrams>\n";
           *s += "<Paintings>\n";
-          *s += QString("<Text 160 60 12 #000000 0 \"%1 dB L-pad 1st Series Attenuator\">\n").arg(ATT->Attenuation);
+          *s += QStringLiteral("<Text 160 60 12 #000000 0 \"%1 dB L-pad 1st Series Attenuator\">\n").arg(ATT->Attenuation);
           if (!SP_box)
              {// If the SP simulation box option is activated, then the input and output ports are attached.
               // Thus, it doesn't make sense to have a text field indicating the input/output impedance
-                *s += QString("<Text 50 122 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
-                *s += QString("<Text 360 122 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(QString::number(ATT->R3, 'f', 1));
+                *s += QStringLiteral("<Text 50 122 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
+                *s += QStringLiteral("<Text 360 122 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(QString::number(ATT->R3, 'f', 1));
              }
           *s += "</Paintings>\n";
           break;
 
       case L_PAD_1ST_SHUNT:
-          *s += QString("<R R1 1 180 200 -15 60 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
-          *s += QString("<R R2 1 255 130 -35 -45 0 0 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R2, 'f', 1));
+          *s += QStringLiteral("<R R1 1 180 200 -15 60 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
+          *s += QStringLiteral("<R R2 1 255 130 -35 -45 0 0 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R2, 'f', 1));
           *s += "<GND * 1 180 230 0 0 0 0>\n";
 
           if (SP_box)
@@ -675,11 +675,11 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
              *s += "<Eqn Eqn1 1 360 350 -32 19 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"yes\" 0>\n";
 
              // Input term
-             *s += QString("<Pac P1 1 50 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
+             *s += QStringLiteral("<Pac P1 1 50 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
              *s += "<GND * 1 50 230 0 0 0 0>\n";
 
              // Output term
-             *s += QString("<Pac P1 1 460 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
+             *s += QStringLiteral("<Pac P1 1 460 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
              *s += "<GND * 1 460 230 0 0 0 0>\n";
            }
           *s += "</Components>\n";
@@ -702,17 +702,17 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
           *s += "<Diagrams>\n";
           *s += "</Diagrams>\n";
           *s += "<Paintings>\n";
-          *s += QString("<Text 160 60 12 #000000 0 \"%1 dB L-pad 1st Shunt Attenuator\">\n").arg(ATT->Attenuation);
+          *s += QStringLiteral("<Text 160 60 12 #000000 0 \"%1 dB L-pad 1st Shunt Attenuator\">\n").arg(ATT->Attenuation);
           if (!SP_box)
              {// If the SP simulation box option is activated, then the input and output ports are attached.
               // Thus, it doesn't make sense to have a text field indicating the input/output impedance
-                *s += QString("<Text 50 122 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
-                *s += QString("<Text 360 122 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(QString::number(ATT->R3, 'f', 1));
+                *s += QStringLiteral("<Text 50 122 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
+                *s += QStringLiteral("<Text 360 122 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(QString::number(ATT->R3, 'f', 1));
              }
           *s += "</Paintings>\n";
       break;
      case R_SERIES:
-      *s += QString("<R R1 1 255 130 -35 -45 0 0 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
+      *s += QStringLiteral("<R R1 1 255 130 -35 -45 0 0 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
       if (SP_box)
        {
          // S-parameter simulation block
@@ -725,11 +725,11 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
          *s += "<Eqn Eqn1 1 360 350 -32 19 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"yes\" 0>\n";
 
          // Input term
-         *s += QString("<Pac P1 1 50 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
+         *s += QStringLiteral("<Pac P1 1 50 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
          *s += "<GND * 1 50 230 0 0 0 0>\n";
 
          // Output term
-         *s += QString("<Pac P1 1 460 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
+         *s += QStringLiteral("<Pac P1 1 460 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
          *s += "<GND * 1 460 230 0 0 0 0>\n";
        }
       *s += "</Components>\n";
@@ -752,19 +752,19 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
       *s += "<Diagrams>\n";
       *s += "</Diagrams>\n";
       *s += "<Paintings>\n";
-      *s += QString("<Text 160 60 12 #000000 0 \"%1 dB R Series Attenuator\">\n").arg(ATT->Attenuation);
+      *s += QStringLiteral("<Text 160 60 12 #000000 0 \"%1 dB R Series Attenuator\">\n").arg(ATT->Attenuation);
       if (!SP_box)
          {// If the SP simulation box option is activated, then the input and output ports are attached.
           // Thus, it doesn't make sense to have a text field indicating the input/output impedance
-            *s += QString("<Text 50 122 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
-            *s += QString("<Text 360 122 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(ATT->Zout);
+            *s += QStringLiteral("<Text 50 122 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
+            *s += QStringLiteral("<Text 360 122 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(ATT->Zout);
          }
       *s += "</Paintings>\n";
       break;
 
       case R_SHUNT:
 
-        *s += QString("<R R1 1 250 200 -15 60 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
+        *s += QStringLiteral("<R R1 1 250 200 -15 60 0 1 \"%1 Ohm\" 1 \"26.85\" 0 \"0.0\" 0 \"0.0\" 0 \"26.85\" 0 \"US\" 0>\n").arg(QString::number(ATT->R1, 'f', 1));
         *s += "<GND * 1 250 230 0 0 0 0>\n";
         if (SP_box)
          {
@@ -778,11 +778,11 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
            *s += "<Eqn Eqn1 1 360 350 -32 19 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"yes\" 0>\n";
 
            // Input term
-           *s += QString("<Pac P1 1 50 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
+           *s += QStringLiteral("<Pac P1 1 50 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zin);
            *s += "<GND * 1 50 230 0 0 0 0>\n";
 
            // Output term
-           *s += QString("<Pac P1 1 460 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
+           *s += QStringLiteral("<Pac P1 1 460 200 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n").arg(ATT->Zout);
            *s += "<GND * 1 460 230 0 0 0 0>\n";
          }
         *s += "</Components>\n";
@@ -804,12 +804,12 @@ QString* QUCS_Att::createSchematic(tagATT *ATT, bool SP_box)
         *s += "<Diagrams>\n";
         *s += "</Diagrams>\n";
         *s += "<Paintings>\n";
-        *s += QString("<Text 160 60 12 #000000 0 \"%1 dB Shunt R Attenuator\">\n").arg(ATT->Attenuation);
+        *s += QStringLiteral("<Text 160 60 12 #000000 0 \"%1 dB Shunt R Attenuator\">\n").arg(ATT->Attenuation);
         if (!SP_box)
            {// If the SP simulation box option is activated, then the input and output ports are attached.
             // Thus, it doesn't make sense to have a text field indicating the input/output impedance
-              *s += QString("<Text 50 122 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
-              *s += QString("<Text 360 122 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(ATT->Zout);
+              *s += QStringLiteral("<Text 50 122 10 #000000 0 \"Z1: %1 Ohm\">\n").arg(ATT->Zin);
+              *s += QStringLiteral("<Text 360 122 10 #000000 0 \"Z2: %1 Ohm\">\n").arg(ATT->Zout);
            }
         *s += "</Paintings>\n";
         break;

--- a/qucs-attenuator/main.cpp
+++ b/qucs-attenuator/main.cpp
@@ -94,7 +94,7 @@ int main( int argc, char ** argv )
   QString lang = QucsSettings.Language;
   if(lang.isEmpty())
     lang = QString(QLocale::system().name());
-  tor.load( QString("qucs_") + lang, QucsSettings.LangDir);
+  tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir);
   a.installTranslator( &tor );
 
   QucsAttenuator *qucs = new QucsAttenuator();

--- a/qucs-attenuator/qucsattenuator.cpp
+++ b/qucs-attenuator/qucsattenuator.cpp
@@ -171,10 +171,10 @@ QucsAttenuator::QucsAttenuator()
   powerunits.append("mW");
   powerunits.append("W");
   powerunits.append("dBm");
-  powerunits.append(QString("dB%1V [75%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)));
-  powerunits.append(QString("dB%1V [50%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)));
-  powerunits.append(QString("dBmV [75%1]").arg(QChar(0xa9, 0x03)));
-  powerunits.append(QString("dBmV [50%1]").arg(QChar(0xa9, 0x03)));
+  powerunits.append(QStringLiteral("dB%1V [75%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)));
+  powerunits.append(QStringLiteral("dB%1V [50%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)));
+  powerunits.append(QStringLiteral("dBmV [75%1]").arg(QChar(0xa9, 0x03)));
+  powerunits.append(QStringLiteral("dBmV [50%1]").arg(QChar(0xa9, 0x03)));
   Combo_InputPowerUnits = new QComboBox();
   Combo_InputPowerUnits->addItems(powerunits);
   Combo_InputPowerUnits->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
@@ -696,7 +696,7 @@ void QucsAttenuator::slotCalculate()
       lineEdit_R3->setText(QString::number(Values.R3, 'f', 1));
       lineEdit_R4->setText(QString::number(Values.R4, 'f', 1));
 
-      lineEdit_R1_Pdiss->setText(QString::number(ConvertPowerUnits(Values.PR1, QString("W"), ComboR1_PowerUnits->currentText()), 'f', 5));
+      lineEdit_R1_Pdiss->setText(QString::number(ConvertPowerUnits(Values.PR1, QStringLiteral("W"), ComboR1_PowerUnits->currentText()), 'f', 5));
       lineEdit_R2_Pdiss->setText(QString::number(ConvertPowerUnits(Values.PR2, "W", ComboR2_PowerUnits->currentText()), 'f', 5));
       lineEdit_R3_Pdiss->setText(QString::number(ConvertPowerUnits(Values.PR3, "W", ComboR3_PowerUnits->currentText()), 'f', 5));
       lineEdit_R4_Pdiss->setText(QString::number(ConvertPowerUnits(Values.PR4, "W", ComboR4_PowerUnits->currentText()), 'f', 5));
@@ -744,7 +744,7 @@ void QucsAttenuator::slot_ComboR1PowerUnits_Changed(const QString& new_units)
    //Convert power
    double P = lineEdit_R1_Pdiss->text().toDouble();
    P =ConvertPowerUnits(P, LastUnits[1], new_units);
-   lineEdit_R1_Pdiss->setText(QString("%1").arg(P));
+   lineEdit_R1_Pdiss->setText(QStringLiteral("%1").arg(P));
    LastUnits[1] = new_units;
 
    //Change lineedit input policy
@@ -761,7 +761,7 @@ void QucsAttenuator::slot_ComboR2PowerUnits_Changed(const QString& new_units)
    //Convert power
    double P = lineEdit_R2_Pdiss->text().toDouble();
    P =ConvertPowerUnits(P, LastUnits[2], new_units);
-   lineEdit_R2_Pdiss->setText(QString("%1").arg(P));
+   lineEdit_R2_Pdiss->setText(QStringLiteral("%1").arg(P));
    LastUnits[2] = new_units;
 
    //Change lineedit input policy
@@ -778,7 +778,7 @@ void QucsAttenuator::slot_ComboR3PowerUnits_Changed(const QString& new_units)
    //Convert power
    double P = lineEdit_R3_Pdiss->text().toDouble();
       P =ConvertPowerUnits(P, LastUnits[3], new_units);
-   lineEdit_R3_Pdiss->setText(QString("%1").arg(P));
+   lineEdit_R3_Pdiss->setText(QStringLiteral("%1").arg(P));
    LastUnits[3] = new_units;
 
    //Change lineedit input policy
@@ -795,7 +795,7 @@ void QucsAttenuator::slot_ComboR4PowerUnits_Changed(const QString& new_units)
    //Convert power
    double P = lineEdit_R4_Pdiss->text().toDouble();
    P =ConvertPowerUnits(P, LastUnits[4], new_units);
-   lineEdit_R4_Pdiss->setText(QString("%1").arg(P));
+   lineEdit_R4_Pdiss->setText(QStringLiteral("%1").arg(P));
    LastUnits[4] = new_units;
 
    //Change lineedit input policy
@@ -817,16 +817,16 @@ double QucsAttenuator::ConvertPowerUnits(double Pin, QString from_units, QString
       if (from_units == "dBm")
           Pin = pow(10, 0.1*(Pin-30));//dBm -> W
       else
-          if (from_units == QString("dB%1V [75%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
+          if (from_units == QStringLiteral("dB%1V [75%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
               Pin = pow(10, (0.1*Pin-12))/75;//dBuV [75Ohm] -> W
          else
-             if (from_units == QString("dB%1V [50%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
+             if (from_units == QStringLiteral("dB%1V [50%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
                  Pin = pow(10, (0.1*Pin-12))/50;//dBuV [50Ohm] -> W
              else
-                 if (from_units == QString("dBmV [75%2]").arg(QChar(0xa9, 0x03)))
+                 if (from_units == QStringLiteral("dBmV [75%2]").arg(QChar(0xa9, 0x03)))
                      Pin = pow(10, (0.1*Pin-6))/75;//dBmV [75Ohm] -> W
                  else
-                     if (from_units == QString("dBmV [50%2]").arg(QChar(0xa9, 0x03)))
+                     if (from_units == QStringLiteral("dBmV [50%2]").arg(QChar(0xa9, 0x03)))
                          Pin = pow(10, (0.1*Pin-6))/50;//dBmV [50Ohm] -> W
                      else
                          if (from_units == "mW")
@@ -842,16 +842,16 @@ double QucsAttenuator::ConvertPowerUnits(double Pin, QString from_units, QString
   if (to_units == "dBm")
       return Pin;//Already done
   else
-      if (to_units == QString("dB%1V [75%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
+      if (to_units == QStringLiteral("dB%1V [75%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
           Pin += 108.7506126339170004686755011380612925566374910126647878220;//W -> dBuV [75Ohm]
       else
-          if (to_units == QString("dB%1V [50%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
+          if (to_units == QStringLiteral("dB%1V [50%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
               Pin += 106.9897000433601880478626110527550697323181011853789145868;//W -> dBuV [50Ohm]
           else
-              if (to_units == QString("dBmV [75%2]").arg(QChar(0xa9, 0x03)))
+              if (to_units == QStringLiteral("dBmV [75%2]").arg(QChar(0xa9, 0x03)))
                   Pin += 48.7506126339170004686755011380612925566374910126647878220;//W -> dBmV [75Ohm]
               else
-                  if (to_units == QString("dBmV [50%2]").arg(QChar(0xa9, 0x03)))
+                  if (to_units == QStringLiteral("dBmV [50%2]").arg(QChar(0xa9, 0x03)))
                       Pin += 46.9897000433601880478626110527550697323181011853789145868;//W -> dBmV [50Ohm]
 
   return Pin;

--- a/qucs-filter/cline_filter.cpp
+++ b/qucs-filter/cline_filter.cpp
@@ -39,8 +39,8 @@ QString* CoupledLine_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
 
   x = 60;
   *s += "<Components>\n";
-  *s += QString("<Pac P1 1 %1 380 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
-  *s += QString("<GND * 1 %1 410 0 0 0 0>\n").arg(x);
+  *s += QStringLiteral("<Pac P1 1 %1 380 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
+  *s += QStringLiteral("<GND * 1 %1 410 0 0 0 0>\n").arg(x);
 
   x -= 30;
   y  = 170;
@@ -79,15 +79,15 @@ QString* CoupledLine_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
     if(isMicrostrip) {
       y += 40;
       len -= dl * Substrate->height;
-      *s += QString("<MCOUPLED MS1 1 %1 %2 -26 37 0 0 \"Sub1\" 1 \"%3\" 1 \"%4\" 1 \"%5\" 1 \"Kirschning\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(x).arg(y).arg(num2str(width)).arg(num2str(len)).arg(num2str(gap));
-      *s += QString("<MOPEN MS1 1 %1 %2 -12 15 1 2 \"Sub1\" 1 \"%3\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x-60).arg(y+30).arg(num2str(width));
-      *s += QString("<MOPEN MS1 1 %1 %2 -26 -81 1 0 \"Sub1\" 1 \"%3\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x+60).arg(y-30).arg(num2str(width));
+      *s += QStringLiteral("<MCOUPLED MS1 1 %1 %2 -26 37 0 0 \"Sub1\" 1 \"%3\" 1 \"%4\" 1 \"%5\" 1 \"Kirschning\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(x).arg(y).arg(num2str(width)).arg(num2str(len)).arg(num2str(gap));
+      *s += QStringLiteral("<MOPEN MS1 1 %1 %2 -12 15 1 2 \"Sub1\" 1 \"%3\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x-60).arg(y+30).arg(num2str(width));
+      *s += QStringLiteral("<MOPEN MS1 1 %1 %2 -26 -81 1 0 \"Sub1\" 1 \"%3\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x+60).arg(y-30).arg(num2str(width));
       y += 20;
       x += 60;
     }
     else {
       y += 20;
-      *s += QString("<CTLIN Line1 1 %1 %2 -26 16 0 0 \"%3\" 1 \"%4\" 1 \"%5\" 1 \"1\" 0 \"1\" 0 \"0 dB\" 0 \"0 dB\" 0 \"26.85\" 0>\n").arg(x).arg(y).arg(Z0e).arg(Z0o).arg(num2str(len));
+      *s += QStringLiteral("<CTLIN Line1 1 %1 %2 -26 16 0 0 \"%3\" 1 \"%4\" 1 \"%5\" 1 \"1\" 0 \"1\" 0 \"0 dB\" 0 \"0 dB\" 0 \"26.85\" 0>\n").arg(x).arg(y).arg(Z0e).arg(Z0o).arg(num2str(len));
     }
   }
 
@@ -96,25 +96,25 @@ QString* CoupledLine_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
     x += 20;
   else
     x += 80;
-  *s += QString("<Pac P2 1 %1 %2 18 -26 0 1 \"2\" 1 \"%3 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(y+70).arg(Filter->Impedance);
-  *s += QString("<GND * 1 %1 %2 0 0 0 0>\n").arg(x).arg(y+100);
+  *s += QStringLiteral("<Pac P2 1 %1 %2 18 -26 0 1 \"2\" 1 \"%3 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(y+70).arg(Filter->Impedance);
+  *s += QStringLiteral("<GND * 1 %1 %2 0 0 0 0>\n").arg(x).arg(y+100);
 
-  *s += QString("<.SP SP1 1 70 460 0 67 0 0 \"lin\" 1 \"%2Hz\" 1 \"%3Hz\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(num2str(2.0 * Filter->Frequency  - Filter->Frequency2)).arg(num2str(2.0 * Filter->Frequency2 - Filter->Frequency));
+  *s += QStringLiteral("<.SP SP1 1 70 460 0 67 0 0 \"lin\" 1 \"%2Hz\" 1 \"%3Hz\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(num2str(2.0 * Filter->Frequency  - Filter->Frequency2)).arg(num2str(2.0 * Filter->Frequency2 - Filter->Frequency));
   if(isMicrostrip)
-    *s += QString("<SUBST Sub1 1 310 500 -30 24 0 0 \"%1\" 1 \"%2m\" 1 \"%3m\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate->er).arg(num2str(Substrate->height)).arg(num2str(Substrate->thickness)).arg(Substrate->tand).arg(Substrate->resistivity).arg(Substrate->roughness);
-  *s += QString("<Eqn Eqn1 1 450 560 -28 15 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"yes\" 0>\n");
+    *s += QStringLiteral("<SUBST Sub1 1 310 500 -30 24 0 0 \"%1\" 1 \"%2m\" 1 \"%3m\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate->er).arg(num2str(Substrate->height)).arg(num2str(Substrate->thickness)).arg(Substrate->tand).arg(Substrate->resistivity).arg(Substrate->roughness);
+  *s += QStringLiteral("<Eqn Eqn1 1 450 560 -28 15 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"yes\" 0>\n");
   *s += "</Components>\n";
 
   *s += "<Wires>\n";
 
   // connect left source
-  *s += QString("<60 180 60 350 \"\" 0 0 0>\n");
-  *s += QString("<60 180 90 180 \"\" 0 0 0>\n");
+  *s += QStringLiteral("<60 180 60 350 \"\" 0 0 0>\n");
+  *s += QStringLiteral("<60 180 90 180 \"\" 0 0 0>\n");
 
   // connect right source
   y += 10;
-  *s += QString("<%1 %2 %3 %4 \"\" 0 0 0>\n").arg(x).arg(y).arg(x).arg(y+30);
-  *s += QString("<%1 %2 %3 %4 \"\" 0 0 0>\n").arg(x-50).arg(y).arg(x).arg(y);
+  *s += QStringLiteral("<%1 %2 %3 %4 \"\" 0 0 0>\n").arg(x).arg(y).arg(x).arg(y+30);
+  *s += QStringLiteral("<%1 %2 %3 %4 \"\" 0 0 0>\n").arg(x-50).arg(y).arg(x).arg(y);
 
   // wires between components
   x = 150;
@@ -125,7 +125,7 @@ QString* CoupledLine_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
     y += 40;
   }
   for(i = 0; i < Filter->Order; i++) {
-    *s += QString("<%1 %2 %3 %4 \"\" 0 0 0>\n").arg(x).arg(y).arg(x+dx).arg(y);
+    *s += QStringLiteral("<%1 %2 %3 %4 \"\" 0 0 0>\n").arg(x).arg(y).arg(x+dx).arg(y);
     if(isMicrostrip) {
       x += 150;
       y += 60;
@@ -143,15 +143,15 @@ QString* CoupledLine_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
 
   *s += "<Paintings>\n";
 
-  *s += QString("<Text 70 650 12 #000000 0 \"Coupled-line bandpass filter \\n ");
+  *s += QStringLiteral("<Text 70 650 12 #000000 0 \"Coupled-line bandpass filter \\n ");
   switch(Filter->Type) {
-    case TYPE_BESSEL:      *s += QString("Bessel"); break;
-    case TYPE_BUTTERWORTH: *s += QString("Butterworth"); break;
-    case TYPE_CHEBYSHEV:   *s += QString("Chebyshev"); break;
+    case TYPE_BESSEL:      *s += QStringLiteral("Bessel"); break;
+    case TYPE_BUTTERWORTH: *s += QStringLiteral("Butterworth"); break;
+    case TYPE_CHEBYSHEV:   *s += QStringLiteral("Chebyshev"); break;
   }
 
-  *s += QString(" %1Hz...%2Hz \\n ").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2));
-  *s += QString("Impedance matching %3 Ohm\">\n").arg(Filter->Impedance);
+  *s += QStringLiteral(" %1Hz...%2Hz \\n ").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2));
+  *s += QStringLiteral("Impedance matching %3 Ohm\">\n").arg(Filter->Impedance);
   *s += "</Paintings>\n";
 
   return s;

--- a/qucs-filter/eqn_filter.cpp
+++ b/qucs-filter/eqn_filter.cpp
@@ -50,11 +50,11 @@ QString* Equation_Filter::createSchematic(tFilter *Filter)
   }
 
   // create the Qucs schematic
-  QString *s = new QString("<Qucs Schematic " PACKAGE_VERSION ">\n");
+  QString *s = new QString("<qucs Schematic " PACKAGE_VERSION ">\n");
 
   *s += "<Components>\n";
-  *s += QString("<Pac P1 1 100 30 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Filter->Impedance);
-  *s += QString("<GND * 1 100 60 0 0 0 0>\n");
+  *s += QStringLiteral("<Pac P1 1 100 30 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Filter->Impedance);
+  *s += QStringLiteral("<GND * 1 100 60 0 0 0 0>\n");
 
   QString eqn = "2";  // because of 50ohms input and output
 
@@ -77,11 +77,11 @@ QString* Equation_Filter::createSchematic(tFilter *Filter)
       Omega = 1.0 / Omega;
       break;
     case CLASS_BANDPASS:  // transform to bandpass
-      varS = QString("*(S+%1/S)").arg(Omega*Omega);
+      varS = QStringLiteral("*(S+%1/S)").arg(Omega*Omega);
       Omega = 0.5 / pi / fabs(Filter->Frequency2 - Filter->Frequency);
       break;
     case CLASS_BANDSTOP:  // transform to bandstop
-      varS = QString("/(S+%1/S)").arg(Omega*Omega);
+      varS = QStringLiteral("/(S+%1/S)").arg(Omega*Omega);
       Omega = 2.0 * pi * fabs(Filter->Frequency2 - Filter->Frequency);
       break;
   }
@@ -89,35 +89,35 @@ QString* Equation_Filter::createSchematic(tFilter *Filter)
 
   if(Filter->Order & 1) {
     a = getQuadraticNormValues(0, Filter, b);
-    eqn += QString(" / (1 + %1%2)").arg(a / Omega).arg(varS);
+    eqn += QStringLiteral(" / (1 + %1%2)").arg(a / Omega).arg(varS);
   }
   for(i = 1; i <= Filter->Order/2; i++) {
     a = getQuadraticNormValues(i, Filter, b);
-    eqn += QString(" / (1 + %1%2 + %3%4%5)")
+    eqn += QStringLiteral(" / (1 + %1%2 + %3%4%5)")
            .arg(a/Omega).arg(varS).arg(b/Omega/Omega).arg(varS).arg(varS);
   }
 
 
-  *s += QString("<RFEDD X1 1 260 0 -26 21 0 0 \"G\" 0 \"2\" 0 \"open\" 0 \"%1\" 1 \"0\" 1 \"%2\" 1 \"%3\" 1>\n").arg(1.0/Filter->Impedance).arg(eqn).arg(Filter->Impedance);
+  *s += QStringLiteral("<RFEDD X1 1 260 0 -26 21 0 0 \"G\" 0 \"2\" 0 \"open\" 0 \"%1\" 1 \"0\" 1 \"%2\" 1 \"%3\" 1>\n").arg(1.0/Filter->Impedance).arg(eqn).arg(Filter->Impedance);
 
-  *s += QString("<Pac P2 1 400 30 18 -26 0 1 \"2\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Filter->Impedance);
-  *s += QString("<GND * 1 400 60 0 0 0 0>\n");
+  *s += QStringLiteral("<Pac P2 1 400 30 18 -26 0 1 \"2\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Filter->Impedance);
+  *s += QStringLiteral("<GND * 1 400 60 0 0 0 0>\n");
 
   if((Filter->Class == CLASS_BANDPASS) || (Filter->Class == CLASS_BANDSTOP))
     a = 10.0 * Filter->Frequency2;
   else
     a = 10.0 * Filter->Frequency;
-  *s += QString("<.SP SP1 1 110 160 0 67 0 0 \"log\" 1 \"%1Hz\" 1 \"%2Hz\" 1 \"200\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(num2str(0.1*Filter->Frequency)).arg(num2str(a));
-  *s += QString("<Eqn Eqn1 1 350 170 -28 15 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"yes\" 0>\n");
+  *s += QStringLiteral("<.SP SP1 1 110 160 0 67 0 0 \"log\" 1 \"%1Hz\" 1 \"%2Hz\" 1 \"200\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(num2str(0.1*Filter->Frequency)).arg(num2str(a));
+  *s += QStringLiteral("<Eqn Eqn1 1 350 170 -28 15 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"yes\" 0>\n");
   *s += "</Components>\n";
 
   *s += "<Wires>\n";
 
   // connect left source
-  *s += QString("<100 0 230 0 \"\" 0 0 0>\n");
+  *s += QStringLiteral("<100 0 230 0 \"\" 0 0 0>\n");
 
   // connect right source
-  *s += QString("<290 0 400 0 \"\" 0 0 0>\n");
+  *s += QStringLiteral("<290 0 400 0 \"\" 0 0 0>\n");
 
   *s += "</Wires>\n";
 
@@ -126,24 +126,24 @@ QString* Equation_Filter::createSchematic(tFilter *Filter)
 
   *s += "<Paintings>\n";
 
-  *s += QString("<Text 450 150 12 #000000 0 \"");
+  *s += QStringLiteral("<Text 450 150 12 #000000 0 \"");
   switch(Filter->Type) {
-    case TYPE_BESSEL:      *s += QString("Bessel "); break;
-    case TYPE_BUTTERWORTH: *s += QString("Butterworth "); break;
-    case TYPE_CHEBYSHEV:   *s += QString("Chebyshev "); break;
+    case TYPE_BESSEL:      *s += QStringLiteral("Bessel "); break;
+    case TYPE_BUTTERWORTH: *s += QStringLiteral("Butterworth "); break;
+    case TYPE_CHEBYSHEV:   *s += QStringLiteral("Chebyshev "); break;
   }
 
   switch(Filter->Class) {
     case CLASS_LOWPASS:
-      *s += QString("low-pass filter, %1Hz cutoff").arg(num2str(Filter->Frequency)); break;
+      *s += QStringLiteral("low-pass filter, %1Hz cutoff").arg(num2str(Filter->Frequency)); break;
     case CLASS_HIGHPASS:
-      *s += QString("high-pass filter, %1Hz cutoff").arg(num2str(Filter->Frequency)); break;
+      *s += QStringLiteral("high-pass filter, %1Hz cutoff").arg(num2str(Filter->Frequency)); break;
     case CLASS_BANDPASS:
-      *s += QString("band-pass filter, %1Hz...%2Hz").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2)); break;
+      *s += QStringLiteral("band-pass filter, %1Hz...%2Hz").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2)); break;
     case CLASS_BANDSTOP:
-      *s += QString("band-reject filter, %1Hz...%2Hz").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2)); break;
+      *s += QStringLiteral("band-reject filter, %1Hz...%2Hz").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2)); break;
   }
-  *s += QString(" \\n PI-type, impedance matching %1 Ohm\">\n").arg(Filter->Impedance);
+  *s += QStringLiteral(" \\n PI-type, impedance matching %1 Ohm\">\n").arg(Filter->Impedance);
   *s += "</Paintings>\n";
 
   return s;

--- a/qucs-filter/filter.cpp
+++ b/qucs-filter/filter.cpp
@@ -369,7 +369,7 @@ QString Filter::getLineString(bool isMicrostrip, double width_or_impedance, doub
          text_x = -30;
          text_y = -70;
      }
-     code = QString("<MLIN MS1 1 %1 %2 %3 %4 0 %5 \"Sub1\" 0 \"%6 mm\" 1 \"%7 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
+     code = QStringLiteral("<MLIN MS1 1 %1 %2 %3 %4 0 %5 \"Sub1\" 0 \"%6 mm\" 1 \"%7 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
               .arg(x).arg(y).arg(text_x).arg(text_y).arg(rotate)
               .arg(QString::number(width_or_impedance*1e3, 'f', 2)).arg(QString::number(l*1e3, 'f', 2));
   }
@@ -385,7 +385,7 @@ QString Filter::getLineString(bool isMicrostrip, double width_or_impedance, doub
           text_x = -30;
           text_y = -60;
       }
-     code =  QString("<TLIN Line1 1 %1 %2 %3 %4 0 %5 \"%6 Ohm\" 1 \"%7 mm\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
+     code =  QStringLiteral("<TLIN Line1 1 %1 %2 %3 %4 0 %5 \"%6 Ohm\" 1 \"%7 mm\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
             .arg(x).arg(y).arg(text_x).arg(text_y).arg(rotate).arg(QString::number(width_or_impedance, 'f', 1)).arg(QString::number(l*1e3, 'f', 2));
   }
   return code;
@@ -397,19 +397,19 @@ QString Filter::getMS_Via(double height, int x, int y, int rotate)
     switch (rotate)
     {
         case 0: // No rotation
-            code = QString("<MVIA MS31 1 %1 %2 20 -10 0 0 \"Sub1\" 0 \"%3 mm\" 1 \"26.85\" 0>\n").arg(x).arg(y).arg(height);
+            code = QStringLiteral("<MVIA MS31 1 %1 %2 20 -10 0 0 \"Sub1\" 0 \"%3 mm\" 1 \"26.85\" 0>\n").arg(x).arg(y).arg(height);
             break;
 
         case 1: // CTRL+R
-            code = QString("<MVIA MS31 1 %1 %2 40 -20 0 1 \"Sub1\" 0 \"%3 mm\" 1 \"26.85\" 0>\n").arg(x).arg(y).arg(height);
+            code = QStringLiteral("<MVIA MS31 1 %1 %2 40 -20 0 1 \"Sub1\" 0 \"%3 mm\" 1 \"26.85\" 0>\n").arg(x).arg(y).arg(height);
             break;
 
         case 2: // 2 x (CTRL+R)
-            code = QString("<MVIA MS31 1 %1 %2 -85 -40 0 2 \"Sub1\" 0 \"%3 mm\" 1 \"26.85\" 0>\n").arg(x).arg(y).arg(height);
+            code = QStringLiteral("<MVIA MS31 1 %1 %2 -85 -40 0 2 \"Sub1\" 0 \"%3 mm\" 1 \"26.85\" 0>\n").arg(x).arg(y).arg(height);
             break;
 
         case 3: // 3 x (CTRL+R)
-            code = QString("<MVIA MS31 1 %1 %2 -90 -20 0 3 \"Sub1\" 0 \"%3 mm\" 1 \"26.85\" 0>\n").arg(x).arg(y).arg(height);
+            code = QStringLiteral("<MVIA MS31 1 %1 %2 -90 -20 0 3 \"Sub1\" 0 \"%3 mm\" 1 \"26.85\" 0>\n").arg(x).arg(y).arg(height);
             break;
     }
     return code;
@@ -421,19 +421,19 @@ QString Filter::getMS_Open(double width, int x, int y, int rotate)
     switch (rotate)
     {
         case 0: // No rotation
-            code = QString("<MOPEN MS93 1 %1 %2 -20 -50 0 0 \"Sub1\" 0 \"%3 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x).arg(y).arg(QString::number(width*1e3, 'f', 2));
+            code = QStringLiteral("<MOPEN MS93 1 %1 %2 -20 -50 0 0 \"Sub1\" 0 \"%3 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x).arg(y).arg(QString::number(width*1e3, 'f', 2));
             break;
 
         case 1: // CTRL+R
-            code = QString("<MOPEN MS93 1 %1 %2 15 -12 0 1 \"Sub1\" 0 \"%3 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x).arg(y).arg(QString::number(width*1e3, 'f', 2));
+            code = QStringLiteral("<MOPEN MS93 1 %1 %2 15 -12 0 1 \"Sub1\" 0 \"%3 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x).arg(y).arg(QString::number(width*1e3, 'f', 2));
             break;
 
         case 2: // 2 x (CTRL+R)
-            code = QString("<MOPEN MS93 1 %1 %2 -20 -50 0 2 \"Sub1\" 0 \"%3 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x).arg(y).arg(QString::number(width*1e3, 'f', 2));
+            code = QStringLiteral("<MOPEN MS93 1 %1 %2 -20 -50 0 2 \"Sub1\" 0 \"%3 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x).arg(y).arg(QString::number(width*1e3, 'f', 2));
             break;
 
         case 3: // 3 x (CTRL+R)
-            code = QString("<MOPEN MS93 1 %1 %2 15 -20 0 3 \"Sub1\" 0 \"%3 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x).arg(y).arg(QString::number(width*1e3, 'f', 2));
+            code = QStringLiteral("<MOPEN MS93 1 %1 %2 15 -20 0 3 \"Sub1\" 0 \"%3 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"Kirschning\" 0>\n").arg(x).arg(y).arg(QString::number(width*1e3, 'f', 2));
             break;
     }
     return code;
@@ -441,10 +441,10 @@ QString Filter::getMS_Open(double width, int x, int y, int rotate)
 
 QString Filter::getWireString(int x1, int y1, int x2, int y2)
 {
-  return QString("<%1 %2 %3 %4 \"\" 0 0 0>\n").arg(x1).arg(y1).arg(x2).arg(y2);
+  return QStringLiteral("<%1 %2 %3 %4 \"\" 0 0 0>\n").arg(x1).arg(y1).arg(x2).arg(y2);
 }
 QString Filter::getTeeString(int x, int y, double width1, double width2, double width3)
 {
-  return QString("<MTEE MS1 1 %1 %2 -26 20 1 0 \"Sub1\" 0 \"%3mm\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
+  return QStringLiteral("<MTEE MS1 1 %1 %2 -26 20 1 0 \"Sub1\" 0 \"%3mm\" 1 \"%4mm\" 1 \"%5mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
         .arg(x).arg(y).arg(QString::number(width1*1e3, 'f', 2)).arg(QString::number(width2*1e3, 'f', 2)).arg(QString::number(width3*1e3, 'f', 2));
 }

--- a/qucs-filter/lc_filter.cpp
+++ b/qucs-filter/lc_filter.cpp
@@ -66,8 +66,8 @@ QString* LC_Filter::createSchematic(tFilter *Filter, bool piType)
   x = 20;
   if(Filter->Class != CLASS_BANDPASS)  x += 40;
   *s += "<Components>\n";
-  *s += QString("<Pac P1 1 %1 320 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
-  *s += QString("<GND * 1 %1 350 0 0 0 0>\n").arg(x);
+  *s += QStringLiteral("<Pac P1 1 %1 320 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
+  *s += QStringLiteral("<GND * 1 %1 350 0 0 0 0>\n").arg(x);
 
   for(i = 0; i < Filter->Order; i++) {
     x = 100 +((i+1) * 70);
@@ -93,18 +93,18 @@ QString* LC_Filter::createSchematic(tFilter *Filter, bool piType)
 
       case CLASS_LOWPASS:
         if(i & 1)
-          *s += QString("<L L1 1 %1 %2 -26 10 0 0 \"%3H\" 1>\n").arg(x).arg(yl).arg(num2str(Value));
+          *s += QStringLiteral("<L L1 1 %1 %2 -26 10 0 0 \"%3H\" 1>\n").arg(x).arg(yl).arg(num2str(Value));
         else
-          *s += QString("<C C1 1 %1 %2 17 -26 0 1 \"%3F\" 1>\n").arg(x).arg(yc).arg(num2str(Value));
+          *s += QStringLiteral("<C C1 1 %1 %2 17 -26 0 1 \"%3F\" 1>\n").arg(x).arg(yc).arg(num2str(Value));
         break;
 
 
       case CLASS_HIGHPASS:
         Value = 1.0 / Omega / Omega / Value;  // transform to highpass
         if(i & 1)
-          *s += QString("<C C1 1 %1 %2 -27 10 0 0 \"%3F\" 1>\n").arg(x).arg(yl).arg(num2str(Value));
+          *s += QStringLiteral("<C C1 1 %1 %2 -27 10 0 0 \"%3F\" 1>\n").arg(x).arg(yl).arg(num2str(Value));
         else
-          *s += QString("<L L1 1 %1 %2 17 -26 0 1 \"%3H\" 1>\n").arg(x).arg(yc).arg(num2str(Value));
+          *s += QStringLiteral("<L L1 1 %1 %2 17 -26 0 1 \"%3H\" 1>\n").arg(x).arg(yc).arg(num2str(Value));
         break;
 
 
@@ -112,12 +112,12 @@ QString* LC_Filter::createSchematic(tFilter *Filter, bool piType)
         Value /= Bandwidth;    // transform to bandpass
         Value2 = 0.25 / Filter->Frequency / Filter->Frequency2 / pi / pi / Value;
         if(i & 1) {
-          *s += QString("<L L1 1 %1 %2 -26 -44 0 0 \"%3H\" 1>\n").arg(x+40).arg(yl).arg(num2str(Value));
-          *s += QString("<C C1 1 %1 %2 -26 10 0 0 \"%3F\" 1>\n").arg(x-20).arg(yl).arg(num2str(Value2));
+          *s += QStringLiteral("<L L1 1 %1 %2 -26 -44 0 0 \"%3H\" 1>\n").arg(x+40).arg(yl).arg(num2str(Value));
+          *s += QStringLiteral("<C C1 1 %1 %2 -26 10 0 0 \"%3F\" 1>\n").arg(x-20).arg(yl).arg(num2str(Value2));
         }
         else {
-          *s += QString("<L L1 1 %1 %2 8 -26 0 1 \"%3H\" 1>\n").arg(x).arg(yc).arg(num2str(Value2));
-          *s += QString("<C C1 1 %1 %2 -8 46 0 1 \"%3F\" 1>\n").arg(x-30).arg(yc).arg(num2str(Value));
+          *s += QStringLiteral("<L L1 1 %1 %2 8 -26 0 1 \"%3H\" 1>\n").arg(x).arg(yc).arg(num2str(Value2));
+          *s += QStringLiteral("<C C1 1 %1 %2 -8 46 0 1 \"%3F\" 1>\n").arg(x-30).arg(yc).arg(num2str(Value));
         }
         break;
 
@@ -126,12 +126,12 @@ QString* LC_Filter::createSchematic(tFilter *Filter, bool piType)
         Value2 = 1.0 / Omega / Omega / Bandwidth / Value; // transform to bandstop
         Value *= 0.5 * fabs(Filter->Frequency2/Filter->Frequency - Filter->Frequency/Filter->Frequency2);
         if(i & 1) {
-          *s += QString("<L L1 1 %1 %2 -26 -44 0 0 \"%3H\" 1>\n").arg(x).arg(yl-35).arg(num2str(Value));
-          *s += QString("<C C1 1 %1 %2 -26 10 0 0 \"%3F\" 1>\n").arg(x).arg(yl).arg(num2str(Value2));
+          *s += QStringLiteral("<L L1 1 %1 %2 -26 -44 0 0 \"%3H\" 1>\n").arg(x).arg(yl-35).arg(num2str(Value));
+          *s += QStringLiteral("<C C1 1 %1 %2 -26 10 0 0 \"%3F\" 1>\n").arg(x).arg(yl).arg(num2str(Value2));
         }
         else {
-          *s += QString("<L L1 1 %1 %2 17 -26 0 1 \"%3H\" 1>\n").arg(x).arg(yc).arg(num2str(Value2));
-          *s += QString("<C C1 1 %1 %2 17 -26 0 1 \"%3F\" 1>\n").arg(x).arg(yc+60).arg(num2str(Value));
+          *s += QStringLiteral("<L L1 1 %1 %2 17 -26 0 1 \"%3H\" 1>\n").arg(x).arg(yc).arg(num2str(Value2));
+          *s += QStringLiteral("<C C1 1 %1 %2 17 -26 0 1 \"%3F\" 1>\n").arg(x).arg(yc+60).arg(num2str(Value));
         }
         yc += 60;
         break;
@@ -139,7 +139,7 @@ QString* LC_Filter::createSchematic(tFilter *Filter, bool piType)
     }
 
     if((i & 1) == 0)
-      *s += QString("<GND * 1 %1 %2 0 0 0 0>\n").arg(x).arg(yc + 30);
+      *s += QStringLiteral("<GND * 1 %1 %2 0 0 0 0>\n").arg(x).arg(yc + 30);
 
     if(!piType)
       i--;
@@ -155,8 +155,8 @@ QString* LC_Filter::createSchematic(tFilter *Filter, bool piType)
     if((Filter->Order & 1) == 0)
       x += 70;
   }
-  *s += QString("<Pac P2 1 %1 320 18 -26 0 1 \"2\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
-  *s += QString("<GND * 1 %1 350 0 0 0 0>\n").arg(x);
+  *s += QStringLiteral("<Pac P2 1 %1 320 18 -26 0 1 \"2\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
+  *s += QStringLiteral("<GND * 1 %1 350 0 0 0 0>\n").arg(x);
 
   yc += 100;
   Value = Filter->Frequency / 10.0;
@@ -164,15 +164,15 @@ QString* LC_Filter::createSchematic(tFilter *Filter, bool piType)
     Value2 = 10.0 * Filter->Frequency2;
   else
     Value2 = 10.0 * Filter->Frequency;
-  *s += QString("<.SP SP1 1 70 %1 0 67 0 0 \"log\" 1 \"%2Hz\" 1 \"%3Hz\" 1 \"201\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(yc).arg(num2str(Value)).arg(num2str(Value2));
+  *s += QStringLiteral("<.SP SP1 1 70 %1 0 67 0 0 \"log\" 1 \"%2Hz\" 1 \"%3Hz\" 1 \"201\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(yc).arg(num2str(Value)).arg(num2str(Value2));
 
   QString eqn_string;
   switch (QucsSettings.DefaultSimulator) {
   case spicecompat::simQucsator:
-      eqn_string = QString("<Eqn Eqn1 1 290 %1 -28 15 0 0 \"dBS21=dB(S[2,1])\" 1 \"dBS11=dB(S[1,1])\" 1 \"yes\" 0>\n").arg(yc+10);
+      eqn_string = QStringLiteral("<Eqn Eqn1 1 290 %1 -28 15 0 0 \"dBS21=dB(S[2,1])\" 1 \"dBS11=dB(S[1,1])\" 1 \"yes\" 0>\n").arg(yc+10);
       break;
   case spicecompat::simNgspice :
-      eqn_string = QString("<NutmegEq NutmegEq1 1 290 %1 -28 15 0 0 \"SP1\" 1 \"dBS21=dB(S_2_1)\" 1 \"dBS11=dB(S_1_1)\" 1>\n").arg(yc+10);
+      eqn_string = QStringLiteral("<NutmegEq NutmegEq1 1 290 %1 -28 15 0 0 \"SP1\" 1 \"dBS21=dB(S_2_1)\" 1 \"dBS11=dB(S_1_1)\" 1>\n").arg(yc+10);
       break;
   case spicecompat::simSpiceOpus:
   case spicecompat::simXyce:
@@ -188,13 +188,13 @@ QString* LC_Filter::createSchematic(tFilter *Filter, bool piType)
   x = 20;
   if(Filter->Class != CLASS_BANDPASS)
     x += 40;
-  *s += QString("<%1 240 %2 290 \"\" 0 0 0>\n").arg(x).arg(x);
+  *s += QStringLiteral("<%1 240 %2 290 \"\" 0 0 0>\n").arg(x).arg(x);
   if(piType)
-    *s += QString("<%1 240 170 240 \"\" 0 0 0>\n").arg(x);
+    *s += QStringLiteral("<%1 240 170 240 \"\" 0 0 0>\n").arg(x);
   else if(Filter->Class == CLASS_BANDPASS)
-    *s += QString("<%1 240 120 240 \"\" 0 0 0>\n").arg(x);
+    *s += QStringLiteral("<%1 240 120 240 \"\" 0 0 0>\n").arg(x);
   else
-    *s += QString("<%1 240 140 240 \"\" 0 0 0>\n").arg(x);
+    *s += QStringLiteral("<%1 240 140 240 \"\" 0 0 0>\n").arg(x);
 
   // wires down to shunt components
   x = 30;
@@ -202,7 +202,7 @@ QString* LC_Filter::createSchematic(tFilter *Filter, bool piType)
     x += 70;
   for(i = 0; i < (Filter->Order / 2) + 1; i++) {
     x += 140;
-    *s += QString("<%1 240 %2 290 \"\" 0 0 0>\n").arg(x).arg(x);
+    *s += QStringLiteral("<%1 240 %2 290 \"\" 0 0 0>\n").arg(x).arg(x);
   }
 
   // horizontal wires for series components
@@ -210,32 +210,32 @@ QString* LC_Filter::createSchematic(tFilter *Filter, bool piType)
     if(piType) {
       for(i = 0; i < (Filter->Order / 2); i++) {
         x = 170 + (i * 140);
-        *s += QString("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x).arg(x+20);
-        *s += QString("<%1 290 %2 290 \"\" 0 0 0>\n").arg(x-30).arg(x);
-        *s += QString("<%1 350 %2 350 \"\" 0 0 0>\n").arg(x-30).arg(x);
+        *s += QStringLiteral("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x).arg(x+20);
+        *s += QStringLiteral("<%1 290 %2 290 \"\" 0 0 0>\n").arg(x-30).arg(x);
+        *s += QStringLiteral("<%1 350 %2 350 \"\" 0 0 0>\n").arg(x-30).arg(x);
       }
       if(Filter->Order & 1) {
-        *s += QString("<%1 290 %2 290 \"\" 0 0 0>\n").arg(x+110).arg(x+140);
-        *s += QString("<%1 350 %2 350 \"\" 0 0 0>\n").arg(x+110).arg(x+140);
+        *s += QStringLiteral("<%1 290 %2 290 \"\" 0 0 0>\n").arg(x+110).arg(x+140);
+        *s += QStringLiteral("<%1 350 %2 350 \"\" 0 0 0>\n").arg(x+110).arg(x+140);
       }
     }
     else
       for(i = 0; i < (Filter->Order / 2); i++) {
         x = 240 + (i * 140);
-        *s += QString("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x).arg(x+20);
-        *s += QString("<%1 290 %2 290 \"\" 0 0 0>\n").arg(x-30).arg(x);
-        *s += QString("<%1 350 %2 350 \"\" 0 0 0>\n").arg(x-30).arg(x);
+        *s += QStringLiteral("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x).arg(x+20);
+        *s += QStringLiteral("<%1 290 %2 290 \"\" 0 0 0>\n").arg(x-30).arg(x);
+        *s += QStringLiteral("<%1 350 %2 350 \"\" 0 0 0>\n").arg(x-30).arg(x);
       }
   }
   else
     for(i = 0; i < (Filter->Order / 2); i++) {
       x = 170 + (i * 140);
       if(piType) {
-        *s += QString("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x).arg(x+40);
-        *s += QString("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x+100).arg(x+140);
+        *s += QStringLiteral("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x).arg(x+40);
+        *s += QStringLiteral("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x+100).arg(x+140);
       }
       else
-        *s += QString("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x+30).arg(x+110);
+        *s += QStringLiteral("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x+30).arg(x+110);
     }
 
   // vertical wires for connecting the second series component
@@ -249,8 +249,8 @@ QString* LC_Filter::createSchematic(tFilter *Filter, bool piType)
       i = (Filter->Order+1) / 2 - 1;
     for(; i>=0; i--) {
       x += 140;
-      *s += QString("<%1 240 %2 205 \"\" 0 0 0>\n").arg(x).arg(x);
-      *s += QString("<%1 240 %2 205 \"\" 0 0 0>\n").arg(x+60).arg(x+60);
+      *s += QStringLiteral("<%1 240 %2 205 \"\" 0 0 0>\n").arg(x).arg(x);
+      *s += QStringLiteral("<%1 240 %2 205 \"\" 0 0 0>\n").arg(x+60).arg(x+60);
     }
     if(piType)
       x -= 40;
@@ -262,20 +262,20 @@ QString* LC_Filter::createSchematic(tFilter *Filter, bool piType)
   if(piType) {
     if(Filter->Order & 1) {
       x  += 140 + 110;
-      *s += QString("<%1 240 %2 290 \"\" 0 0 0>\n").arg(x).arg(x);
-      *s += QString("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x-110).arg(x);
+      *s += QStringLiteral("<%1 240 %2 290 \"\" 0 0 0>\n").arg(x).arg(x);
+      *s += QStringLiteral("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x-110).arg(x);
     }
   }
   else {
     if(Filter->Class == CLASS_BANDPASS) {
       if((Filter->Order & 1) == 0)
-        *s += QString("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x+20).arg(x+140);
+        *s += QStringLiteral("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x+20).arg(x+140);
     }
     else {
       if(Filter->Order & 1)
-        *s += QString("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x+170).arg(x+210);
+        *s += QStringLiteral("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x+170).arg(x+210);
       else
-        *s += QString("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x+110).arg(x+210);
+        *s += QStringLiteral("<%1 240 %2 240 \"\" 0 0 0>\n").arg(x+110).arg(x+210);
     }
   }
   *s += "</Wires>\n";
@@ -285,27 +285,27 @@ QString* LC_Filter::createSchematic(tFilter *Filter, bool piType)
 
   *s += "<Paintings>\n";
 
-  *s += QString("<Text 400 %1 12 #000000 0 \"").arg(yc);
+  *s += QStringLiteral("<Text 400 %1 12 #000000 0 \"").arg(yc);
   switch(Filter->Type) {
-    case TYPE_BESSEL:      *s += QString("Bessel "); break;
-    case TYPE_BUTTERWORTH: *s += QString("Butterworth "); break;
-    case TYPE_CHEBYSHEV:   *s += QString("Chebyshev "); break;
+    case TYPE_BESSEL:      *s += QStringLiteral("Bessel "); break;
+    case TYPE_BUTTERWORTH: *s += QStringLiteral("Butterworth "); break;
+    case TYPE_CHEBYSHEV:   *s += QStringLiteral("Chebyshev "); break;
   }
 
   switch(Filter->Class) {
     case CLASS_LOWPASS:
-      *s += QString("low-pass filter \\n %1Hz cutoff").arg(num2str(Filter->Frequency)); break;
+      *s += QStringLiteral("low-pass filter \\n %1Hz cutoff").arg(num2str(Filter->Frequency)); break;
     case CLASS_HIGHPASS:
-      *s += QString("high-pass filter \\n %1Hz cutoff").arg(num2str(Filter->Frequency)); break;
+      *s += QStringLiteral("high-pass filter \\n %1Hz cutoff").arg(num2str(Filter->Frequency)); break;
     case CLASS_BANDPASS:
-      *s += QString("band-pass filter \\n %1Hz...%2Hz").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2)); break;
+      *s += QStringLiteral("band-pass filter \\n %1Hz...%2Hz").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2)); break;
     case CLASS_BANDSTOP:
-      *s += QString("band-stop filter \\n %1Hz...%2Hz").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2)); break;
+      *s += QStringLiteral("band-stop filter \\n %1Hz...%2Hz").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2)); break;
   }
   if (piType == true)
-    *s += QString(", pi-type, \\n impedance matching %1 Ohm\">\n").arg(Filter->Impedance);
+    *s += QStringLiteral(", pi-type, \\n impedance matching %1 Ohm\">\n").arg(Filter->Impedance);
   else
-    *s += QString(", tee-type, \\n impedance matching %1 Ohm\">\n").arg(Filter->Impedance);
+    *s += QStringLiteral(", tee-type, \\n impedance matching %1 Ohm\">\n").arg(Filter->Impedance);
   *s += "</Paintings>\n";
 
   return s;

--- a/qucs-filter/line_filter.cpp
+++ b/qucs-filter/line_filter.cpp
@@ -46,8 +46,8 @@ QString* Line_Filter::createSchematic(tFilter *Filter, tSubstrate *Substrate, bo
   int i, x, yc;
   x = 60;
   *s += "<Components>\n";
-  *s += QString("<Pac P1 1 %1 320 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
-  *s += QString("<GND * 1 %1 350 0 0 0 0>\n").arg(x);
+  *s += QStringLiteral("<Pac P1 1 %1 320 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
+  *s += QStringLiteral("<GND * 1 %1 350 0 0 0 0>\n").arg(x);
 
   x -= 30;
   yc = 180;
@@ -114,45 +114,45 @@ QString* Line_Filter::createSchematic(tFilter *Filter, tSubstrate *Substrate, bo
     if(i > 0) {
       len -= dl;
       if(isMicrostrip)
-        *s += QString("<MLIN MS1 1 %1 %2 -26 15 0 0 \"Subst1\" 0 \"%3\" 1 \"%4\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(x).arg(yc).arg(num2str(width)).arg(num2str(len));
+        *s += QStringLiteral("<MLIN MS1 1 %1 %2 -26 15 0 0 \"Subst1\" 0 \"%3\" 1 \"%4\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(x).arg(yc).arg(num2str(width)).arg(num2str(len));
       else
-        *s += QString("<TLIN Line1 1 %1 %2 -26 20 0 0 \"%3\" 1 \"%4\" 1 \"0 dB\" 0 \"26.85\" 0>\n").arg(x).arg(yc).arg(Filter->Impedance).arg(num2str(len));
+        *s += QStringLiteral("<TLIN Line1 1 %1 %2 -26 20 0 0 \"%3\" 1 \"%4\" 1 \"0 dB\" 0 \"26.85\" 0>\n").arg(x).arg(yc).arg(Filter->Impedance).arg(num2str(len));
       x += 90;
     }
 
     if(isMicrostrip)
-      *s += QString("<MGAP MS1 1 %1 %2 -26 15 0 0 \"Subst1\" 0 \"%3\" 1 \"%4\" 1 \"%5\" 1 \"Hammerstad\" 0 \"Kirschning\" 0>\n").arg(x).arg(yc).arg(num2str(width)).arg(num2str(width)).arg(num2str(gap));
+      *s += QStringLiteral("<MGAP MS1 1 %1 %2 -26 15 0 0 \"Subst1\" 0 \"%3\" 1 \"%4\" 1 \"%5\" 1 \"Hammerstad\" 0 \"Kirschning\" 0>\n").arg(x).arg(yc).arg(num2str(width)).arg(num2str(width)).arg(num2str(gap));
     else
-      *s += QString("<C C1 1 %1 %2 -26 17 0 0 \"%3\" 1>\n").arg(x).arg(yc).arg(num2str(gap));
+      *s += QStringLiteral("<C C1 1 %1 %2 -26 17 0 0 \"%3\" 1>\n").arg(x).arg(yc).arg(num2str(gap));
   }
 
 
   x += 80;
-  *s += QString("<Pac P2 1 %1 320 18 -26 0 1 \"2\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
-  *s += QString("<GND * 1 %1 350 0 0 0 0>\n").arg(x);
+  *s += QStringLiteral("<Pac P2 1 %1 320 18 -26 0 1 \"2\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
+  *s += QStringLiteral("<GND * 1 %1 350 0 0 0 0>\n").arg(x);
 
   Value  = 2.0 * Filter->Frequency  - Filter->Frequency2;
   Value2 = 2.0 * Filter->Frequency2 - Filter->Frequency;
-  *s += QString("<.SP SP1 1 70 420 0 67 0 0 \"lin\" 1 \"%2Hz\" 1 \"%3Hz\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(num2str(Value)).arg(num2str(Value2));
+  *s += QStringLiteral("<.SP SP1 1 70 420 0 67 0 0 \"lin\" 1 \"%2Hz\" 1 \"%3Hz\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(num2str(Value)).arg(num2str(Value2));
   if(isMicrostrip)
-    *s += QString("<SUBST Subst1 1 300 460 -30 24 0 0 \"%1\" 1 \"%2m\" 1 \"%3m\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate->er).arg(num2str(Substrate->height)).arg(num2str(Substrate->thickness)).arg(Substrate->tand).arg(Substrate->resistivity).arg(Substrate->roughness);
-  *s += QString("<Eqn Eqn1 1 450 520 -28 15 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"yes\" 0>\n");
+    *s += QStringLiteral("<SUBST Subst1 1 300 460 -30 24 0 0 \"%1\" 1 \"%2m\" 1 \"%3m\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate->er).arg(num2str(Substrate->height)).arg(num2str(Substrate->thickness)).arg(Substrate->tand).arg(Substrate->resistivity).arg(Substrate->roughness);
+  *s += QStringLiteral("<Eqn Eqn1 1 450 520 -28 15 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"yes\" 0>\n");
   *s += "</Components>\n";
 
   *s += "<Wires>\n";
 
   // connect left source
-  *s += QString("<60 180 60 290 \"\" 0 0 0>\n");
-  *s += QString("<60 180 90 180 \"\" 0 0 0>\n");
+  *s += QStringLiteral("<60 180 60 290 \"\" 0 0 0>\n");
+  *s += QStringLiteral("<60 180 90 180 \"\" 0 0 0>\n");
 
   // connect right source
-  *s += QString("<%1 180 %2 290 \"\" 0 0 0>\n").arg(x).arg(x);
-  *s += QString("<%1 180 %2 180 \"\" 0 0 0>\n").arg(x-50).arg(x);
+  *s += QStringLiteral("<%1 180 %2 290 \"\" 0 0 0>\n").arg(x).arg(x);
+  *s += QStringLiteral("<%1 180 %2 180 \"\" 0 0 0>\n").arg(x-50).arg(x);
 
   // wires between components
   x = 150;
   for(i = 0; i < 2*Filter->Order; i++) {
-    *s += QString("<%1 180 %2 180 \"\" 0 0 0>\n").arg(x).arg(x+30);
+    *s += QStringLiteral("<%1 180 %2 180 \"\" 0 0 0>\n").arg(x).arg(x+30);
     x += 90;
   }
 
@@ -163,15 +163,15 @@ QString* Line_Filter::createSchematic(tFilter *Filter, tSubstrate *Substrate, bo
 
   *s += "<Paintings>\n";
 
-  *s += QString("<Text 420 420 12 #000000 0 \"end-coupled, half-wavelength bandpass filter \\n ");
+  *s += QStringLiteral("<Text 420 420 12 #000000 0 \"end-coupled, half-wavelength bandpass filter \\n ");
   switch(Filter->Type) {
-    case TYPE_BESSEL:      *s += QString("Bessel"); break;
-    case TYPE_BUTTERWORTH: *s += QString("Butterworth"); break;
-    case TYPE_CHEBYSHEV:   *s += QString("Chebyshev"); break;
+    case TYPE_BESSEL:      *s += QStringLiteral("Bessel"); break;
+    case TYPE_BUTTERWORTH: *s += QStringLiteral("Butterworth"); break;
+    case TYPE_CHEBYSHEV:   *s += QStringLiteral("Chebyshev"); break;
   }
 
-  *s += QString(" %1Hz...%2Hz \\n ").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2));
-  *s += QString("impedance matching %3 Ohm\">\n").arg(Filter->Impedance);
+  *s += QStringLiteral(" %1Hz...%2Hz \\n ").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2));
+  *s += QStringLiteral("impedance matching %3 Ohm\">\n").arg(Filter->Impedance);
   *s += "</Paintings>\n";
 
   return s;

--- a/qucs-filter/main.cpp
+++ b/qucs-filter/main.cpp
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
   QString lang = QucsSettings.Language;
   if(lang.isEmpty())
     lang = QString(QLocale::system().name());
-  tor.load( QString("qucs_") + lang, QucsSettings.LangDir);
+  tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir);
   a.installTranslator( &tor );
 
   QucsFilter *qucs = new QucsFilter();

--- a/qucs-filter/qf_filter.cpp
+++ b/qucs-filter/qf_filter.cpp
@@ -148,134 +148,134 @@ QString filter::to_qucs() {
   int x          = 0;
   // Draw left power source
 
-  compos += QString("<Pac P1 1 %1 290 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 "
+  compos += QStringLiteral("<Pac P1 1 %1 290 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 "
                     "dBm\" 0 \"1 GHz\" 0>\n")
                 .arg(x)
                 .arg((double)imp_);
-  compos += QString("<GND * 1 %1 320 0 0 0 0>\n").arg(x);
-  wires += QString("<0 200 %1 200 \"\" 0 0 0>\n").arg(space / 2);
-  wires += QString("<%1 200 %1 260 \"\" 0 0 0>\n").arg(x);
+  compos += QStringLiteral("<GND * 1 %1 320 0 0 0 0>\n").arg(x);
+  wires += QStringLiteral("<0 200 %1 200 \"\" 0 0 0>\n").arg(space / 2);
+  wires += QStringLiteral("<%1 200 %1 260 \"\" 0 0 0>\n").arg(x);
   // Draw filter sections
   for (auto& subsec : subsecs_) {
     x += space;
     if (subsec.wiring == SERIES) {
       if (subsec.content == INDUC) {
         wires +=
-            QString("<%1 200 %2 200 0 0 0>\n").arg(x - space / 2).arg(x - 30);
-        compos += QString("<L L1 1 %1 %2 -26 -50 0 0 \"%3H\" 1>\n")
+            QStringLiteral("<%1 200 %2 200 0 0 0>\n").arg(x - space / 2).arg(x - 30);
+        compos += QStringLiteral("<L L1 1 %1 %2 -26 -50 0 0 \"%3H\" 1>\n")
                       .arg(x)
                       .arg(200)
                       .arg(num2str(subsec.indc_v));
         wires +=
-            QString("<%1 200 %2 200 0 0 0>\n").arg(x + 30).arg(x + space / 2);
+            QStringLiteral("<%1 200 %2 200 0 0 0>\n").arg(x + 30).arg(x + space / 2);
       } else if (subsec.content == CAPA) {
         wires +=
-            QString("<%1 200 %2 200 0 0 0>\n").arg(x - space / 2).arg(x - 30);
-        compos += QString("<C C1 1 %1 %2 -26 -50 0 0 \"%3F\" 1>\n")
+            QStringLiteral("<%1 200 %2 200 0 0 0>\n").arg(x - space / 2).arg(x - 30);
+        compos += QStringLiteral("<C C1 1 %1 %2 -26 -50 0 0 \"%3F\" 1>\n")
                       .arg(x)
                       .arg(200)
                       .arg(num2str(subsec.capa_v));
         wires +=
-            QString("<%1 200 %2 200 0 0 0>\n").arg(x + 30).arg(x + space / 2);
+            QStringLiteral("<%1 200 %2 200 0 0 0>\n").arg(x + 30).arg(x + space / 2);
       } else if (subsec.content == PARA_CAPA_INDUC) {
         wires +=
-            QString("<%1 200 %2 200 0 0 0>\n").arg(x - space / 2).arg(x - 30);
-        compos += QString("<C C1 1 %1 %2 -26 -80 0 0 \"%3F\" 1>\n")
+            QStringLiteral("<%1 200 %2 200 0 0 0>\n").arg(x - space / 2).arg(x - 30);
+        compos += QStringLiteral("<C C1 1 %1 %2 -26 -80 0 0 \"%3F\" 1>\n")
                       .arg(x)
                       .arg(200)
                       .arg(num2str(subsec.capa_v));
-        wires += QString("<%1 %2 %1 %3 0 0 0>\n").arg(x - 30).arg(200).arg(170);
-        wires += QString("<%1 %2 %1 %3 0 0 0>\n").arg(x + 30).arg(200).arg(170);
-        compos += QString("<L L1 1 %1 %2 -26 -90 0 0 \"%3H\" 1>\n")
+        wires += QStringLiteral("<%1 %2 %1 %3 0 0 0>\n").arg(x - 30).arg(200).arg(170);
+        wires += QStringLiteral("<%1 %2 %1 %3 0 0 0>\n").arg(x + 30).arg(200).arg(170);
+        compos += QStringLiteral("<L L1 1 %1 %2 -26 -90 0 0 \"%3H\" 1>\n")
                       .arg(x)
                       .arg(170)
                       .arg(num2str(subsec.indc_v));
         wires +=
-            QString("<%1 200 %2 200 0 0 0>\n").arg(x + 30).arg(x + space / 2);
+            QStringLiteral("<%1 200 %2 200 0 0 0>\n").arg(x + 30).arg(x + space / 2);
       } else if (subsec.content == SERIES_CAPA_INDUC) {
         wires +=
-            QString("<%1 200 %2 200 0 0 0>\n").arg(x - space / 2).arg(x - 30);
-        compos += QString("<C C1 1 %1 %2 -26 -50 0 0 \"%3F\" 1>\n")
+            QStringLiteral("<%1 200 %2 200 0 0 0>\n").arg(x - space / 2).arg(x - 30);
+        compos += QStringLiteral("<C C1 1 %1 %2 -26 -50 0 0 \"%3F\" 1>\n")
                       .arg(x)
                       .arg(200)
                       .arg(num2str(subsec.capa_v));
         wires +=
-            QString("<%1 200 %2 200 0 0 0>\n").arg(x + 30).arg(x + space / 2);
+            QStringLiteral("<%1 200 %2 200 0 0 0>\n").arg(x + 30).arg(x + space / 2);
         x += space;
         wires +=
-            QString("<%1 200 %2 200 0 0 0>\n").arg(x - space / 2).arg(x - 30);
-        compos += QString("<L L1 1 %1 %2 -26 -50 0 0 \"%3H\" 1>\n")
+            QStringLiteral("<%1 200 %2 200 0 0 0>\n").arg(x - space / 2).arg(x - 30);
+        compos += QStringLiteral("<L L1 1 %1 %2 -26 -50 0 0 \"%3H\" 1>\n")
                       .arg(x)
                       .arg(200)
                       .arg(num2str(subsec.indc_v));
         wires +=
-            QString("<%1 200 %2 200 0 0 0>\n").arg(x + 30).arg(x + space / 2);
+            QStringLiteral("<%1 200 %2 200 0 0 0>\n").arg(x + 30).arg(x + space / 2);
       }
     } else if (subsec.wiring == SHUNT) {
       if (subsec.content == INDUC) {
-        wires += QString("<%1 200 %2 200 0 0 0>\n")
+        wires += QStringLiteral("<%1 200 %2 200 0 0 0>\n")
                      .arg(x - space / 2)
                      .arg(x + space / 2);
-        wires += QString("<%1 %2 %1 %3 0 0 0>\n").arg(x).arg(200).arg(260);
-        compos += QString("<L L1 1 %1 %2 17 -26 0 1 \"%3H\" 1>\n")
+        wires += QStringLiteral("<%1 %2 %1 %3 0 0 0>\n").arg(x).arg(200).arg(260);
+        compos += QStringLiteral("<L L1 1 %1 %2 17 -26 0 1 \"%3H\" 1>\n")
                       .arg(x)
                       .arg(290)
                       .arg(num2str(subsec.indc_v));
-        compos += QString("<GND * 1 %1 320 0 0 0 0>\n").arg(x);
+        compos += QStringLiteral("<GND * 1 %1 320 0 0 0 0>\n").arg(x);
       } else if (subsec.content == CAPA) {
-        wires += QString("<%1 200 %2 200 0 0 0>\n")
+        wires += QStringLiteral("<%1 200 %2 200 0 0 0>\n")
                      .arg(x - space / 2)
                      .arg(x + space / 2);
-        wires += QString("<%1 %2 %1 %3 0 0 0>\n").arg(x).arg(200).arg(260);
-        compos += QString("<C C1 1 %1 %2 17 -26 0 1 \"%3F\" 1>\n")
+        wires += QStringLiteral("<%1 %2 %1 %3 0 0 0>\n").arg(x).arg(200).arg(260);
+        compos += QStringLiteral("<C C1 1 %1 %2 17 -26 0 1 \"%3F\" 1>\n")
                       .arg(x)
                       .arg(290)
                       .arg(num2str(subsec.capa_v));
-        compos += QString("<GND * 1 %1 320 0 0 0 0>\n").arg(x);
+        compos += QStringLiteral("<GND * 1 %1 320 0 0 0 0>\n").arg(x);
       } else if (subsec.content == SERIES_CAPA_INDUC) {
-        wires += QString("<%1 200 %2 200 0 0 0>\n")
+        wires += QStringLiteral("<%1 200 %2 200 0 0 0>\n")
                      .arg(x - space / 2)
                      .arg(x + space / 2);
-        compos += QString("<L L1 1 %1 %2 17 -26 0 1 \"%3H\" 1>\n")
+        compos += QStringLiteral("<L L1 1 %1 %2 17 -26 0 1 \"%3H\" 1>\n")
                       .arg(x)
                       .arg(230)
                       .arg(num2str(subsec.indc_v));
-        compos += QString("<C C1 1 %1 %2 17 -26 0 1 \"%3F\" 1>\n")
+        compos += QStringLiteral("<C C1 1 %1 %2 17 -26 0 1 \"%3F\" 1>\n")
                       .arg(x)
                       .arg(290)
                       .arg(num2str(subsec.capa_v));
-        compos += QString("<GND * 1 %1 320 0 0 0 0>\n").arg(x);
+        compos += QStringLiteral("<GND * 1 %1 320 0 0 0 0>\n").arg(x);
       } else if (subsec.content == PARA_CAPA_INDUC) {
-        wires += QString("<%1 200 %2 200 0 0 0>\n")
+        wires += QStringLiteral("<%1 200 %2 200 0 0 0>\n")
                      .arg(x - space / 2)
                      .arg(x + space / 2);
-        wires += QString("<%1 %2 %1 %3 0 0 0>\n").arg(x).arg(200).arg(260);
-        compos += QString("<L L1 1 %1 %2 47 16 0 1 \"%3H\" 1>\n")
+        wires += QStringLiteral("<%1 %2 %1 %3 0 0 0>\n").arg(x).arg(200).arg(260);
+        compos += QStringLiteral("<L L1 1 %1 %2 47 16 0 1 \"%3H\" 1>\n")
                       .arg(x)
                       .arg(290)
                       .arg(num2str(subsec.indc_v));
-        wires += QString("<%1 260 %2 260 0 0 0>\n").arg(x).arg(x + 30);
-        compos += QString("<C C1 1 %1 %2 17 -26 0 1 \"%3F\" 1>\n")
+        wires += QStringLiteral("<%1 260 %2 260 0 0 0>\n").arg(x).arg(x + 30);
+        compos += QStringLiteral("<C C1 1 %1 %2 17 -26 0 1 \"%3F\" 1>\n")
                       .arg(x + 30)
                       .arg(290)
                       .arg(num2str(subsec.capa_v));
-        wires += QString("<%1 320 %2 320 0 0 0>\n").arg(x).arg(x + 30);
-        compos += QString("<GND * 1 %1 320 0 0 0 0>\n").arg(x);
+        wires += QStringLiteral("<%1 320 %2 320 0 0 0>\n").arg(x).arg(x + 30);
+        compos += QStringLiteral("<GND * 1 %1 320 0 0 0 0>\n").arg(x);
       }
     }
   }
   // Draw right power source
   x += space;
-  wires += QString("<%1 200 %2 200 0 0 0>\n").arg(x - space / 2).arg(x);
-  compos += QString("<Pac P2 1 %1 290 18 -26 0 1 \"2\" 1 \"%2 Ohm\" 1 \"0 "
+  wires += QStringLiteral("<%1 200 %2 200 0 0 0>\n").arg(x - space / 2).arg(x);
+  compos += QStringLiteral("<Pac P2 1 %1 290 18 -26 0 1 \"2\" 1 \"%2 Ohm\" 1 \"0 "
                     "dBm\" 0 \"1 GHz\" 0>\n")
                 .arg(x)
                 .arg((double)imp_);
-  compos += QString("<GND * 1 %1 320 0 0 0 0>\n").arg(x);
-  wires += QString("<%1 200 %1 260 \"\" 0 0 0>\n").arg(x);
+  compos += QStringLiteral("<GND * 1 %1 320 0 0 0 0>\n").arg(x);
+  wires += QStringLiteral("<%1 200 %1 260 \"\" 0 0 0>\n").arg(x);
 
   QString s = "";
-  s += QString("<Qucs Schematic " PACKAGE_VERSION ">\n");
+  s += QStringLiteral("<Qucs Schematic " PACKAGE_VERSION ">\n");
   s += "<Components>\n";
   s += compos;
 
@@ -293,7 +293,7 @@ QString filter::to_qucs() {
     eqn_string += "\"dBS11=dB(S[1,1])\" 1 \"yes\" 0>\n";
     break;
   case spicecompat::simNgspice :
-    eqn_string = QString("<NutmegEq NutmegEq1 1 260 410 -28 15 0 0 \"SP1\" 1 \"dBS21=dB(S_2_1)\" 1 \"dBS11=dB(S_1_1)\" 1>\n");
+    eqn_string = QStringLiteral("<NutmegEq NutmegEq1 1 260 410 -28 15 0 0 \"SP1\" 1 \"dBS21=dB(S_2_1)\" 1 \"dBS11=dB(S_1_1)\" 1>\n");
     break;
   case spicecompat::simSpiceOpus:
   case spicecompat::simXyce:

--- a/qucs-filter/quarterwave_filter.cpp
+++ b/qucs-filter/quarterwave_filter.cpp
@@ -64,8 +64,8 @@ QString *QuarterWave_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
   int x_space = 50;
 
   // First power and ground
-  c_s += QString("<Pac P1 1 %1 330 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
-  c_s += QString("<GND * 1 %1 360 0 0 0 0>\n").arg(x);
+  c_s += QStringLiteral("<Pac P1 1 %1 330 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
+  c_s += QStringLiteral("<GND * 1 %1 360 0 0 0 0>\n").arg(x);
   w_s += getWireString(60, 180, 60, 300);
   w_s += getWireString(60, 180, 90, 180);
   x += 60;
@@ -116,7 +116,7 @@ QString *QuarterWave_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
               c_s += getMS_Via(0.5, x+40 + x_space, 30, 2); // MS via diameter = 0.5 mm
           }
           else{
-              c_s += QString("<GND * 1 %1 30 0 0 1 0>\n").arg(x + 60 + x_space);
+              c_s += QStringLiteral("<GND * 1 %1 30 0 0 1 0>\n").arg(x + 60 + x_space);
           }
       }
 
@@ -135,30 +135,30 @@ QString *QuarterWave_Filter::createSchematic(tFilter *Filter, tSubstrate *Substr
 
   // Last power and ground
   x += 80;
-  c_s += QString("<Pac P2 1 %1 330 18 -26 0 1 \"2\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
-  c_s += QString("<GND * 1 %1 360 0 0 0 0>\n").arg(x);
+  c_s += QStringLiteral("<Pac P2 1 %1 330 18 -26 0 1 \"2\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
+  c_s += QStringLiteral("<GND * 1 %1 360 0 0 0 0>\n").arg(x);
   w_s += getWireString(x, 180, x, 300);
   w_s += getWireString(x-50, 180, x, 180);
   // Components footer
-  c_s += QString("<.SP SP1 1 70 460 0 67 0 0 \"lin\" 1 \"%2Hz\" 1 \"%3Hz\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(num2str(0.1 * Filter->Frequency)).arg(num2str(10.0 * Filter->Frequency));
+  c_s += QStringLiteral("<.SP SP1 1 70 460 0 67 0 0 \"lin\" 1 \"%2Hz\" 1 \"%3Hz\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(num2str(0.1 * Filter->Frequency)).arg(num2str(10.0 * Filter->Frequency));
   if (isMicrostrip)
-    c_s += QString("<SUBST Sub1 1 300 500 -30 24 0 0 \"%1\" 1 \"%2m\" 1 \"%3m\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate->er).arg(num2str(Substrate->height)).arg(num2str(Substrate->thickness)).arg(Substrate->tand).arg(Substrate->resistivity).arg(Substrate->roughness);
-  c_s += QString("<Eqn Eqn1 1 450 560 -28 15 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"yes\" 0>\n");
+    c_s += QStringLiteral("<SUBST Sub1 1 300 500 -30 24 0 0 \"%1\" 1 \"%2m\" 1 \"%3m\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate->er).arg(num2str(Substrate->height)).arg(num2str(Substrate->thickness)).arg(Substrate->tand).arg(Substrate->resistivity).arg(Substrate->roughness);
+  c_s += QStringLiteral("<Eqn Eqn1 1 450 560 -28 15 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"yes\" 0>\n");
   *s += c_s + "</Components>\n";
   *s += w_s + "</Wires>\n";
   // Footer
   *s += "<Diagrams>\n";
   *s += "</Diagrams>\n";
   *s += "<Paintings>\n";
-  *s += QString("<Text 420 460 12 #000000 0 \"Quarter wave bandpass filter \\n ");
+  *s += QStringLiteral("<Text 420 460 12 #000000 0 \"Quarter wave bandpass filter \\n ");
   switch (Filter->Type)
   {
-    case TYPE_BESSEL: *s += QString("Bessel"); break;
-    case TYPE_BUTTERWORTH: *s += QString("Butterworth"); break;
-    case TYPE_CHEBYSHEV: *s += QString("Chebyshev"); break;
+    case TYPE_BESSEL: *s += QStringLiteral("Bessel"); break;
+    case TYPE_BUTTERWORTH: *s += QStringLiteral("Butterworth"); break;
+    case TYPE_CHEBYSHEV: *s += QStringLiteral("Chebyshev"); break;
   }
-  *s += QString(" %1Hz...%2Hz \\n ").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2));
-  *s += QString("Impedance matching %3 Ohm\">\n").arg(Filter->Impedance);
+  *s += QStringLiteral(" %1Hz...%2Hz \\n ").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2));
+  *s += QStringLiteral("Impedance matching %3 Ohm\">\n").arg(Filter->Impedance);
   *s += "</Paintings>\n";
   return s;
 }

--- a/qucs-filter/qucsfilter.cpp
+++ b/qucs-filter/qucsfilter.cpp
@@ -511,7 +511,7 @@ void QucsFilter::slotShowResult()
   ResultState++;
   if(ResultState & 1)  c = 0xFF;
   else c = 0x80;
-  QString s = QString("<font color=\"#00%1000\"><b>  ").arg(c, 2, 16);
+  QString s = QStringLiteral("<font color=\"#00%1000\"><b>  ").arg(c, 2, 16);
   LabelResult->setText(tr("Result:") + s + tr("Successful") + "</b></font>");
 
   c = 500;

--- a/qucs-filter/stepz_filter.cpp
+++ b/qucs-filter/stepz_filter.cpp
@@ -53,8 +53,8 @@ QString* StepImpedance_Filter::createSchematic(tFilter *Filter, tSubstrate *Subs
 
   x = 60;
   *s += "<Components>\n";
-  *s += QString("<Pac P1 1 %1 330 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
-  *s += QString("<GND * 1 %1 360 0 0 0 0>\n").arg(x);
+  *s += QStringLiteral("<Pac P1 1 %1 330 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
+  *s += QStringLiteral("<GND * 1 %1 360 0 0 0 0>\n").arg(x);
 
   x -= 30;
   for(i = 0; i < Filter->Order; i++) {
@@ -85,36 +85,36 @@ QString* StepImpedance_Filter::createSchematic(tFilter *Filter, tSubstrate *Subs
     }
 
     if(isMicrostrip)
-      *s += QString("<MLIN MS1 1 %1 180 -26 15 0 0 \"Sub1\" 1 \"%2\" 1 \"%3\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(x).arg(num2str(width)).arg(num2str(len));
+      *s += QStringLiteral("<MLIN MS1 1 %1 180 -26 15 0 0 \"Sub1\" 1 \"%2\" 1 \"%3\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(x).arg(num2str(width)).arg(num2str(len));
     else
-      *s += QString("<TLIN Line1 1 %1 180 -26 20 0 0 \"%2\" 1 \"%3\" 1 \"0 dB\" 0 \"26.85\" 0>\n").arg(x).arg(Z0).arg(num2str(len));
+      *s += QStringLiteral("<TLIN Line1 1 %1 180 -26 20 0 0 \"%2\" 1 \"%3\" 1 \"0 dB\" 0 \"26.85\" 0>\n").arg(x).arg(Z0).arg(num2str(len));
   }
 
 
   x += 80;
-  *s += QString("<Pac P2 1 %1 330 18 -26 0 1 \"2\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
-  *s += QString("<GND * 1 %1 360 0 0 0 0>\n").arg(x);
+  *s += QStringLiteral("<Pac P2 1 %1 330 18 -26 0 1 \"2\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Filter->Impedance);
+  *s += QStringLiteral("<GND * 1 %1 360 0 0 0 0>\n").arg(x);
 
-  *s += QString("<.SP SP1 1 70 460 0 67 0 0 \"lin\" 1 \"%2Hz\" 1 \"%3Hz\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(num2str(0.1 * Filter->Frequency)).arg(num2str(10.0 * Filter->Frequency));
+  *s += QStringLiteral("<.SP SP1 1 70 460 0 67 0 0 \"lin\" 1 \"%2Hz\" 1 \"%3Hz\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(num2str(0.1 * Filter->Frequency)).arg(num2str(10.0 * Filter->Frequency));
   if(isMicrostrip)
-    *s += QString("<SUBST Sub1 1 300 500 -30 24 0 0 \"%1\" 1 \"%2m\" 1 \"%3m\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate->er).arg(num2str(Substrate->height)).arg(num2str(Substrate->thickness)).arg(Substrate->tand).arg(Substrate->resistivity).arg(Substrate->roughness);
-  *s += QString("<Eqn Eqn1 1 450 560 -28 15 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"yes\" 0>\n");
+    *s += QStringLiteral("<SUBST Sub1 1 300 500 -30 24 0 0 \"%1\" 1 \"%2m\" 1 \"%3m\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate->er).arg(num2str(Substrate->height)).arg(num2str(Substrate->thickness)).arg(Substrate->tand).arg(Substrate->resistivity).arg(Substrate->roughness);
+  *s += QStringLiteral("<Eqn Eqn1 1 450 560 -28 15 0 0 \"S21_dB=dB(S[2,1])\" 1 \"S11_dB=dB(S[1,1])\" 1 \"yes\" 0>\n");
   *s += "</Components>\n";
 
   *s += "<Wires>\n";
 
   // connect left source
-  *s += QString("<60 180 60 300 \"\" 0 0 0>\n");
-  *s += QString("<60 180 90 180 \"\" 0 0 0>\n");
+  *s += QStringLiteral("<60 180 60 300 \"\" 0 0 0>\n");
+  *s += QStringLiteral("<60 180 90 180 \"\" 0 0 0>\n");
 
   // connect right source
-  *s += QString("<%1 180 %2 300 \"\" 0 0 0>\n").arg(x).arg(x);
-  *s += QString("<%1 180 %2 180 \"\" 0 0 0>\n").arg(x-50).arg(x);
+  *s += QStringLiteral("<%1 180 %2 300 \"\" 0 0 0>\n").arg(x).arg(x);
+  *s += QStringLiteral("<%1 180 %2 180 \"\" 0 0 0>\n").arg(x-50).arg(x);
 
   // wires between components
   x = 150;
   for(i = 1; i < Filter->Order; i++) {
-    *s += QString("<%1 180 %2 180 \"\" 0 0 0>\n").arg(x).arg(x+30);
+    *s += QStringLiteral("<%1 180 %2 180 \"\" 0 0 0>\n").arg(x).arg(x+30);
     x += 90;
   }
 
@@ -125,15 +125,15 @@ QString* StepImpedance_Filter::createSchematic(tFilter *Filter, tSubstrate *Subs
 
   *s += "<Paintings>\n";
 
-  *s += QString("<Text 420 460 12 #000000 0 \"stepped-impedance lowpass filter \\n ");
+  *s += QStringLiteral("<Text 420 460 12 #000000 0 \"stepped-impedance lowpass filter \\n ");
   switch(Filter->Type) {
-    case TYPE_BESSEL:      *s += QString("Bessel"); break;
-    case TYPE_BUTTERWORTH: *s += QString("Butterworth"); break;
-    case TYPE_CHEBYSHEV:   *s += QString("Chebyshev"); break;
+    case TYPE_BESSEL:      *s += QStringLiteral("Bessel"); break;
+    case TYPE_BUTTERWORTH: *s += QStringLiteral("Butterworth"); break;
+    case TYPE_CHEBYSHEV:   *s += QStringLiteral("Chebyshev"); break;
   }
 
-  *s += QString(" %1Hz...%2Hz \\n ").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2));
-  *s += QString("impedance matching %3 Ohm\">\n").arg(Filter->Impedance);
+  *s += QStringLiteral(" %1Hz...%2Hz \\n ").arg(num2str(Filter->Frequency)).arg(num2str(Filter->Frequency2));
+  *s += QStringLiteral("impedance matching %3 Ohm\">\n").arg(Filter->Impedance);
   *s += "</Paintings>\n";
 
   return s;

--- a/qucs-powercombining/main.cpp
+++ b/qucs-powercombining/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
     QString lang = QucsSettings.Language;
     if(lang.isEmpty())
       lang = QString(QLocale::system().name());
-    tor.load( QString("qucs_") + lang, QucsSettings.LangDir);
+    tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir);
     app.installTranslator( &tor );
 
     QucsPowerCombiningTool *PowerCombiningTool = new QucsPowerCombiningTool();

--- a/qucs-powercombining/qucspowercombiningtool.cpp
+++ b/qucs-powercombining/qucspowercombiningtool.cpp
@@ -355,54 +355,54 @@ void QucsPowerCombiningTool::UpdateImage()
        case 0: //Wilkinson
                if (lumpedImplementation)
                {
-                  imgWidget->load(QString(":/bitmaps/WilkinsonLC.svg"));
+                  imgWidget->load(QStringLiteral(":/bitmaps/WilkinsonLC.svg"));
                }
                else
                { 
-                (microstripImplementation) ? imgWidget->load(QString(":/bitmaps/Wilkinson_microstrip.svg"))
-                                           : imgWidget->load(QString(":/bitmaps/Wilkinson_idealTL.svg"));
+                (microstripImplementation) ? imgWidget->load(QStringLiteral(":/bitmaps/Wilkinson_microstrip.svg"))
+                                           : imgWidget->load(QStringLiteral(":/bitmaps/Wilkinson_idealTL.svg"));
                }
                break;
        case 1: //Mutistage Wilkinson
                if (lumpedImplementation)
                {
-                  imgWidget->load(QString(":/bitmaps/MultistageWilkinsonLC.svg"));
+                  imgWidget->load(QStringLiteral(":/bitmaps/MultistageWilkinsonLC.svg"));
                }
                else
                {
-                (microstripImplementation) ? imgWidget->load(QString(":/bitmaps/MultistageWilkinson_microstrip.svg"))
-                                           : imgWidget->load(QString(":/bitmaps/MultistageWilkinson_idealTL.svg"));
+                (microstripImplementation) ? imgWidget->load(QStringLiteral(":/bitmaps/MultistageWilkinson_microstrip.svg"))
+                                           : imgWidget->load(QStringLiteral(":/bitmaps/MultistageWilkinson_idealTL.svg"));
                }
                                        
                break;
        case 2: //Tee
-               (microstripImplementation) ? imgWidget->load(QString(":/bitmaps/Tee_microstrip.svg"))
-                                          : imgWidget->load(QString(":/bitmaps/Tee_idealTL.svg")); 
+               (microstripImplementation) ? imgWidget->load(QStringLiteral(":/bitmaps/Tee_microstrip.svg"))
+                                          : imgWidget->load(QStringLiteral(":/bitmaps/Tee_idealTL.svg"));
                break;
        case 3: //Branch-line
-               (microstripImplementation) ? imgWidget->load(QString(":/bitmaps/Branchline_microstrip.svg"))
-                                          : imgWidget->load(QString(":/bitmaps/Branchline_idealTL.svg"));
+               (microstripImplementation) ? imgWidget->load(QStringLiteral(":/bitmaps/Branchline_microstrip.svg"))
+                                          : imgWidget->load(QStringLiteral(":/bitmaps/Branchline_idealTL.svg"));
                break;
        case 4: //Double-box branch-line
-               (microstripImplementation) ? imgWidget->load(QString(":/bitmaps/DoubleBoxBranchline_microstrip.svg"))
-                                          : imgWidget->load(QString(":/bitmaps/DoubleBoxBranchline_idealTL.svg"));
+               (microstripImplementation) ? imgWidget->load(QStringLiteral(":/bitmaps/DoubleBoxBranchline_microstrip.svg"))
+                                          : imgWidget->load(QStringLiteral(":/bitmaps/DoubleBoxBranchline_idealTL.svg"));
                break;
        case 5: //Bagley power combiner
-               (microstripImplementation) ? imgWidget->load(QString(":/bitmaps/Bagley_microstrip.svg"))
-                                          : imgWidget->load(QString(":/bitmaps/Bagley_idealTL.svg"));
+               (microstripImplementation) ? imgWidget->load(QStringLiteral(":/bitmaps/Bagley_microstrip.svg"))
+                                          : imgWidget->load(QStringLiteral(":/bitmaps/Bagley_idealTL.svg"));
                break;
        case 6: //Gysel power combiner
-               (microstripImplementation) ? imgWidget->load(QString(":/bitmaps/Gysel_microstrip.svg"))
-                                          : imgWidget->load(QString(":/bitmaps/Gysel_idealTL.svg")); 
+               (microstripImplementation) ? imgWidget->load(QStringLiteral(":/bitmaps/Gysel_microstrip.svg"))
+                                          : imgWidget->load(QStringLiteral(":/bitmaps/Gysel_idealTL.svg"));
                break;
        // -------------  CORPORATE COMBINERS  -----------------
        case 7: //Travelling wave
-               (microstripImplementation) ? imgWidget->load(QString(":/bitmaps/TravellingWave_microstrip.svg"))
-                                          : imgWidget->load(QString(":/bitmaps/TravellingWave_idealTL.svg"));
+               (microstripImplementation) ? imgWidget->load(QStringLiteral(":/bitmaps/TravellingWave_microstrip.svg"))
+                                          : imgWidget->load(QStringLiteral(":/bitmaps/TravellingWave_idealTL.svg"));
                break;
        case 8: //Tree
-               (microstripImplementation) ? imgWidget->load(QString(":/bitmaps/Tree_microstrip.svg"))
-                                          : imgWidget->load(QString(":/bitmaps/Tree_idealTL.svg")); 
+               (microstripImplementation) ? imgWidget->load(QStringLiteral(":/bitmaps/Tree_microstrip.svg"))
+                                          : imgWidget->load(QStringLiteral(":/bitmaps/Tree_idealTL.svg"));
                break;   
     }
 }
@@ -589,7 +589,7 @@ QString QucsPowerCombiningTool::CalculateWilkinson(double Z0, double K)
     double R=Z0*((K2+1)/K);
     double R2 = Z0*K;
     double R3 = Z0/K;
-    return QString("%1;%2;%3;%4;%5").arg(Z2).arg(Z3).arg(R).arg(R2).arg(R3);
+    return QStringLiteral("%1;%2;%3;%4;%5").arg(Z2).arg(Z3).arg(R).arg(R2).arg(R3);
 }
 
 //-----------------------------------------------------
@@ -636,70 +636,70 @@ int QucsPowerCombiningTool::Wilkinson(double Z0, double Freq, double K, bool SP_
     if (SP_block)
     {
         //Source
-        s += QString("<Pac P1 1 0 0 18 -26 0 1 \"1\" 0 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 0 30 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 0 0 18 -26 0 1 \"1\" 0 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 0 30 0 0 0 0>\n");
         //Output port 1
-        s += QString("<Pac P1 1 500 -60 18 -26 0 1 \"1\" 0 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 500 -30 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 500 -60 18 -26 0 1 \"1\" 0 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 500 -30 0 0 0 0>\n");
         //Output port 2
-        s += QString("<Pac P1 1 500 60 18 -26 0 1 \"1\" 0 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 500 90 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 500 60 18 -26 0 1 \"1\" 0 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 500 90 0 0 0 0>\n");
         
         //S-parameter analysis component
-        QString freq_start = QString("%1%2").arg(0.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        QString freq_stop = QString("%1%2").arg(1.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        s += QString("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg((freq_start)).arg((freq_stop));
+        QString freq_start = QStringLiteral("%1%2").arg(0.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        QString freq_stop = QStringLiteral("%1%2").arg(1.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        s += QStringLiteral("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg((freq_start)).arg((freq_stop));
         s += getSPEquationString(50,200);
-        if (microcheck)s += QString("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
+        if (microcheck)s += QStringLiteral("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
     }
 
     if (microcheck)//Microstrip implementation
     {
         er = Substrate.er;
         getMicrostrip(Z0, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 130 -30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 130 -30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(Z2, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 260 -90 -26 -71 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 260 -90 -26 -71 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(Z3, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 260 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 260 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
     }
     else
     {
         if (LumpedElements)// CLC equivalent
         {
         //First capacitor
-        s += QString("<C C1 1 110 0 13 4 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(CC));
-        s += QString("<GND * 1 110 30 0 1 0 0>\n");
+        s += QStringLiteral("<C C1 1 110 0 13 4 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(CC));
+        s += QStringLiteral("<GND * 1 110 30 0 1 0 0>\n");
 
         //Upper branch
-        s += QString("<C C1 1 310 -140 -89 -28 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C2));
-        s += QString("<GND * 1 310 -170 0 0 0 2>\n");
-        s += QString("<L L1 1 260 -90 -25 8 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L2));
+        s += QStringLiteral("<C C1 1 310 -140 -89 -28 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C2));
+        s += QStringLiteral("<GND * 1 310 -170 0 0 0 2>\n");
+        s += QStringLiteral("<L L1 1 260 -90 -25 8 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L2));
         //Lower branch
-        s += QString("<C C1 1 310 80 -77 10 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C3));
-        s += QString("<GND * 1 310 110 0 0 0 0>\n");
-        s += QString("<L L2 1 260 30 -28 12 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L3));
+        s += QStringLiteral("<C C1 1 310 80 -77 10 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C3));
+        s += QStringLiteral("<GND * 1 310 110 0 0 0 0>\n");
+        s += QStringLiteral("<L L2 1 260 30 -28 12 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L3));
         }
         else
         {
-        s += QString("<TLIN Line1 1 130 -30 -26 20 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Z0)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Z0 line
-        s += QString("<TLIN Line1 1 260 -90 -26 -71 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Z2)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 1
-        s += QString("<TLIN Line1 1 260 30 -26 20 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Z3)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 2
+        s += QStringLiteral("<TLIN Line1 1 130 -30 -26 20 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Z0)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Z0 line
+        s += QStringLiteral("<TLIN Line1 1 260 -90 -26 -71 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Z2)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 1
+        s += QStringLiteral("<TLIN Line1 1 260 30 -26 20 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Z3)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 2
         }
     }
-    s += QString("<R R1 1 340 -20 20 -26 0 -1 \"%1 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(R);//Isolation resistor
+    s += QStringLiteral("<R R1 1 340 -20 20 -26 0 -1 \"%1 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(R);//Isolation resistor
     if (K!=1)
     {// An unequal power ratio implies that the load impedance != 50, so it requires matching
         if (microcheck)//Microstrip
         {
             er = Substrate.er;
             getMicrostrip(sqrt(Z0*R2), Freq, &Substrate, width, er);
-            s += QString("<MLIN MS1 1 410 -90 -26 -71 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+            s += QStringLiteral("<MLIN MS1 1 410 -90 -26 -71 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
             er = Substrate.er;
             getMicrostrip(sqrt(Z0*R3), Freq, &Substrate, width, er);
-            s += QString("<MLIN MS1 1 410 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+            s += QStringLiteral("<MLIN MS1 1 410 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
 
         }
         else
@@ -707,19 +707,19 @@ int QucsPowerCombiningTool::Wilkinson(double Z0, double Freq, double K, bool SP_
            if (LumpedElements)//CLC equivalent
            {
              // Upper branch
-             s += QString("<L L2 1 410 -90 -22 5 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L2_));
-             s += QString("<C C1 1 450 -140 -80 -30 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C2_));
-             s += QString("<GND * 1 450 -170 0 0 0 2>\n");
+             s += QStringLiteral("<L L2 1 410 -90 -22 5 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L2_));
+             s += QStringLiteral("<C C1 1 450 -140 -80 -30 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C2_));
+             s += QStringLiteral("<GND * 1 450 -170 0 0 0 2>\n");
 
              // Lower branch
-             s += QString("<L L2 1 410 30 -41 7 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L3_));
-             s += QString("<C C1 1 450 90 -79 -7 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C3_));
-             s += QString("<GND * 1 450 120 0 0 0 0>\n");
+             s += QStringLiteral("<L L2 1 410 30 -41 7 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L3_));
+             s += QStringLiteral("<C C1 1 450 90 -79 -7 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C3_));
+             s += QStringLiteral("<GND * 1 450 120 0 0 0 0>\n");
            }
            else
            {
-               s += QString("<TLIN Line1 1 410 -90 -26 -71 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(sqrt(Z0*R2))).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Quarter wave matching output branch 1
-               s += QString("<TLIN Line1 1 410 30 -26 20 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(sqrt(Z0*R3))).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Quarter wave matching output branch 2
+               s += QStringLiteral("<TLIN Line1 1 410 -90 -26 -71 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(sqrt(Z0*R2))).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Quarter wave matching output branch 1
+               s += QStringLiteral("<TLIN Line1 1 410 30 -26 20 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(sqrt(Z0*R3))).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Quarter wave matching output branch 2
            }
            }
     }
@@ -727,47 +727,47 @@ int QucsPowerCombiningTool::Wilkinson(double Z0, double Freq, double K, bool SP_
 
     //Wiring
     s += "<Wires>\n";
-    s += QString("<0 -30 100 -30 \"\" 0 0 0>\n");//Source to Z0 line
-    s += QString("<160 -30 190 -30 \"\" 0 0 0 \"\">\n");//Z0 line to branches
-    s += QString("<190 -90 190 -30 \"\" 0 0 0 \"\">\n");//Z0 line to upper branch
-    s += QString("<190 -90 230 -90 \"\" 0 0 0 \"\">\n");//Z0 line (corner) to upper branch
-    s += QString("<290 -90 340 -90 \"\" 0 0 0 \"\">\n");//Upper branch to isolation resistor
-    s += QString("<340 -90 340 -50 \"\" 0 0 0 \"\">\n");//Upper branch (corner) to isolation resistor
-    s += QString("<190 -30 190 30 \"\" 0 0 0 \"\">\n");//Z0 line to lower branch
-    s += QString("<190 30 230 30 \"\" 0 0 0 \"\">\n");//Z0 line (corner) to lower branch
-    s += QString("<290 30 340 30 \"\" 0 0 0 \"\">\n");//Lower branch to isolation resistor
-    s += QString("<340 10 340 30 \"\" 0 0 0 \"\">\n");//Lower branch (corner) to isolation resistor
+    s += QStringLiteral("<0 -30 100 -30 \"\" 0 0 0>\n");//Source to Z0 line
+    s += QStringLiteral("<160 -30 190 -30 \"\" 0 0 0 \"\">\n");//Z0 line to branches
+    s += QStringLiteral("<190 -90 190 -30 \"\" 0 0 0 \"\">\n");//Z0 line to upper branch
+    s += QStringLiteral("<190 -90 230 -90 \"\" 0 0 0 \"\">\n");//Z0 line (corner) to upper branch
+    s += QStringLiteral("<290 -90 340 -90 \"\" 0 0 0 \"\">\n");//Upper branch to isolation resistor
+    s += QStringLiteral("<340 -90 340 -50 \"\" 0 0 0 \"\">\n");//Upper branch (corner) to isolation resistor
+    s += QStringLiteral("<190 -30 190 30 \"\" 0 0 0 \"\">\n");//Z0 line to lower branch
+    s += QStringLiteral("<190 30 230 30 \"\" 0 0 0 \"\">\n");//Z0 line (corner) to lower branch
+    s += QStringLiteral("<290 30 340 30 \"\" 0 0 0 \"\">\n");//Lower branch to isolation resistor
+    s += QStringLiteral("<340 10 340 30 \"\" 0 0 0 \"\">\n");//Lower branch (corner) to isolation resistor
 
     if (LumpedElements)
     {
-       s += QString("<90 -30 180 -30 \"\" 0 0 0>\n");
-       s += QString("<310 -110 310 -90 \"\" 0 0 0>\n");//Upper branch
-       s += QString("<310 30 310 50 \"\" 0 0 0>\n");//Lower branch
+       s += QStringLiteral("<90 -30 180 -30 \"\" 0 0 0>\n");
+       s += QStringLiteral("<310 -110 310 -90 \"\" 0 0 0>\n");//Upper branch
+       s += QStringLiteral("<310 30 310 50 \"\" 0 0 0>\n");//Lower branch
     }
 
     if (K!=1)//Unequal power split ratio => need additional matching
     {
         if (LumpedElements)
         {
-         s += QString("<340 -90 380 -90 \"\" 0 0 0 \"\">\n");//Upper branch, R to L
-         s += QString("<440 -90 500 -90 \"\" 0 0 0 \"\">\n");//Upper branch, L to port
-         s += QString("<450 -110 450 -90 \"\" 0 0 0 \"\">\n");//Upper branch, L to C
-         s += QString("<340 30 380 30 \"\" 0 0 0 \"\">\n");//Lower branch, R to L
-         s += QString("<440 30 500 30 \"\" 0 0 0 \"\">\n");//Lower branch, L to port
-         s += QString("<450 30 450 60 \"\" 0 0 0 \"\">\n");//Lower branch, L to C
+         s += QStringLiteral("<340 -90 380 -90 \"\" 0 0 0 \"\">\n");//Upper branch, R to L
+         s += QStringLiteral("<440 -90 500 -90 \"\" 0 0 0 \"\">\n");//Upper branch, L to port
+         s += QStringLiteral("<450 -110 450 -90 \"\" 0 0 0 \"\">\n");//Upper branch, L to C
+         s += QStringLiteral("<340 30 380 30 \"\" 0 0 0 \"\">\n");//Lower branch, R to L
+         s += QStringLiteral("<440 30 500 30 \"\" 0 0 0 \"\">\n");//Lower branch, L to port
+         s += QStringLiteral("<450 30 450 60 \"\" 0 0 0 \"\">\n");//Lower branch, L to C
         }
         else//Transmission lines
         {
-         s += QString("<340 -90 380 -90 \"\" 0 0 0 \"\">\n");//Isolation resistor to matching line. Upper branch
-         s += QString("<440 -90 500 -90 \"\" 0 0 0 \"\">\n");//Matching line to port 2. Upper branch
-         s += QString("<340 30 380 30 \"\" 0 0 0 \"\">\n");//Isolation resistor to matching line. Lowe branch
-         s += QString("<440 30 500 30 \"\" 0 0 0 \"\">\n");//Matching line to port 2. Lower branch
+         s += QStringLiteral("<340 -90 380 -90 \"\" 0 0 0 \"\">\n");//Isolation resistor to matching line. Upper branch
+         s += QStringLiteral("<440 -90 500 -90 \"\" 0 0 0 \"\">\n");//Matching line to port 2. Upper branch
+         s += QStringLiteral("<340 30 380 30 \"\" 0 0 0 \"\">\n");//Isolation resistor to matching line. Lowe branch
+         s += QStringLiteral("<440 30 500 30 \"\" 0 0 0 \"\">\n");//Matching line to port 2. Lower branch
         }
     }
     else//Equal power split ratio
     {
-        s += QString("<340 -90 500 -90 \"\" 0 0 0 \"\">\n");//Branch 2 to Port 2
-        s += QString("<340 30 500 30 \"\" 0 0 0 \"\">\n");//Branch 2 to Port 3
+        s += QStringLiteral("<340 -90 500 -90 \"\" 0 0 0 \"\">\n");//Branch 2 to Port 2
+        s += QStringLiteral("<340 30 500 30 \"\" 0 0 0 \"\">\n");//Branch 2 to Port 3
     }
 
     s += "</Wires>\n";
@@ -847,7 +847,7 @@ QString QucsPowerCombiningTool::calcChebyLines(double RL, double Z0, double gamm
     {
         (RL<Z0) ? Zi = exp(log(Zaux) - gamma*w[i]):Zi = exp(log(Zaux) + gamma*w[i]); // When RL<Z0, Z_{i}<Z_{i-1}
         Zaux=Zi;
-        s+=QString("%1;").arg(Zi);
+        s+=QStringLiteral("%1;").arg(Zi);
 
     }
     return s;
@@ -865,7 +865,7 @@ QString QucsPowerCombiningTool::calcMultistageWilkinsonIsolators(QString Zlines,
     Zaux  = Zlines.section(';', i-1, i-1).toDouble();
     R = Z0*Z_/(Z_ - Z0);
     Zi = Z0;
-    s +=QString("%1;").arg(2*R);
+    s +=QStringLiteral("%1;").arg(2*R);
   }
   return s;
 }
@@ -922,21 +922,21 @@ int QucsPowerCombiningTool::MultistageWilkinson(double Z0, double Freq, int NSta
     if (SP_block)//Add S-param simulation
     {
         //Source
-        s += QString("<Pac P1 1 0 30 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 0 60 0 0 0 0>\n");
-        wirestr +=QString("<0 0 0 -30 \"\" 0 0 0>\n");//Vertical wire
-        wirestr +=QString("<0 -30 70 -30 \"\" 0 0 0>\n");//Horizontal wire
+        s += QStringLiteral("<Pac P1 1 0 30 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 0 60 0 0 0 0>\n");
+        wirestr +=QStringLiteral("<0 0 0 -30 \"\" 0 0 0>\n");//Vertical wire
+        wirestr +=QStringLiteral("<0 -30 70 -30 \"\" 0 0 0>\n");//Horizontal wire
         //S-parameter analysis component
-        QString freq_start = QString("%1%2").arg((1/NStages)*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        QString freq_stop = QString("%1%2").arg((2+1/NStages)*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        s += QString("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop);
-        str += QString("\"S11_dB=dB(S[1,1])\" 1 ");
-        str += QString("\"S22_dB=dB(S[2,2])\" 1 ");
-        str += QString("\"S33_dB=dB(S[3,3])\" 1 ");
-        str += QString("\"S21_dB=dB(S[2,1])\" 1 ");
-        str +=QString("\"S31_dB=dB(S[3,1])\" 1 ");
+        QString freq_start = QStringLiteral("%1%2").arg((1/NStages)*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        QString freq_stop = QStringLiteral("%1%2").arg((2+1/NStages)*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        s += QStringLiteral("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop);
+        str += QStringLiteral("\"S11_dB=dB(S[1,1])\" 1 ");
+        str += QStringLiteral("\"S22_dB=dB(S[2,2])\" 1 ");
+        str += QStringLiteral("\"S33_dB=dB(S[3,3])\" 1 ");
+        str += QStringLiteral("\"S21_dB=dB(S[2,1])\" 1 ");
+        str +=QStringLiteral("\"S31_dB=dB(S[3,1])\" 1 ");
         s += getSPEquationString(50,200);
-        if (microcheck)s += QString("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
+        if (microcheck)s += QStringLiteral("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
 
     }
 
@@ -947,28 +947,28 @@ int QucsPowerCombiningTool::MultistageWilkinson(double Z0, double Freq, int NSta
     {
         er = Substrate.er;
         getMicrostrip(Z0, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 %3 -30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x);
+        s += QStringLiteral("<MLIN MS1 1 %3 -30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x);
     }
     else
     {
        if (LumpedElements)//LC elements. Pi CLC equivalent of a lambda/4 line
        {
         //First capacitor
-        s += QString("<C C1 1 %2 0 -35 -80 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(2*C[0])).arg(x);
-        s += QString("<GND * 1 %2 30 0 1 0 0>\n").arg(x);
-        wirestr +=QString("<%1 -30 %2 -30 \"\" 0 0 0>\n").arg(x-30).arg(x+30);
+        s += QStringLiteral("<C C1 1 %2 0 -35 -80 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(2*C[0])).arg(x);
+        s += QStringLiteral("<GND * 1 %2 30 0 1 0 0>\n").arg(x);
+        wirestr +=QStringLiteral("<%1 -30 %2 -30 \"\" 0 0 0>\n").arg(x-30).arg(x+30);
        }
        else//Ideal transmission lines
        {
-       s += QString("<TLIN Line1 1 %1 -30 -26 20 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x).arg(RoundVariablePrecision(Z0)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Z0 line
+       s += QStringLiteral("<TLIN Line1 1 %1 -30 -26 20 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x).arg(RoundVariablePrecision(Z0)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Z0 line
        }
 
     }
     
     
     x+=50;//Separation between the source transmission line and the beginning of the output branches
-    wirestr +=QString("<%1 -30 %2 -30 \"\" 0 0 0>\n").arg(x-20).arg(x+30);//Vertical line joining the output branches
-    wirestr +=QString("<%1 -90 %1 30 \"\" 0 0 0>\n").arg(x+30);//Vertical line joining the output branches
+    wirestr +=QStringLiteral("<%1 -30 %2 -30 \"\" 0 0 0>\n").arg(x-20).arg(x+30);//Vertical line joining the output branches
+    wirestr +=QStringLiteral("<%1 -90 %1 30 \"\" 0 0 0>\n").arg(x+30);//Vertical line joining the output branches
     
 
 
@@ -978,24 +978,24 @@ int QucsPowerCombiningTool::MultistageWilkinson(double Z0, double Freq, int NSta
         Zi = Zlines.section(';', i, i).toDouble();
         Ri = Risol.section(';', (NStages-1)-i, (NStages-1)-i).toDouble();
 
-        wirestr +=QString("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+30).arg(x+70);
-        wirestr +=QString("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+30).arg(x+70);
+        wirestr +=QStringLiteral("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+30).arg(x+70);
+        wirestr +=QStringLiteral("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+30).arg(x+70);
 
-        wirestr +=QString("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+130).arg(x+180);
-        wirestr +=QString("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+130).arg(x+180);
+        wirestr +=QStringLiteral("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+130).arg(x+180);
+        wirestr +=QStringLiteral("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+130).arg(x+180);
 
         //Wiring the isolation resistor
-        wirestr +=QString("<%1 30 %1 10 \"\" 0 0 0>\n").arg(x+160);
-        wirestr +=QString("<%1 -90 %1 -50 \"\" 0 0 0>\n").arg(x+160);
+        wirestr +=QStringLiteral("<%1 30 %1 10 \"\" 0 0 0>\n").arg(x+160);
+        wirestr +=QStringLiteral("<%1 -90 %1 -50 \"\" 0 0 0>\n").arg(x+160);
 
         if (microcheck)
         {
             er = Substrate.er;
             getMicrostrip(Zi, Freq, &Substrate, width, er);
-            s += QString("<MLIN MS1 1 %3 -90 -30 -73 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x+100);
+            s += QStringLiteral("<MLIN MS1 1 %3 -90 -30 -73 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x+100);
             er = Substrate.er;
             getMicrostrip(Zi, Freq, &Substrate, width, er);
-            s += QString("<MLIN MS1 1 %3 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x+100);
+            s += QStringLiteral("<MLIN MS1 1 %3 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x+100);
         }
         else
         {
@@ -1004,50 +1004,50 @@ int QucsPowerCombiningTool::MultistageWilkinson(double Z0, double Freq, int NSta
                if (i == 0)//Last element
                {
                  // Upper branch
-                 s += QString("<L L2 1 %2 -90 -31 9 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L[aux-1])).arg(x+100);
-                 s += QString("<C C1 1 %2 -150 14 -21 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C[aux-1])).arg(x+160);
-                 wirestr +=QString("<%1 -90 %1 -120 \"\" 0 0 0>\n").arg(x+160);
-                 s += QString("<GND * 1 %2 -180 0 0 0 2>\n").arg(x+160);
+                 s += QStringLiteral("<L L2 1 %2 -90 -31 9 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L[aux-1])).arg(x+100);
+                 s += QStringLiteral("<C C1 1 %2 -150 14 -21 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C[aux-1])).arg(x+160);
+                 wirestr +=QStringLiteral("<%1 -90 %1 -120 \"\" 0 0 0>\n").arg(x+160);
+                 s += QStringLiteral("<GND * 1 %2 -180 0 0 0 2>\n").arg(x+160);
 
                  // Lower branch
-                 s += QString("<L L2 1 %2 30 -31 9 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L[aux-1])).arg(x+100);
-                 s += QString("<C C1 1 %2 90 14 -23 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C[aux-1])).arg(x+160);
-                 wirestr +=QString("<%1 30 %1 60 \"\" 0 0 0>\n").arg(x+160);
-                 s += QString("<GND * 1 %2 120 0 0 0 0>\n").arg(x+160);
+                 s += QStringLiteral("<L L2 1 %2 30 -31 9 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L[aux-1])).arg(x+100);
+                 s += QStringLiteral("<C C1 1 %2 90 14 -23 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C[aux-1])).arg(x+160);
+                 wirestr +=QStringLiteral("<%1 30 %1 60 \"\" 0 0 0>\n").arg(x+160);
+                 s += QStringLiteral("<GND * 1 %2 120 0 0 0 0>\n").arg(x+160);
                          
                 }
                 else
                 {
                  // Upper branch
-                 s += QString("<L L2 1 %2 -90 -31 9 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L[aux-1])).arg(x+100);
-                 s += QString("<C C1 1 %2 -150 14 -21 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C[aux]+C[aux-1])).arg(x+160);
-                 wirestr +=QString("<%1 -90 %1 -120 \"\" 0 0 0>\n").arg(x+160);
-                 s += QString("<GND * 1 %2 -180 0 0 0 2>\n").arg(x+160);
+                 s += QStringLiteral("<L L2 1 %2 -90 -31 9 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L[aux-1])).arg(x+100);
+                 s += QStringLiteral("<C C1 1 %2 -150 14 -21 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C[aux]+C[aux-1])).arg(x+160);
+                 wirestr +=QStringLiteral("<%1 -90 %1 -120 \"\" 0 0 0>\n").arg(x+160);
+                 s += QStringLiteral("<GND * 1 %2 -180 0 0 0 2>\n").arg(x+160);
 
                  // Lower branch
-                 s += QString("<L L2 1 %2 30 -31 9 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L[aux-1])).arg(x+100);
-                 s += QString("<C C1 1 %2 90 14 -23 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C[aux]+C[aux-1])).arg(x+160);
-                 wirestr +=QString("<%1 30 %1 60 \"\" 0 0 0>\n").arg(x+160);
-                 s += QString("<GND * 1 %2 120 0 0 0 0>\n").arg(x+160);
+                 s += QStringLiteral("<L L2 1 %2 30 -31 9 0 0 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(L[aux-1])).arg(x+100);
+                 s += QStringLiteral("<C C1 1 %2 90 14 -23 0 3 \"%1\" 1 \"\" 0 \"neutral\" 0>\n").arg(num2str(C[aux]+C[aux-1])).arg(x+160);
+                 wirestr +=QStringLiteral("<%1 30 %1 60 \"\" 0 0 0>\n").arg(x+160);
+                 s += QStringLiteral("<GND * 1 %2 120 0 0 0 0>\n").arg(x+160);
                }
             }
             else//Ideal transmission lines
             {
-            s += QString("<TLIN Line1 1 %1 -90 -30 -73 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x+100).arg(RoundVariablePrecision(Zi)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Upper branch
-            s += QString("<TLIN Line1 1 %1 30 -26 20 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x+100).arg(RoundVariablePrecision(Zi)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Lower branch
+            s += QStringLiteral("<TLIN Line1 1 %1 -90 -30 -73 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x+100).arg(RoundVariablePrecision(Zi)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Upper branch
+            s += QStringLiteral("<TLIN Line1 1 %1 30 -26 20 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x+100).arg(RoundVariablePrecision(Zi)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Lower branch
             }
         }
-        s += QString("<R R1 1 %1 -20 11 -25 0 3 \"%2 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(x+160).arg(RoundVariablePrecision(Ri));//Isolation resistor
+        s += QStringLiteral("<R R1 1 %1 -20 11 -25 0 3 \"%2 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(x+160).arg(RoundVariablePrecision(Ri));//Isolation resistor
         x+=spacing;
 
         if(SP_block && (i==1))//Add output ports at the last stage
         {
-                s += QString("<Pac P1 1 %1 60 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x+300).arg(Z0);
-                s += QString("<GND * 1 %1 90 0 0 0 0>\n").arg(x+300);
-                wirestr +=QString("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+150).arg(x+300);
-                s += QString("<Pac P1 1 %1 -60 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x+300).arg(Z0);
-                s += QString("<GND * 1 %1 -30 0 0 0 0>\n").arg(x+300);
-                wirestr +=QString("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+150).arg(x+300);
+                s += QStringLiteral("<Pac P1 1 %1 60 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x+300).arg(Z0);
+                s += QStringLiteral("<GND * 1 %1 90 0 0 0 0>\n").arg(x+300);
+                wirestr +=QStringLiteral("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+150).arg(x+300);
+                s += QStringLiteral("<Pac P1 1 %1 -60 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x+300).arg(Z0);
+                s += QStringLiteral("<GND * 1 %1 -30 0 0 0 0>\n").arg(x+300);
+                wirestr +=QStringLiteral("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+150).arg(x+300);
         }
       }
       s += "</Components>\n";
@@ -1069,20 +1069,20 @@ int QucsPowerCombiningTool::Tee(double Z0, double Freq, double K, bool SP_block,
     if (SP_block)
     {
         //Source
-        s += QString("<Pac P1 1 0 0 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 0 30 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 0 0 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 0 30 0 0 0 0>\n");
         //Output port 1
-        s += QString("<Pac P1 1 450 -60 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(2*Z0);
-        s += QString("<GND * 1 450 -30 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 450 -60 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(2*Z0);
+        s += QStringLiteral("<GND * 1 450 -30 0 0 0 0>\n");
         //Output port 2
-        s += QString("<Pac P1 1 450 60 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(2*Z0);
-        s += QString("<GND * 1 450 90 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 450 60 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(2*Z0);
+        s += QStringLiteral("<GND * 1 450 90 0 0 0 0>\n");
         //S-parameter analysis component
-        QString freq_start = QString("%1%2").arg(0.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        QString freq_stop = QString("%1%2").arg(1.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        s += QString("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop);
-        s += QString("<Eqn Eqn1 1 50 200 -28 15 0 0 \"S11_dB=dB(S[1,1])\" 1 \"S21_dB=dB(S[2,1])\" 1  \"S31_dB=dB(S[3,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"S33_dB=dB(S[3,3])\" 1 \"yes\" 0>\n");
-        if (microcheck)s += QString("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
+        QString freq_start = QStringLiteral("%1%2").arg(0.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        QString freq_stop = QStringLiteral("%1%2").arg(1.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        s += QStringLiteral("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop);
+        s += QStringLiteral("<Eqn Eqn1 1 50 200 -28 15 0 0 \"S11_dB=dB(S[1,1])\" 1 \"S21_dB=dB(S[2,1])\" 1  \"S31_dB=dB(S[3,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"S33_dB=dB(S[3,3])\" 1 \"yes\" 0>\n");
+        if (microcheck)s += QStringLiteral("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
 
     }
 
@@ -1090,19 +1090,19 @@ int QucsPowerCombiningTool::Tee(double Z0, double Freq, double K, bool SP_block,
     {
         er = Substrate.er;
         getMicrostrip(Z0, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 120 -30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 120 -30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(Z0*(K+1), Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 270 -90 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 270 -90 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(Z0*(K+1)/K, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 270 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 270 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
     }
     else
     {
-        s += QString("<TLIN Line1 1 120 -30 -26 20 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Z0)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Z0 line
-        s += QString("<TLIN Line1 1 270 -90 -26 20 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Z0*(K+1))).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 1
-        s += QString("<TLIN Line1 1 270 30 -26 20 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Z0*(K+1)/K)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 2
+        s += QStringLiteral("<TLIN Line1 1 120 -30 -26 20 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Z0)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Z0 line
+        s += QStringLiteral("<TLIN Line1 1 270 -90 -26 20 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Z0*(K+1))).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 1
+        s += QStringLiteral("<TLIN Line1 1 270 30 -26 20 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Z0*(K+1)/K)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 2
     }
     if (K!=1)
     {// An unequal power ratio implies that the load impedance != 50, so it requires matching
@@ -1110,39 +1110,39 @@ int QucsPowerCombiningTool::Tee(double Z0, double Freq, double K, bool SP_block,
         {
             er = Substrate.er;
             getMicrostrip(sqrt(2*Z0*Z0*(K+1)), Freq, &Substrate, width, er);
-            s += QString("<MLIN MS1 1 370 -90 -26 20 0 0 \"Sub1\" 0 \"%1\" 0 \"%2\" 0 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(width).arg(lambda4/sqrt(er));
+            s += QStringLiteral("<MLIN MS1 1 370 -90 -26 20 0 0 \"Sub1\" 0 \"%1\" 0 \"%2\" 0 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(width).arg(lambda4/sqrt(er));
             er = Substrate.er;
             getMicrostrip(sqrt(Z0*Z0*(K+1)/K), Freq, &Substrate, width, er);
-            s += QString("<MLIN MS1 1 370 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 0 \"%2\" 0 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(width).arg(lambda4/sqrt(er));
+            s += QStringLiteral("<MLIN MS1 1 370 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 0 \"%2\" 0 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(width).arg(lambda4/sqrt(er));
 
         }
         else
         {
-            s += QString("<TLIN Line1 1 370 -90 -26 20 0 0 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(sqrt(2*Z0*Z0*(K+1)))).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Quarter wave matching output branch 1
-            s += QString("<TLIN Line1 1 370 30 -26 20 0 0 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(sqrt(2*Z0*Z0*(K+1)/K))).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Quarter wave matching output branch 2
+            s += QStringLiteral("<TLIN Line1 1 370 -90 -26 20 0 0 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(sqrt(2*Z0*Z0*(K+1)))).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Quarter wave matching output branch 1
+            s += QStringLiteral("<TLIN Line1 1 370 30 -26 20 0 0 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(sqrt(2*Z0*Z0*(K+1)/K))).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Quarter wave matching output branch 2
         }
     }
     s += "</Components>\n";
 
     //Wiring
     s += "<Wires>\n";
-    s += QString("<0 -30 90 -30 \"\" 0 0 0>\n");//Source to Z0 line
-    s += QString("<150 -30 200 -30 \"\" 0 0 0>\n");//Source to Z0 line
-    s += QString("<200 30 200 -90 \"\" 0 0 0>\n");//Z0 line to branches
-    s += QString("<200 30 240 30 \"\" 0 0 0>\n");//Z0 line to branch 1
-    s += QString("<200 -90 240 -90 \"\" 0 0 0>\n");//Z0 line to branch 2
+    s += QStringLiteral("<0 -30 90 -30 \"\" 0 0 0>\n");//Source to Z0 line
+    s += QStringLiteral("<150 -30 200 -30 \"\" 0 0 0>\n");//Source to Z0 line
+    s += QStringLiteral("<200 30 200 -90 \"\" 0 0 0>\n");//Z0 line to branches
+    s += QStringLiteral("<200 30 240 30 \"\" 0 0 0>\n");//Z0 line to branch 1
+    s += QStringLiteral("<200 -90 240 -90 \"\" 0 0 0>\n");//Z0 line to branch 2
 
-    s += QString("<300 30 340 30 \"\" 0 0 0>\n");//Branch 2to R
-    s += QString("<300 -90 340 -90 \"\" 0 0 0>\n");//Branch 1 to R
+    s += QStringLiteral("<300 30 340 30 \"\" 0 0 0>\n");//Branch 2to R
+    s += QStringLiteral("<300 -90 340 -90 \"\" 0 0 0>\n");//Branch 1 to R
     if (K!=1)
     {
-        s += QString("<400 30 450 30 \"\" 0 0 0>\n");//Branch 2 to Port 2
-        s += QString("<400 -90 450 -90 \"\" 0 0 0>\n");//Branch 2 to Port 3
+        s += QStringLiteral("<400 30 450 30 \"\" 0 0 0>\n");//Branch 2 to Port 2
+        s += QStringLiteral("<400 -90 450 -90 \"\" 0 0 0>\n");//Branch 2 to Port 3
     }
     else
     {
-        s += QString("<340 30 450 30 \"\" 0 0 0>\n");//Branch 2 to Port 2
-        s += QString("<340 -90 450 -90 \"\" 0 0 0>\n");//Branch 2 to Port 3
+        s += QStringLiteral("<340 30 450 30 \"\" 0 0 0>\n");//Branch 2 to Port 2
+        s += QStringLiteral("<340 -90 450 -90 \"\" 0 0 0>\n");//Branch 2 to Port 3
     }
 
     s += "</Wires>\n";
@@ -1164,20 +1164,20 @@ int QucsPowerCombiningTool::Branchline(double Z0, double Freq, double K, bool SP
     if (SP_block)
     {
         //Source
-        s += QString("<Pac P1 1 50 -120 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 50 -90 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 50 -120 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 50 -90 0 0 0 0>\n");
         //Output port 1
-        s += QString("<Pac P1 1 400 -120 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 400 -90 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 400 -120 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 400 -90 0 0 0 0>\n");
         //Output port 2
-        s += QString("<Pac P1 1 400 90 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 400 120 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 400 90 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 400 120 0 0 0 0>\n");
         //S-parameter analysis component
-        QString freq_start = QString("%1%2").arg(0.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        QString freq_stop = QString("%1%2").arg(1.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        s += QString("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop);
-        s += QString("<Eqn Eqn1 1 50 200 -28 15 0 0 \"S11_dB=dB(S[1,1])\" 1 \"S21_dB=dB(S[2,1])\" 1  \"S31_dB=dB(S[3,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"S33_dB=dB(S[3,3])\" 1 \"yes\" 0>\n");
-        if (microcheck)s += QString("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
+        QString freq_start = QStringLiteral("%1%2").arg(0.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        QString freq_stop = QStringLiteral("%1%2").arg(1.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        s += QStringLiteral("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop);
+        s += QStringLiteral("<Eqn Eqn1 1 50 200 -28 15 0 0 \"S11_dB=dB(S[1,1])\" 1 \"S21_dB=dB(S[2,1])\" 1  \"S31_dB=dB(S[3,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"S33_dB=dB(S[3,3])\" 1 \"yes\" 0>\n");
+        if (microcheck)s += QStringLiteral("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
 
     }
 
@@ -1186,47 +1186,47 @@ int QucsPowerCombiningTool::Branchline(double Z0, double Freq, double K, bool SP
     {
         er = Substrate.er;
         getMicrostrip(ZA, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 220 30 -42 19 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 220 30 -42 19 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(ZA, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 220 -90 -41 -71 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 220 -90 -41 -71 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(ZB, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 150 -20 -60 -30 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 150 -20 -60 -30 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(ZB, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 290 -20 22 -31 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 290 -20 22 -31 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
     }
     else
     {
-        s += QString("<TLIN Line1 1 220 30 -42 19 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZA)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Z0 line
-        s += QString("<TLIN Line1 1 220 -90 -41 -71 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZA)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 1
-        s += QString("<TLIN Line1 1 150 -20 -94 -29 0 1 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZB)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 2
-        s += QString("<TLIN Line1 1 290 -20 22 -31 0 1 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZB)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 2
+        s += QStringLiteral("<TLIN Line1 1 220 30 -42 19 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZA)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Z0 line
+        s += QStringLiteral("<TLIN Line1 1 220 -90 -41 -71 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZA)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 1
+        s += QStringLiteral("<TLIN Line1 1 150 -20 -94 -29 0 1 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZB)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 2
+        s += QStringLiteral("<TLIN Line1 1 290 -20 22 -31 0 1 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZB)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 2
     }
-    s += QString("<R R1 1 50 90 14 -19 0 3 \"%1 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(Z0);//Isolated port
-    s += QString("<GND * 1 50 120 0 0 0 0>\n");
+    s += QStringLiteral("<R R1 1 50 90 14 -19 0 3 \"%1 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(Z0);//Isolated port
+    s += QStringLiteral("<GND * 1 50 120 0 0 0 0>\n");
     s += "</Components>\n";
 
     //Wiring
     s += "<Wires>\n";
-    s += QString("<150 -90 190 -90 \"\" 0 0 0 \"\">\n");
-    s += QString("<150 -90 150 -50 \"\" 0 0 0 \"\">\n");
-    s += QString("<290 -90 290 -50 \"\" 0 0 0 \"\">\n");
-    s += QString("<250 -90 290 -90 \"\" 0 0 0 \"\">\n");
-    s += QString("<250 30 290 30 \"\" 0 0 0 \"\">\n");
-    s += QString("<290 10 290 30 \"\" 0 0 0 \"\">\n");
-    s += QString("<150 30 190 30 \"\" 0 0 0 \"\">\n");
-    s += QString("<150 10 150 30 \"\" 0 0 0 \"\">\n");
-    s += QString("<290 -150 290 -90 \"\" 0 0 0 \"\">\n");
-    s += QString("<290 -150 400 -150 \"\" 0 0 0 \"\">\n");
-    s += QString("<150 -150 150 -90 \"\" 0 0 0 \"\">\n");
-    s += QString("<50 -150 150 -150 \"\" 0 0 0 \"\">\n");
-    s += QString("<150 30 150 60 \"\" 0 0 0 \"\">\n");
-    s += QString("<150 30 150 60 \"\" 0 0 0 \"\">\n");
-    s += QString("<50 60 150 60 \"\" 0 0 0 \"\">\n");
-    s += QString("<290 30 290 60 \"\" 0 0 0 \"\">\n");
-    s += QString("<290 60 400 60 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<150 -90 190 -90 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<150 -90 150 -50 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<290 -90 290 -50 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<250 -90 290 -90 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<250 30 290 30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<290 10 290 30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<150 30 190 30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<150 10 150 30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<290 -150 290 -90 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<290 -150 400 -150 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<150 -150 150 -90 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<50 -150 150 -150 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<150 30 150 60 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<150 30 150 60 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<50 60 150 60 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<290 30 290 60 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<290 60 400 60 \"\" 0 0 0 \"\">\n");
     s += "</Wires>\n";
 
 
@@ -1253,20 +1253,20 @@ int QucsPowerCombiningTool::DoubleBoxBranchline(double Z0, double Freq, double K
     if (SP_block)
     {
         //Source
-        s += QString("<Pac P1 1 40 -100 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 40 -70 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 40 -100 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 40 -70 0 0 0 0>\n");
         //Output port 1
-        s += QString("<Pac P1 1 500 -100 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 500 -70 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 500 -100 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 500 -70 0 0 0 0>\n");
         //Output port 2
-        s += QString("<Pac P1 1 500 90 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 500 120 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 500 90 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 500 120 0 0 0 0>\n");
         //S-parameter analysis component
-        QString freq_start = QString("%1%2").arg(0.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        QString freq_stop = QString("%1%2").arg(1.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        s += QString("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop);
-        s += QString("<Eqn Eqn1 1 50 200 -28 15 0 0 \"S11_dB=dB(S[1,1])\" 1 \"S21_dB=dB(S[2,1])\" 1  \"S31_dB=dB(S[3,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"S33_dB=dB(S[3,3])\" 1 \"yes\" 0>\n");
-        if (microcheck)s += QString("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
+        QString freq_start = QStringLiteral("%1%2").arg(0.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        QString freq_stop = QStringLiteral("%1%2").arg(1.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        s += QStringLiteral("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop);
+        s += QStringLiteral("<Eqn Eqn1 1 50 200 -28 15 0 0 \"S11_dB=dB(S[1,1])\" 1 \"S21_dB=dB(S[2,1])\" 1  \"S31_dB=dB(S[3,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"S33_dB=dB(S[3,3])\" 1 \"yes\" 0>\n");
+        if (microcheck)s += QStringLiteral("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
 
     }
 
@@ -1275,71 +1275,71 @@ int QucsPowerCombiningTool::DoubleBoxBranchline(double Z0, double Freq, double K
     {
         er = Substrate.er;
         getMicrostrip(ZB, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 220 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 220 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(ZB, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 220 -90 -29 -72 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 220 -90 -29 -72 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(ZB, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 290 -20 19 -33 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 290 -20 19 -33 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(ZB, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 350 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 350 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(ZB, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 350 -90 -35 -71 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 350 -90 -35 -71 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(ZA, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 150 -20 -82 -31 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 150 -20 -82 -31 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(ZD, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 420 -20 21 -33 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 420 -20 21 -33 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
 
     }
     else
     {
-        s += QString("<TLIN Line1 1 220 30 -26 20 0 0 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZB)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
-        s += QString("<TLIN Line1 1 220 -90 -29 -72 0 0 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZB)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
+        s += QStringLiteral("<TLIN Line1 1 220 30 -26 20 0 0 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZB)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
+        s += QStringLiteral("<TLIN Line1 1 220 -90 -29 -72 0 0 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZB)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
 
-        s += QString("<TLIN Line1 1 290 -20 19 -33 0 1 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZB)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
+        s += QStringLiteral("<TLIN Line1 1 290 -20 19 -33 0 1 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZB)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
 
 
-        s += QString("<TLIN Line1 1 350 30 -26 20 0 0 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZB)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
-        s += QString("<TLIN Line1 1 350 -90 -35 -71 0 0 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZB)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
+        s += QStringLiteral("<TLIN Line1 1 350 30 -26 20 0 0 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZB)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
+        s += QStringLiteral("<TLIN Line1 1 350 -90 -35 -71 0 0 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZB)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
 
-        s += QString("<TLIN Line1 1 150 -20 -82 -31 0 1 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZA)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
-        s += QString("<TLIN Line1 1 420 -20 21 -33 0 1 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZD)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
+        s += QStringLiteral("<TLIN Line1 1 150 -20 -82 -31 0 1 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZA)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
+        s += QStringLiteral("<TLIN Line1 1 420 -20 21 -33 0 1 \"%1\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(ZD)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
     }
-    s += QString("<R R1 1 40 90 30 -26 0 -1 \"%1 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(Z0);//Isolated port
-    s += QString("<GND * 1 40 120 0 0 0 0>\n");
+    s += QStringLiteral("<R R1 1 40 90 30 -26 0 -1 \"%1 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(Z0);//Isolated port
+    s += QStringLiteral("<GND * 1 40 120 0 0 0 0>\n");
     s += "</Components>\n";
 
     //Wiring
     s += "<Wires>\n";
-    s += QString("<290 -90 290 -50 \"\" 0 0 0 \"\">\n");
-    s += QString("<290 10 290 30 \"\" 0 0 0 \"\">\n");
-    s += QString("<290 -90 320 -90 \"\" 0 0 0 \"\">\n");
-    s += QString("<250 -90 290 -90 \"\" 0 0 0 \"\">\n");
-    s += QString("<290 30 320 30 \"\" 0 0 0 \"\">\n");
-    s += QString("<250 30 290 30 \"\" 0 0 0 \"\">\n");
-    s += QString("<380 -90 420 -90 \"\" 0 0 0 \"\">\n");
-    s += QString("<420 -90 420 -50 \"\" 0 0 0 \"\">\n");
-    s += QString("<380 30 420 30 \"\" 0 0 0 \"\">\n");
-    s += QString("<420 10 420 30 \"\" 0 0 0 \"\">\n");
-    s += QString("<40 30 40 60 \"\" 0 0 0 \"\">\n");
-    s += QString("<40 30 150 30 \"\" 0 0 0 \"\">\n");
-    s += QString("<150 30 190 30 \"\" 0 0 0 \"\">\n");
-    s += QString("<150 10 150 30 \"\" 0 0 0 \"\">\n");
-    s += QString("<150 -90 150 -50 \"\" 0 0 0 \"\">\n");
-    s += QString("<150 -90 190 -90 \"\" 0 0 0 \"\">\n");
-    s += QString("<420 -160 420 -90 \"\" 0 0 0 \"\">\n");
-    s += QString("<420 -160 500 -160 \"\" 0 0 0 \"\">\n");
-    s += QString("<500 -160 500 -130 \"\" 0 0 0 \"\">\n");
-    s += QString("<500 30 500 60 \"\" 0 0 0 \"\">\n");
-    s += QString("<420 30 500 30 \"\" 0 0 0 \"\">\n");
-    s += QString("<130 -160 150 -90 \"\" 0 0 0 \"\">\n");
-    s += QString("<40 -160 150 -160 \"\" 0 0 0 \"\">\n");
-    s += QString("<40 -160 40 -130 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<290 -90 290 -50 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<290 10 290 30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<290 -90 320 -90 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<250 -90 290 -90 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<290 30 320 30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<250 30 290 30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<380 -90 420 -90 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<420 -90 420 -50 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<380 30 420 30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<420 10 420 30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<40 30 40 60 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<40 30 150 30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<150 30 190 30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<150 10 150 30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<150 -90 150 -50 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<150 -90 190 -90 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<420 -160 420 -90 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<420 -160 500 -160 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<500 -160 500 -130 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<500 30 500 60 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<420 30 500 30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<130 -160 150 -90 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<40 -160 150 -160 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<40 -160 40 -130 \"\" 0 0 0 \"\">\n");
     s += "</Wires>\n";
 
 
@@ -1356,7 +1356,7 @@ int QucsPowerCombiningTool::Bagley(double Z0, double Freq, int N, bool SP_block,
     if (N % 2 == 0)
     {
         N++;
-        QString str = QString("The number of outputs must be an odd number. N=%1 will be used instead").arg(N);
+        QString str = QStringLiteral("The number of outputs must be an odd number. N=%1 will be used instead").arg(N);
         QMessageBox::warning(this, tr("Bagley"), str, QMessageBox::Close);
     }
     double er, width;
@@ -1369,20 +1369,20 @@ int QucsPowerCombiningTool::Bagley(double Z0, double Freq, int N, bool SP_block,
     if (SP_block)
     {
         //Source
-        s += QString("<Pac P1 1 0 -60 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 0 -30 0 0 0 0>\n");
-        QString freq_start = QString("%1%2").arg(0.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        QString freq_stop = QString("%1%2").arg(1.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        s += QString("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop);
+        s += QStringLiteral("<Pac P1 1 0 -60 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 0 -30 0 0 0 0>\n");
+        QString freq_start = QStringLiteral("%1%2").arg(0.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        QString freq_stop = QStringLiteral("%1%2").arg(1.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        s += QStringLiteral("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop);
         //Equations
-        QString str = QString(" \"S11_dB=dB(S[1,1])\" 1 ");
+        QString str = QStringLiteral(" \"S11_dB=dB(S[1,1])\" 1 ");
         for (int i=2;i<=N+1; i++) 
         {
-          str += QString("\"S%1%2_dB=dB(S[%1,1])\" 1 ").arg(i).arg(1);
-          str += QString("\"S%1%1_dB=dB(S[%1,%1])\" 1 ").arg(i);
+          str += QStringLiteral("\"S%1%2_dB=dB(S[%1,1])\" 1 ").arg(i).arg(1);
+          str += QStringLiteral("\"S%1%1_dB=dB(S[%1,%1])\" 1 ").arg(i);
         }
-        s += QString("<Eqn Eqn1 1 50 200 -28 15 0 0") + str + QString("\"yes\" 0>\n");
-        if (microcheck)s += QString("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
+        s += QStringLiteral("<Eqn Eqn1 1 50 200 -28 15 0 0") + str + QStringLiteral("\"yes\" 0>\n");
+        if (microcheck)s += QStringLiteral("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
     }
 
     //Input section
@@ -1390,39 +1390,39 @@ int QucsPowerCombiningTool::Bagley(double Z0, double Freq, int N, bool SP_block,
     {
         er = Substrate.er;
         getMicrostrip(Zbranch, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 100 -140 21 -28 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 100 -140 21 -28 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(Zbranch, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 100 -30 19 -60 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 100 -30 19 -60 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
 
     }
     else
     {
-        s += QString("<TLIN Line1 1 100 -140 21 -28 0 1 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Zbranch)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
-        s += QString("<TLIN Line1 1 100 -30 19 -60 0 1 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Zbranch)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
+        s += QStringLiteral("<TLIN Line1 1 100 -140 21 -28 0 1 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Zbranch)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
+        s += QStringLiteral("<TLIN Line1 1 100 -30 19 -60 0 1 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Zbranch)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
     }
     //Output branches
     int x = 240;
-    s += QString("<Pac P1 1 %1 60 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x-100).arg(Z0);
-    s += QString("<GND * 1 %1 90 0 0 0 0>\n").arg(x-100);
+    s += QStringLiteral("<Pac P1 1 %1 60 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x-100).arg(Z0);
+    s += QStringLiteral("<GND * 1 %1 90 0 0 0 0>\n").arg(x-100);
     for (int i=1;i<N; i++)
     {
         if (microcheck)
         {
             er = Substrate.er;
             getMicrostrip(Zbranch, Freq, &Substrate, width, er);
-            s += QString("<MLIN MS1 1 %1 30 -34 -73 0 0 \"Sub1\" 0 \"%2\" 1 \"%3\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(x).arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda2/sqrt(er)));
+            s += QStringLiteral("<MLIN MS1 1 %1 30 -34 -73 0 0 \"Sub1\" 0 \"%2\" 1 \"%3\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(x).arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda2/sqrt(er)));
         }
         else
         {
-            s += QString("<TLIN Line1 1 %1 30 -34 -73 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x).arg(RoundVariablePrecision(Zbranch)).arg(ConvertLengthFromM(lambda2)).arg(Alpha);
+            s += QStringLiteral("<TLIN Line1 1 %1 30 -34 -73 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x).arg(RoundVariablePrecision(Zbranch)).arg(ConvertLengthFromM(lambda2)).arg(Alpha);
         }
         x+=100;
         if (SP_block)
         {
             //i-th output port
-            s += QString("<Pac P1 1 %1 60 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Z0);
-            s += QString("<GND * 1 %1 90 0 0 0 0>\n").arg(x);
+            s += QStringLiteral("<Pac P1 1 %1 60 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Z0);
+            s += QStringLiteral("<GND * 1 %1 90 0 0 0 0>\n").arg(x);
         }
         x+=100;
     }
@@ -1432,24 +1432,24 @@ int QucsPowerCombiningTool::Bagley(double Z0, double Freq, int N, bool SP_block,
 
     //Wiring
     s += "<Wires>\n";
-    s += QString("<0 -90 100 -90 \"\" 0 0 0>\n");//Source to lambda/4 lines
-    s += QString("<100 -110 100 -60 \"\" 0 0 0>\n");//lambda/4 lines
-    s += QString("<100 30 140 30 \"\" 0 0 0>\n");//Lower lambda/4 line to the first lambda/2 section
-    s += QString("<100 30 100 0 \"\" 0 0 0>\n");//Lower lambda/4 line to the first lambda/2 section
+    s += QStringLiteral("<0 -90 100 -90 \"\" 0 0 0>\n");//Source to lambda/4 lines
+    s += QStringLiteral("<100 -110 100 -60 \"\" 0 0 0>\n");//lambda/4 lines
+    s += QStringLiteral("<100 30 140 30 \"\" 0 0 0>\n");//Lower lambda/4 line to the first lambda/2 section
+    s += QStringLiteral("<100 30 100 0 \"\" 0 0 0>\n");//Lower lambda/4 line to the first lambda/2 section
 
     //Wiring the rest of the lambda/2 sections
     x=140;
     for (int i=1;i<N;i++)
     {
-        s += QString("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x).arg(x+70);
-        s += QString("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+130).arg(x+200);
+        s += QStringLiteral("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x).arg(x+70);
+        s += QStringLiteral("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+130).arg(x+200);
         x+=200;
     }
     
-    s += QString("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x).arg(x+30);
-    s += QString("<%1 30 %1 -200 \"\" 0 0 0>\n").arg(x+30);//Final lambda/2 section to the upper lambda/4 section. Vertical line
-    s += QString("<100 -200 %1 -200 \"\" 0 0 0>\n").arg(x+30);//Final lambda/2 section to the upper lambda/4 section. Horizontal line
-    s += QString("<100 -170 100 -200 \"\" 0 0 0>\n");
+    s += QStringLiteral("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x).arg(x+30);
+    s += QStringLiteral("<%1 30 %1 -200 \"\" 0 0 0>\n").arg(x+30);//Final lambda/2 section to the upper lambda/4 section. Vertical line
+    s += QStringLiteral("<100 -200 %1 -200 \"\" 0 0 0>\n").arg(x+30);//Final lambda/2 section to the upper lambda/4 section. Horizontal line
+    s += QStringLiteral("<100 -170 100 -200 \"\" 0 0 0>\n");
     s += "</Wires>\n";
 
 
@@ -1470,22 +1470,22 @@ int QucsPowerCombiningTool::Gysel(double Z0, double Freq, bool SP_block, bool mi
     if (SP_block)
     {
         //Source
-        s += QString("<Pac P1 1 0 0 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 0 30 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 0 0 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 0 30 0 0 0 0>\n");
         //Output port 1
-        s += QString("<Pac P1 1 30 140 -96 -27 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 30 170 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 30 140 -96 -27 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 30 170 0 0 0 0>\n");
         //Output port 2
-        s += QString("<Pac P1 1 30 -160 -96 -27 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 30 -130 0 0 0 0>\n");
+        s += QStringLiteral("<Pac P1 1 30 -160 -96 -27 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 30 -130 0 0 0 0>\n");
 
         //S-parameter analysis component
-        QString freq_start = QString("%1%2").arg(0.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        QString freq_stop = QString("%1%2").arg(1.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        s += QString("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop);
-        s += QString("<Eqn Eqn1 1 50 250 -28 15 0 0 \"S11_dB=dB(S[1,1])\" 1 \"S21_dB=dB(S[2,1])\" 1  \"S31_dB=dB(S[3,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"S33_dB=dB(S[3,3])\" 1 \"yes\" 0>\n");
+        QString freq_start = QStringLiteral("%1%2").arg(0.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        QString freq_stop = QStringLiteral("%1%2").arg(1.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        s += QStringLiteral("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop);
+        s += QStringLiteral("<Eqn Eqn1 1 50 250 -28 15 0 0 \"S11_dB=dB(S[1,1])\" 1 \"S21_dB=dB(S[2,1])\" 1  \"S31_dB=dB(S[3,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"S33_dB=dB(S[3,3])\" 1 \"yes\" 0>\n");
 
-        if (microcheck)s += QString("<SUBST Sub1 1 400 250 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
+        if (microcheck)s += QStringLiteral("<SUBST Sub1 1 400 250 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
 
 
     }
@@ -1494,58 +1494,58 @@ int QucsPowerCombiningTool::Gysel(double Z0, double Freq, bool SP_block, bool mi
     {
         er = Substrate.er;
         getMicrostrip(sqrt(2)*Z0, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 120 -70 21 -30 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 120 -70 21 -30 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(sqrt(2)*Z0, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 120 40 18 -27 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 120 40 18 -27 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(Z0, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 220 -130 -42 -68 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 220 -130 -42 -68 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(Z0, Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 220 100 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 220 100 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er)));
         er = Substrate.er;
         getMicrostrip(Z0/sqrt(2), Freq, &Substrate, width, er);
-        s += QString("<MLIN MS1 1 320 -20 18 -32 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(2*lambda4/sqrt(er)));
+        s += QStringLiteral("<MLIN MS1 1 320 -20 18 -32 0 1 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(2*lambda4/sqrt(er)));
 
     }
     else
     {
-        s += QString("<TLIN Line1 1 120 -70 21 -30 0 1 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(sqrt(2)*Z0)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
-        s += QString("<TLIN Line1 1 120 40 18 -27 0 1 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(sqrt(2)*Z0)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
-        s += QString("<TLIN Line1 1 220 -130 -42 -68 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(Z0).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
-        s += QString("<TLIN Line1 1 220 100 -26 20 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(Z0).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
-        s += QString("<TLIN Line1 1 320 -20 18 -32 0 1 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Z0/sqrt(2))).arg(ConvertLengthFromM(2*lambda4)).arg(Alpha);
+        s += QStringLiteral("<TLIN Line1 1 120 -70 21 -30 0 1 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(sqrt(2)*Z0)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
+        s += QStringLiteral("<TLIN Line1 1 120 40 18 -27 0 1 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(sqrt(2)*Z0)).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
+        s += QStringLiteral("<TLIN Line1 1 220 -130 -42 -68 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(Z0).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
+        s += QStringLiteral("<TLIN Line1 1 220 100 -26 20 0 0 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(Z0).arg(ConvertLengthFromM(lambda4)).arg(Alpha);
+        s += QStringLiteral("<TLIN Line1 1 320 -20 18 -32 0 1 \"%1 Ohm\" 1 \"%2\" 1 \"%3 dB\" 0 \"26.85\" 0>\n").arg(RoundVariablePrecision(Z0/sqrt(2))).arg(ConvertLengthFromM(2*lambda4)).arg(Alpha);
     }
     //Resistors
-    s += QString("<R R1 1 400 -160 19 -16 0 3 \"%1 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(Z0);//Isolation resistor
-    s += QString("<GND * 1 400 -130 0 0 0 0>\n");
-    s += QString("<R R1 1 400 130 19 -16 0 3 \"%1 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(Z0);//Isolation resistor
-    s += QString("<GND * 1 400 160 0 0 0 0>\n");
+    s += QStringLiteral("<R R1 1 400 -160 19 -16 0 3 \"%1 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(Z0);//Isolation resistor
+    s += QStringLiteral("<GND * 1 400 -130 0 0 0 0>\n");
+    s += QStringLiteral("<R R1 1 400 130 19 -16 0 3 \"%1 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(Z0);//Isolation resistor
+    s += QStringLiteral("<GND * 1 400 160 0 0 0 0>\n");
 
     s += "</Components>\n";
 
     s += "<Wires>\n";
-    s += QString("<120 70 120 100 \"\" 0 0 0 \"\">\n");//Source to the lines at the input
-    s += QString("<120 -130 120 -100 \"\" 0 0 0 \"\">\n");//Line between the two lines at the input
-    s += QString("<120 -130 190 -130 \"\" 0 0 0 \"\">\n");
-    s += QString("<120 -200 120 -130 \"\" 0 0 0 \"\">\n");
-    s += QString("<250 -130 320 -130 \"\" 0 0 0 \"\">\n");
-    s += QString("<320 -130 320 -50 \"\" 0 0 0 \"\">\n");
-    s += QString("<120 100 190 100 \"\" 0 0 0 \"\">\n");//Line between the line on the top to the upper resistor
-    s += QString("<250 100 320 100 \"\" 0 0 0 \"\">\n");//Line between the line on the top to the lower resistor
-    s += QString("<320 10 320 100 \"\" 0 0 0 \"\">\n");
-    s += QString("<30 -200 120 -200 \"\" 0 0 0 \"\">\n");
-    s += QString("<30 -200 30 -190 \"\" 0 0 0 \"\">\n");
-    s += QString("<400 -200 400 -190 \"\" 0 0 0 \"\">\n");
-    s += QString("<320 -200 320 -130 \"\" 0 0 0 \"\">\n");
-    s += QString("<320 -200 400 -200 \"\" 0 0 0 \"\">\n");
-    s += QString("<320 100 400 100 \"\" 0 0 0 \"\">\n");
-    s += QString("<30 100 120 100 \"\" 0 0 0 \"\">\n");
-    s += QString("<30 100 30 110 \"\" 0 0 0 \"\">\n");
-    s += QString("<120 -40 120 -30 \"\" 0 0 0 \"\">\n");
-    s += QString("<120 -30 120 10 \"\" 0 0 0 \"\">\n");
-    s += QString("<0 -30 120 -30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<120 70 120 100 \"\" 0 0 0 \"\">\n");//Source to the lines at the input
+    s += QStringLiteral("<120 -130 120 -100 \"\" 0 0 0 \"\">\n");//Line between the two lines at the input
+    s += QStringLiteral("<120 -130 190 -130 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<120 -200 120 -130 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<250 -130 320 -130 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<320 -130 320 -50 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<120 100 190 100 \"\" 0 0 0 \"\">\n");//Line between the line on the top to the upper resistor
+    s += QStringLiteral("<250 100 320 100 \"\" 0 0 0 \"\">\n");//Line between the line on the top to the lower resistor
+    s += QStringLiteral("<320 10 320 100 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<30 -200 120 -200 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<30 -200 30 -190 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<400 -200 400 -190 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<320 -200 320 -130 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<320 -200 400 -200 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<320 100 400 100 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<30 100 120 100 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<30 100 30 110 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<120 -40 120 -30 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<120 -30 120 10 \"\" 0 0 0 \"\">\n");
+    s += QStringLiteral("<0 -30 120 -30 \"\" 0 0 0 \"\">\n");
     s += "</Wires>\n";
 
     QApplication::clipboard()->setText(s, QClipboard::Clipboard);
@@ -1563,23 +1563,23 @@ int QucsPowerCombiningTool::TravellingWave(double Z0, double Freq, int N, bool S
     if (SP_block)
     {
         //Source
-        s += QString("<Pac P1 1 0 30 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
-        s += QString("<GND * 1 0 60 0 0 0 0>\n");
-        wirestr +=QString("<0 0 0 -30 \"\" 0 0 0>\n");//Vertical wire
-        wirestr +=QString("<0 -30 40 -30 \"\" 0 0 0>\n");//Horizontal wire
+        s += QStringLiteral("<Pac P1 1 0 30 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0);
+        s += QStringLiteral("<GND * 1 0 60 0 0 0 0>\n");
+        wirestr +=QStringLiteral("<0 0 0 -30 \"\" 0 0 0>\n");//Vertical wire
+        wirestr +=QStringLiteral("<0 -30 40 -30 \"\" 0 0 0>\n");//Horizontal wire
         //S-parameter analysis component
-        QString freq_start = QString("%1%2").arg(0.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        QString freq_stop = QString("%1%2").arg(1.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-        s += QString("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop);
+        QString freq_start = QStringLiteral("%1%2").arg(0.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        QString freq_stop = QStringLiteral("%1%2").arg(1.5*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+        s += QStringLiteral("<.SP SP1 1 200 200 0 67 0 0 \"lin\" 1 \"%2\" 1 \"%3\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop);
         // Equations
-        str = QString("\"S11_dB=dB(S[1,1])\" 1 ");
+        str = QStringLiteral("\"S11_dB=dB(S[1,1])\" 1 ");
         for (int i=2;i<=N+1; i++) 
         {
-          str += QString("\"S%1%2_dB=dB(S[%1,1])\" 1 ").arg(i).arg(1);
-          str += QString("\"S%1%1_dB=dB(S[%1,%1])\" 1 ").arg(i);
+          str += QStringLiteral("\"S%1%2_dB=dB(S[%1,1])\" 1 ").arg(i).arg(1);
+          str += QStringLiteral("\"S%1%1_dB=dB(S[%1,%1])\" 1 ").arg(i);
         }
-        s += QString("<Eqn Eqn1 1 50 200 -28 15 0 0 ") + str + QString("\"yes\" 0>\n");
-        if (microcheck)s += QString("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
+        s += QStringLiteral("<Eqn Eqn1 1 50 200 -28 15 0 0 ") + str + QStringLiteral("\"yes\" 0>\n");
+        if (microcheck)s += QStringLiteral("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
 
     }
 
@@ -1596,48 +1596,48 @@ int QucsPowerCombiningTool::TravellingWave(double Z0, double Freq, int N, bool S
         R2 =  wilkstr.section(';', 3, 3).toDouble();
         R3 =  wilkstr.section(';', 4, 4).toDouble();
 
-        wirestr +=QString("<%1 -30 %2 -30 \"\" 0 0 0>\n").arg(x-60).arg(x-30);
-        wirestr +=QString("<%1 -30 %2 -30 \"\" 0 0 0>\n").arg(x+30).arg(x+60);
+        wirestr +=QStringLiteral("<%1 -30 %2 -30 \"\" 0 0 0>\n").arg(x-60).arg(x-30);
+        wirestr +=QStringLiteral("<%1 -30 %2 -30 \"\" 0 0 0>\n").arg(x+30).arg(x+60);
 
-        wirestr +=QString("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+60).arg(x+100);
-        wirestr +=QString("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+60).arg(x+100);
+        wirestr +=QStringLiteral("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+60).arg(x+100);
+        wirestr +=QStringLiteral("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+60).arg(x+100);
 
-        wirestr +=QString("<%1 -90 %1 30 \"\" 0 0 0>\n").arg(x+60);
+        wirestr +=QStringLiteral("<%1 -90 %1 30 \"\" 0 0 0>\n").arg(x+60);
 
-        wirestr +=QString("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+160).arg(x+200);
-        wirestr +=QString("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+160).arg(x+200);
+        wirestr +=QStringLiteral("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+160).arg(x+200);
+        wirestr +=QStringLiteral("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+160).arg(x+200);
 
-        wirestr +=QString("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+260).arg(x+350);
-        wirestr +=QString("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+260).arg(x+290);
-        wirestr +=QString("<%1 30 %1 60 \"\" 0 0 0>\n").arg(x+350);
+        wirestr +=QStringLiteral("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+260).arg(x+350);
+        wirestr +=QStringLiteral("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+260).arg(x+290);
+        wirestr +=QStringLiteral("<%1 30 %1 60 \"\" 0 0 0>\n").arg(x+350);
 
         //Wiring the isolation resistor
-        wirestr +=QString("<%1 30 %1 10 \"\" 0 0 0>\n").arg(x+190);
-        wirestr +=QString("<%1 -90 %1 -50 \"\" 0 0 0>\n").arg(x+190);
+        wirestr +=QStringLiteral("<%1 30 %1 10 \"\" 0 0 0>\n").arg(x+190);
+        wirestr +=QStringLiteral("<%1 -90 %1 -50 \"\" 0 0 0>\n").arg(x+190);
 
-        if(n>1)wirestr +=QString("<%1 -90 %1 -30 \"\" 0 0 0>\n").arg(x+290);
-        if(n==1)wirestr +=QString("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+290).arg(x+350);//Last power combiner
+        if(n>1)wirestr +=QStringLiteral("<%1 -90 %1 -30 \"\" 0 0 0>\n").arg(x+290);
+        if(n==1)wirestr +=QStringLiteral("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+290).arg(x+350);//Last power combiner
 
         if (microcheck)
         {
             er = Substrate.er;
             getMicrostrip(Z0, Freq, &Substrate, width, er);
-            s += QString("<MLIN MS1 1 %3 -30 -38 -80 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x);
+            s += QStringLiteral("<MLIN MS1 1 %3 -30 -38 -80 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x);
             er = Substrate.er;
             getMicrostrip(Z3, Freq, &Substrate, width, er);
-            s += QString("<MLIN MS1 1 %3 -90 -40 -80 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x+130);
+            s += QStringLiteral("<MLIN MS1 1 %3 -90 -40 -80 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x+130);
             er = Substrate.er;
             getMicrostrip(Z2, Freq, &Substrate, width, er);
-            s += QString("<MLIN MS1 1 %3 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x+130);
+            s += QStringLiteral("<MLIN MS1 1 %3 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x+130);
         }
         else
         {
             aux_str = ConvertLengthFromM(lambda4);
-            s += QString("<TLIN Line1 1 %1 -30 -38 -68 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x).arg(Z0).arg(aux_str).arg(Alpha);//Z0 line
-            s += QString("<TLIN Line1 1 %1 -90 -40 -70 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x+130).arg(RoundVariablePrecision(Z3)).arg(aux_str).arg(Alpha);//Output branch 1
-            s += QString("<TLIN Line1 1 %1 30 -26 20 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x+130).arg(RoundVariablePrecision(Z2)).arg(aux_str).arg(Alpha);//Output branch 2
+            s += QStringLiteral("<TLIN Line1 1 %1 -30 -38 -68 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x).arg(Z0).arg(aux_str).arg(Alpha);//Z0 line
+            s += QStringLiteral("<TLIN Line1 1 %1 -90 -40 -70 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x+130).arg(RoundVariablePrecision(Z3)).arg(aux_str).arg(Alpha);//Output branch 1
+            s += QStringLiteral("<TLIN Line1 1 %1 30 -26 20 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x+130).arg(RoundVariablePrecision(Z2)).arg(aux_str).arg(Alpha);//Output branch 2
         }
-        s += QString("<R R1 1 %1 -20 30 -26 0 -1 \"%2 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(x+190).arg(RoundVariablePrecision(R));//Isolation resistor
+        s += QStringLiteral("<R R1 1 %1 -20 30 -26 0 -1 \"%2 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(x+190).arg(RoundVariablePrecision(R));//Isolation resistor
 
         if ((R2!=50)||(R3 != 50))
         {// An unequal power ratio implies that the load impedance != 50, so it requires matching.
@@ -1647,37 +1647,37 @@ int QucsPowerCombiningTool::TravellingWave(double Z0, double Freq, int N, bool S
                 getMicrostrip(sqrt(Z0*R3), Freq, &Substrate, width, er);
                 aux_str = ConvertLengthFromM(lambda4/sqrt(er));
                 aux_str_2 = ConvertLengthFromM(width);
-                s += QString("<MLIN MS1 1 %3 -90 -40 -80 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(aux_str_2).arg(aux_str).arg(x+230);
+                s += QStringLiteral("<MLIN MS1 1 %3 -90 -40 -80 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(aux_str_2).arg(aux_str).arg(x+230);
 
                 er = Substrate.er;
                 getMicrostrip(sqrt(Z0*R2), Freq, &Substrate, width, er);
                 aux_str = ConvertLengthFromM(lambda4/sqrt(er));
                 aux_str_2 = ConvertLengthFromM(width);
-                s += QString("<MLIN MS1 1 %3 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(aux_str_2).arg(aux_str).arg(x+230);
+                s += QStringLiteral("<MLIN MS1 1 %3 30 -26 20 0 0 \"Sub1\" 0 \"%1\" 1 \"%2\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(aux_str_2).arg(aux_str).arg(x+230);
 
             }
             else
             {
-                s += QString("<TLIN Line1 1 %1 -90 -40 -70 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x+230).arg(RoundVariablePrecision(sqrt(Z0*R3))).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Quarter wave matching output branch 1
-                s += QString("<TLIN Line1 1 %1 30 -26 20 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x+230).arg(RoundVariablePrecision(sqrt(Z0*R2))).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Quarter wave matching output branch 2
+                s += QStringLiteral("<TLIN Line1 1 %1 -90 -40 -70 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x+230).arg(RoundVariablePrecision(sqrt(Z0*R3))).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Quarter wave matching output branch 1
+                s += QStringLiteral("<TLIN Line1 1 %1 30 -26 20 0 0 \"%2 Ohm\" 1 \"%3\" 1 \"%4 dB\" 0 \"26.85\" 0>\n").arg(x+230).arg(RoundVariablePrecision(sqrt(Z0*R2))).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Quarter wave matching output branch 2
             }
         }
         else
         {
-            wirestr +=QString("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+200).arg(x+260);
-            wirestr +=QString("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+200).arg(x+260);
+            wirestr +=QStringLiteral("<%1 30 %2 30 \"\" 0 0 0>\n").arg(x+200).arg(x+260);
+            wirestr +=QStringLiteral("<%1 -90 %2 -90 \"\" 0 0 0>\n").arg(x+200).arg(x+260);
         }
         x+=spacing;
 
         if(SP_block)//Add output terms
         {
-            s += QString("<Pac P1 1 %1 90 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Z0);
-            s += QString("<GND * 1 %1 120 0 0 0 0>\n").arg(x);
+            s += QStringLiteral("<Pac P1 1 %1 90 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Z0);
+            s += QStringLiteral("<GND * 1 %1 120 0 0 0 0>\n").arg(x);
 
             if(n==1)//The last Wilkinson divider
             {
-                s += QString("<Pac P1 1 %1 -60 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Z0);
-                s += QString("<GND * 1 %1 -30 0 0 0 0>\n").arg(x);
+                s += QStringLiteral("<Pac P1 1 %1 -60 18 -26 0 1 \"1\" 1 \"%2 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(x).arg(Z0);
+                s += QStringLiteral("<GND * 1 %1 -30 0 0 0 0>\n").arg(x);
             }
         }
 
@@ -1696,7 +1696,7 @@ int QucsPowerCombiningTool::Tree(double Z0, double Freq, int N, bool SP_block, b
     if ((N & (N - 1)) != 0)//Checking if the number of outputs is power of 2
     {
         N = pow(2, ceil(log(N)/log(2)));//Rounding to the next power of 2
-        QString str = QString("The number of outputs must be a power of 2. A %1-way combiner will be designed").arg(N);
+        QString str = QStringLiteral("The number of outputs must be a power of 2. A %1-way combiner will be designed").arg(N);
         QMessageBox::warning(this, tr("Tree combiner"), str, QMessageBox::Close);
     }
     double er, width;
@@ -1724,69 +1724,69 @@ int QucsPowerCombiningTool::Tree(double Z0, double Freq, int N, bool SP_block, b
             {
                 er = Substrate.er;
                 getMicrostrip(Z0, Freq, &Substrate, width, er);
-                s += QString("<MLIN MS1 1 %3 %4 -26 20 0 0 \"Sub1\" 0 \"%1\" 0 \"%2\" 0 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x).arg(offset);
+                s += QStringLiteral("<MLIN MS1 1 %3 %4 -26 20 0 0 \"Sub1\" 0 \"%1\" 0 \"%2\" 0 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x).arg(offset);
 
                 er = Substrate.er;
                 getMicrostrip(Zbranch, Freq, &Substrate, width, er);
-                s += QString("<MLIN MS1 1 %3 %4 -26 20 0 0 \"Sub1\" 0 \"%1\" 0 \"%2\" 0 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x+100).arg(y+offset);
+                s += QStringLiteral("<MLIN MS1 1 %3 %4 -26 20 0 0 \"Sub1\" 0 \"%1\" 0 \"%2\" 0 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x+100).arg(y+offset);
 
                 er = Substrate.er;
                 getMicrostrip(Zbranch, Freq, &Substrate, width, er);
-                s += QString("<MLIN MS1 1 %3 %4 -26 20 0 0 \"Sub1\" 0 \"%1\" 0 \"%2\" 0 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x+100).arg(-y+offset);
+                s += QStringLiteral("<MLIN MS1 1 %3 %4 -26 20 0 0 \"Sub1\" 0 \"%1\" 0 \"%2\" 0 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").arg(ConvertLengthFromM(width)).arg(ConvertLengthFromM(lambda4/sqrt(er))).arg(x+100).arg(-y+offset);
 
             }
             else
             {
-                s += QString("<TLIN Line1 1 %1 %2 -26 20 0 0 \"%3\" 0 \"%4\" 0 \"%5 dB\" 0 \"26.85\" 0>\n").arg(x).arg(offset).arg(Z0).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Z0 line
-                s += QString("<TLIN Line1 1 %1 %2 -26 20 0 0 \"%3\" 0 \"%4\" 0 \"%5 dB\" 0 \"26.85\" 0>\n").arg(x+100).arg(y+offset).arg(Zbranch).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 1
-                s += QString("<TLIN Line1 1 %1 %2 -26 20 0 0 \"%3\" 0 \"%4\" 0 \"%5 dB\" 0 \"26.85\" 0>\n").arg(x+100).arg(-y+offset).arg(Zbranch).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 2
+                s += QStringLiteral("<TLIN Line1 1 %1 %2 -26 20 0 0 \"%3\" 0 \"%4\" 0 \"%5 dB\" 0 \"26.85\" 0>\n").arg(x).arg(offset).arg(Z0).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Z0 line
+                s += QStringLiteral("<TLIN Line1 1 %1 %2 -26 20 0 0 \"%3\" 0 \"%4\" 0 \"%5 dB\" 0 \"26.85\" 0>\n").arg(x+100).arg(y+offset).arg(Zbranch).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 1
+                s += QStringLiteral("<TLIN Line1 1 %1 %2 -26 20 0 0 \"%3\" 0 \"%4\" 0 \"%5 dB\" 0 \"26.85\" 0>\n").arg(x+100).arg(-y+offset).arg(Zbranch).arg(ConvertLengthFromM(lambda4)).arg(Alpha);//Output branch 2
             }
-            s += QString("<R R1 1 %1 %2 15 -26 0 -1 \"%3 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(x+160).arg(offset).arg(2*Z0);//Isolation resistor
+            s += QStringLiteral("<R R1 1 %1 %2 15 -26 0 -1 \"%3 Ohm\" 1 \"26.85\" 0 \"US\" 0>\n").arg(x+160).arg(offset).arg(2*Z0);//Isolation resistor
 
-            wirestr +=QString("<%1 %3 %2 %3 \"\" 0 0 0>\n").arg(x+30).arg(x+70).arg(y+offset);
-            wirestr +=QString("<%1 %3 %2 %3 \"\" 0 0 0>\n").arg(x+30).arg(x+70).arg(-y+offset);
+            wirestr +=QStringLiteral("<%1 %3 %2 %3 \"\" 0 0 0>\n").arg(x+30).arg(x+70).arg(y+offset);
+            wirestr +=QStringLiteral("<%1 %3 %2 %3 \"\" 0 0 0>\n").arg(x+30).arg(x+70).arg(-y+offset);
 
-            wirestr +=QString("<%1 %2 %1 %3 \"\" 0 0 0>\n").arg(x+30).arg(y+offset).arg(-y+offset);
+            wirestr +=QStringLiteral("<%1 %2 %1 %3 \"\" 0 0 0>\n").arg(x+30).arg(y+offset).arg(-y+offset);
 
-            wirestr +=QString("<%1 %3 %2 %3 \"\" 0 0 0>\n").arg(x+130).arg(x+170).arg(y+offset);
-            wirestr +=QString("<%1 %3 %2 %3 \"\" 0 0 0>\n").arg(x+130).arg(x+170).arg(-y+offset);
+            wirestr +=QStringLiteral("<%1 %3 %2 %3 \"\" 0 0 0>\n").arg(x+130).arg(x+170).arg(y+offset);
+            wirestr +=QStringLiteral("<%1 %3 %2 %3 \"\" 0 0 0>\n").arg(x+130).arg(x+170).arg(-y+offset);
 
             //Wiring the isolation resistor
-            wirestr +=QString("<%1 %2 %1 %3 \"\" 0 0 0>\n").arg(x+160).arg(y+offset).arg(offset+30);
-            wirestr +=QString("<%1 %2 %1 %3 \"\" 0 0 0>\n").arg(x+160).arg(-y+offset).arg(offset-30);
+            wirestr +=QStringLiteral("<%1 %2 %1 %3 \"\" 0 0 0>\n").arg(x+160).arg(y+offset).arg(offset+30);
+            wirestr +=QStringLiteral("<%1 %2 %1 %3 \"\" 0 0 0>\n").arg(x+160).arg(-y+offset).arg(offset-30);
 
             if (SP_block)
             {
                 if (n==1)//Source
                 {
                     int sindex=s.indexOf("<Components>\n");
-                    s.insert(sindex+13, QString("<Pac P1 1 %2 %3 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0).arg(x-100).arg(offset+50));
-                    s += QString("<GND * 1 %1 %2 0 0 0 0>\n").arg(x-100).arg(offset+80);
-                    wirestr +=QString("<%1 %2 %1 %3 \"\" 0 0 0>\n").arg(x-100).arg(offset+20).arg(offset);//Vertical wire
-                    wirestr +=QString("<%2 %1 %3 %1 \"\" 0 0 0>\n").arg(offset).arg(x-100).arg(x-30);//Horizontal wire
+                    s.insert(sindex+13, QStringLiteral("<Pac P1 1 %2 %3 18 -26 0 1 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0).arg(x-100).arg(offset+50));
+                    s += QStringLiteral("<GND * 1 %1 %2 0 0 0 0>\n").arg(x-100).arg(offset+80);
+                    wirestr +=QStringLiteral("<%1 %2 %1 %3 \"\" 0 0 0>\n").arg(x-100).arg(offset+20).arg(offset);//Vertical wire
+                    wirestr +=QStringLiteral("<%2 %1 %3 %1 \"\" 0 0 0>\n").arg(offset).arg(x-100).arg(x-30);//Horizontal wire
 
                     //S-parameter analysis component
-                    QString freq_start = QString("%1%2").arg((1/N)*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-                    QString freq_stop = QString("%1%2").arg((2+1/N)*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
-                    s += QString("<.SP SP1 1 %3 %4 0 67 0 0 \"lin\" 1 \"%1\" 1 \"%2\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop).arg(x-200).arg(offset+200);
+                    QString freq_start = QStringLiteral("%1%2").arg((1/N)*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+                    QString freq_stop = QStringLiteral("%1%2").arg((2+1/N)*FreqlineEdit->text().toDouble()).arg(FreqScaleCombo->currentText());
+                    s += QStringLiteral("<.SP SP1 1 %3 %4 0 67 0 0 \"lin\" 1 \"%1\" 1 \"%2\" 1 \"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n").arg(freq_start).arg(freq_stop).arg(x-200).arg(offset+200);
                 
                     // Equations
-                    str = QString("\"S11_dB=dB(S[1,1])\" 1 ");
+                    str = QStringLiteral("\"S11_dB=dB(S[1,1])\" 1 ");
                     for (int i=2;i<=N+1; i++) 
                     {
-                      str += QString("\"S%1%2_dB=dB(S[%1,1])\" 1 ").arg(i).arg(1);
-                      str += QString("\"S%1%1_dB=dB(S[%1,%1])\" 1 ").arg(i);
+                      str += QStringLiteral("\"S%1%2_dB=dB(S[%1,1])\" 1 ").arg(i).arg(1);
+                      str += QStringLiteral("\"S%1%1_dB=dB(S[%1,%1])\" 1 ").arg(i);
                     }
-                    s += QString("<Eqn Eqn1 1 %1 %2 -28 15 0 0 ").arg(x-400).arg(offset+200) + str + QString("\"yes\" 0>\n");
-                    if (microcheck)s += QString("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
+                    s += QStringLiteral("<Eqn Eqn1 1 %1 %2 -28 15 0 0 ").arg(x-400).arg(offset+200) + str + QStringLiteral("\"yes\" 0>\n");
+                    if (microcheck)s += QStringLiteral("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").arg(Substrate.er).arg(Substrate.height*1e3).arg(Substrate.thickness*1e6).arg(Substrate.tand).arg(Substrate.resistivity).arg(Substrate.roughness);
 
                 }
                 if(n==N/2)//Loads
                 {
-                    s += QString("<Pac P1 1 %2 %3 45 -29 0 0 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0).arg(x+200).arg(offset+y);
-                    s += QString("<GND * 1 %1 %2 0 0 0 0>\n").arg(x+230).arg(offset+y);
-                    s += QString("<Pac P1 1 %2 %3 45 -29 0 0 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0).arg(x+200).arg(offset-y);
-                    s += QString("<GND * 1 %1 %2 0 0 0 0>\n").arg(x+230).arg(offset-y);
+                    s += QStringLiteral("<Pac P1 1 %2 %3 45 -29 0 0 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0).arg(x+200).arg(offset+y);
+                    s += QStringLiteral("<GND * 1 %1 %2 0 0 0 0>\n").arg(x+230).arg(offset+y);
+                    s += QStringLiteral("<Pac P1 1 %2 %3 45 -29 0 0 \"1\" 1 \"%1 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0>\n").arg(Z0).arg(x+200).arg(offset-y);
+                    s += QStringLiteral("<GND * 1 %1 %2 0 0 0 0>\n").arg(x+230).arg(offset-y);
                 }
             }
 
@@ -1995,7 +1995,7 @@ QString QucsPowerCombiningTool::ConvertLengthFromM(double len)
             index = 2;//microns
             break;
           }
-          return QString("%1 mil").arg(RoundVariablePrecision(conv));
+          return QStringLiteral("%1 mil").arg(RoundVariablePrecision(conv));
     case 2: //microns
           conv *= 1e6;
           if (conv > 999.99)
@@ -2008,7 +2008,7 @@ QString QucsPowerCombiningTool::ConvertLengthFromM(double len)
             index = 3;//nanometers
             break;
           }
-          return QString("%1 um").arg(RoundVariablePrecision(conv));
+          return QStringLiteral("%1 um").arg(RoundVariablePrecision(conv));
     case 3: //nanometers
           conv *= 1e9;
           if (conv > 999.99)
@@ -2016,7 +2016,7 @@ QString QucsPowerCombiningTool::ConvertLengthFromM(double len)
             index = 2;//microns
             break;
           }
-          return QString("%1 nm").arg(RoundVariablePrecision(conv));
+          return QStringLiteral("%1 nm").arg(RoundVariablePrecision(conv));
     case 4: //inch
           conv *= 39.3701;
           if (conv > 999.99)
@@ -2029,7 +2029,7 @@ QString QucsPowerCombiningTool::ConvertLengthFromM(double len)
             index = 1;//mils
             break;
           }
-          return QString("%1 in").arg(RoundVariablePrecision(conv));
+          return QStringLiteral("%1 in").arg(RoundVariablePrecision(conv));
     case 5: //ft
           conv *= 3.280841666667; 
           if (conv > 999.99)
@@ -2042,14 +2042,14 @@ QString QucsPowerCombiningTool::ConvertLengthFromM(double len)
             index = 4;//inches
             break;
           }
-          return QString("%1 ft").arg(RoundVariablePrecision(conv));
+          return QStringLiteral("%1 ft").arg(RoundVariablePrecision(conv));
     case 6: //m
           if(conv < 1) 
           {
             index = 0;//mm
             break;
           }
-          return QString("%1").arg(RoundVariablePrecision(len));
+          return QStringLiteral("%1").arg(RoundVariablePrecision(len));
     default: //milimeters
           conv *=1e3;
           if (conv > 999.99)
@@ -2062,7 +2062,7 @@ QString QucsPowerCombiningTool::ConvertLengthFromM(double len)
             index = 2;//microns
             break;
           }
-          return QString("%1 mm").arg(RoundVariablePrecision(conv));
+          return QStringLiteral("%1 mm").arg(RoundVariablePrecision(conv));
   }
   }while(true);
   return QString();
@@ -2106,10 +2106,10 @@ QString QucsPowerCombiningTool::getSPEquationString(int x, int y)
 {
     QString s;
     if (QucsSettings.DefaultSimulator == spicecompat::simQucsator) {
-        s = QString("<Eqn Eqn1 1 %1 %2 -28 15 0 0 \"S11_dB=dB(S[1,1])\" 1 \"S21_dB=dB(S[2,1])\" 1"
+        s = QStringLiteral("<Eqn Eqn1 1 %1 %2 -28 15 0 0 \"S11_dB=dB(S[1,1])\" 1 \"S21_dB=dB(S[2,1])\" 1"
                      "  \"S31_dB=dB(S[3,1])\" 1 \"S22_dB=dB(S[2,2])\" 1 \"S33_dB=dB(S[3,3])\" 1 \"yes\" 0>\n").arg(x).arg(y);
     } else if (QucsSettings.DefaultSimulator == spicecompat::simNgspice) {
-        s = QString("<NutmegEq NutmegEq1 1 %1 %2 -28 15 0 0 \"sp\" 1 \"S11_dB=dB(S_1_1)\" 1 \"S21_dB=dB(S_2_1)\" 1"
+        s = QStringLiteral("<NutmegEq NutmegEq1 1 %1 %2 -28 15 0 0 \"sp\" 1 \"S11_dB=dB(S_1_1)\" 1 \"S21_dB=dB(S_2_1)\" 1"
                      "  \"S31_dB=dB(S_3_1)\" 1 \"S22_dB=dB(S_2_2)\" 1 \"S33_dB=dB(S_3_3)\" 1>\n").arg(x).arg(y);
     }
     return s;

--- a/qucs-s-spar-viewer/main.cpp
+++ b/qucs-s-spar-viewer/main.cpp
@@ -99,7 +99,7 @@ int main( int argc, char ** argv )
   QString lang = QucsSettings.Language;
   if(lang.isEmpty())
     lang = QString(QLocale::system().name());
-  tor.load( QString("qucs_") + lang, QucsSettings.LangDir);
+  tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir);
   a.installTranslator( &tor );
 
   Qucs_S_SPAR_Viewer *qucs = new Qucs_S_SPAR_Viewer();

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -575,7 +575,7 @@ void Qucs_S_SPAR_Viewer::slotQuit()
 
 void Qucs_S_SPAR_Viewer::addFile()
 {
-    QFileDialog dialog(this, QString("Select S-parameter data files (.snp)"), QDir::homePath(),
+    QFileDialog dialog(this, QStringLiteral("Select S-parameter data files (.snp)"), QDir::homePath(),
                        tr("S-Parameter Files (*.s1p *.s2p *.s3p *.s4p);;All Files (*.*)"));
     dialog.setFileMode(QFileDialog::ExistingFiles);
 
@@ -630,13 +630,13 @@ void Qucs_S_SPAR_Viewer::addFiles(QStringList fileNames)
         filename = QFileInfo(fileNames.at(i-existing_files)).fileName();
 
         QLabel * Filename_Label = new QLabel(filename.left(filename.lastIndexOf('.')));
-        Filename_Label->setObjectName(QString("File_") + QString::number(i));
+        Filename_Label->setObjectName(QStringLiteral("File_") + QString::number(i));
         List_FileNames.append(Filename_Label);
         this->FilesGrid->addWidget(List_FileNames.last(), i,0,1,1);
 
         // Create the "Remove" button
         QToolButton * RemoveButton = new QToolButton();
-        RemoveButton->setObjectName(QString("Remove_") + QString::number(i));
+        RemoveButton->setObjectName(QStringLiteral("Remove_") + QString::number(i));
         QIcon icon(":/bitmaps/trash.png"); // Use a resource path or a relative path
         RemoveButton->setIcon(icon);
 
@@ -753,7 +753,7 @@ void Qucs_S_SPAR_Viewer::addFiles(QStringList fileNames)
 
            for (int i = 1; i<=number_of_ports; i++){
                for (int j = 1; j<=number_of_ports; j++){
-                   s1 = QString("S") + QString::number(j) + QString::number(i) + QString("_dB");
+                   s1 = QStringLiteral("S") + QString::number(j) + QString::number(i) + QStringLiteral("_dB");
                    s2 = s1.mid(0, s1.length() - 2).append("ang");
                    s3 = s1.mid(0, s1.length() - 2).append("re");
                    s4 = s1.mid(0, s1.length() - 2).append("im");
@@ -849,7 +849,7 @@ void Qucs_S_SPAR_Viewer::addFiles(QStringList fileNames)
 
     // Default behavior: If there's no more data loaded and a single S1P file is selected, then automatically plot S11
     if ((fileNames.length() == 1) && (fileNames.first().toLower().endsWith(".s1p")) && (datasets.size() == 1)){
-        this->addTrace(filename, QString("S11"), Qt::red);
+        this->addTrace(filename, QStringLiteral("S11"), Qt::red);
 
         adjust_x_axis_to_file(filename);
         adjust_y_axis_to_trace(filename, "S11");
@@ -857,9 +857,9 @@ void Qucs_S_SPAR_Viewer::addFiles(QStringList fileNames)
 
     // Default behavior: If there's no more data loaded and a single S2P file is selected, then automatically plot S21, S11 and S22
     if ((fileNames.length() == 1) && (fileNames.first().toLower().endsWith(".s2p")) && (datasets.size() == 1)){
-        this->addTrace(filename, QString("S21"), Qt::red);
-        this->addTrace(filename, QString("S11"), Qt::blue);
-        this->addTrace(filename, QString("S22"), Qt::darkGreen);
+        this->addTrace(filename, QStringLiteral("S21"), Qt::red);
+        this->addTrace(filename, QStringLiteral("S11"), Qt::blue);
+        this->addTrace(filename, QStringLiteral("S22"), Qt::darkGreen);
 
         adjust_x_axis_to_file(filename);
         adjust_y_axis_to_trace(filename, "S11");
@@ -882,7 +882,7 @@ void Qucs_S_SPAR_Viewer::addFiles(QStringList fileNames)
                 filename = filename.left(filename.lastIndexOf('.'));
                 // Pick a random color
                 QColor trace_color = QColor(QRandomGenerator::global()->bounded(256), QRandomGenerator::global()->bounded(256), QRandomGenerator::global()->bounded(256));
-                this->addTrace(filename, QString("S21"), trace_color);
+                this->addTrace(filename, QStringLiteral("S21"), trace_color);
                 adjust_y_axis_to_trace(filename, "S21");
             }
             // Update the frequency setting to fit the last s2p file
@@ -1210,15 +1210,15 @@ void Qucs_S_SPAR_Viewer::addTrace(QString selected_dataset, QString selected_tra
 
     // Label
     QLabel * new_trace_label = new QLabel(trace_name);
-    new_trace_label->setObjectName(QString("Trace_Name_") + trace_name);
+    new_trace_label->setObjectName(QStringLiteral("Trace_Name_") + trace_name);
     List_TraceNames.append(new_trace_label);
     this->TracesGrid->addWidget(new_trace_label, n_trace, 0);
 
     // Color picker
     QPushButton * new_trace_color = new QPushButton();
-    new_trace_color->setObjectName(QString("Trace_Color_") + trace_name);
+    new_trace_color->setObjectName(QStringLiteral("Trace_Color_") + trace_name);
     connect(new_trace_color, SIGNAL(clicked()), SLOT(changeTraceColor()));
-    QString styleSheet = QString("QPushButton { background-color: %1; }").arg(trace_color.name());
+    QString styleSheet = QStringLiteral("QPushButton { background-color: %1; }").arg(trace_color.name());
     new_trace_color->setStyleSheet(styleSheet);
     new_trace_color->setAttribute(Qt::WA_TranslucentBackground); // Needed for Windows buttons to behave as they should
     List_Trace_Color.append(new_trace_color);
@@ -1226,7 +1226,7 @@ void Qucs_S_SPAR_Viewer::addTrace(QString selected_dataset, QString selected_tra
 
     // Line Style
     QComboBox * new_trace_linestyle = new QComboBox();
-    new_trace_linestyle->setObjectName(QString("Trace_LineStyle_") + trace_name);
+    new_trace_linestyle->setObjectName(QStringLiteral("Trace_LineStyle_") + trace_name);
     new_trace_linestyle->addItem("Solid");
     new_trace_linestyle->addItem("- - - -");
     new_trace_linestyle->addItem("·······");
@@ -1240,7 +1240,7 @@ void Qucs_S_SPAR_Viewer::addTrace(QString selected_dataset, QString selected_tra
 
     // Line width
     QSpinBox * new_trace_width = new QSpinBox();
-    new_trace_width->setObjectName(QString("Trace_Width_") + trace_name);
+    new_trace_width->setObjectName(QStringLiteral("Trace_Width_") + trace_name);
     new_trace_width->setValue(trace_width);
     connect(new_trace_width, SIGNAL(valueChanged(int)), SLOT(changeTraceWidth()));
     List_TraceWidth.append(new_trace_width);
@@ -1249,7 +1249,7 @@ void Qucs_S_SPAR_Viewer::addTrace(QString selected_dataset, QString selected_tra
 
     // Remove button
     QToolButton * new_trace_removebutton = new QToolButton();
-    new_trace_removebutton->setObjectName(QString("Trace_RemoveButton_") + trace_name);
+    new_trace_removebutton->setObjectName(QStringLiteral("Trace_RemoveButton_") + trace_name);
     QIcon icon(":/bitmaps/trash.png"); // Use a resource path or a relative path
     new_trace_removebutton->setIcon(icon);
     new_trace_removebutton->setStyleSheet(R"(
@@ -1291,7 +1291,7 @@ void Qucs_S_SPAR_Viewer::updateTracesCombo()
 
     for (int i=1; i<=n_ports; i++){
         for (int j=1; j<=n_ports; j++){
-            traces.append(QString("S") + QString::number(i) + QString::number(j));
+            traces.append(QStringLiteral("S") + QString::number(i) + QString::number(j));
         }
     }
 
@@ -1303,10 +1303,10 @@ void Qucs_S_SPAR_Viewer::updateTracesCombo()
 
     if(n_ports == 2){
         // Additional traces
-        traces.append(QString("|%1|").arg(QChar(0x0394)));
+        traces.append(QStringLiteral("|%1|").arg(QChar(0x0394)));
         traces.append("K");
-        traces.append(QString("%1%2").arg(QChar(0x03BC)).arg(QChar(0x209B)));
-        traces.append(QString("%1%2").arg(QChar(0x03BC)).arg(QChar(0x209A)));
+        traces.append(QStringLiteral("%1%2").arg(QChar(0x03BC)).arg(QChar(0x209B)));
+        traces.append(QStringLiteral("%1%2").arg(QChar(0x03BC)).arg(QChar(0x209A)));
         traces.append("MAG");
         traces.append("MSG");
         traces.append("Re{Zin}");
@@ -1327,7 +1327,7 @@ void Qucs_S_SPAR_Viewer::changeTraceColor()
                 // For example, set the background color of the button
                 QPushButton *button = qobject_cast<QPushButton*>(sender());
                 if (button) {
-                  QString styleSheet = QString("QPushButton { background-color: %1; }").arg(color.name());
+                  QString styleSheet = QStringLiteral("QPushButton { background-color: %1; }").arg(color.name());
                   button->setStyleSheet(styleSheet);
 
                     QString ID = button->objectName();
@@ -1584,15 +1584,15 @@ void Qucs_S_SPAR_Viewer::updateTraces()
         QString trace_file = trace_name_parts[1];
 
         if (trace_file.at(0) == 'S'){
-            trace_file = trace_file + QString("_dB");
+            trace_file = trace_file + QStringLiteral("_dB");
         }
-        if (trace_file == QString("|%1|").arg(QChar(0x0394))){
+        if (trace_file == QStringLiteral("|%1|").arg(QChar(0x0394))){
             trace_file = "delta";
         }
-        if (trace_file == QString("%1%2").arg(QChar(0x03BC)).arg(QChar(0x209B))){
+        if (trace_file == QStringLiteral("%1%2").arg(QChar(0x03BC)).arg(QChar(0x209B))){
             trace_file = "mu";
         }
-        if (trace_file == QString("%1%2").arg(QChar(0x03BC)).arg(QChar(0x209A))){
+        if (trace_file == QStringLiteral("%1%2").arg(QChar(0x03BC)).arg(QChar(0x209A))){
             trace_file = "mu_p";
         }
 
@@ -1653,7 +1653,7 @@ void Qucs_S_SPAR_Viewer::updateTraces()
             marker_series->append(x, y);
         }
         QString trace_name = tableMarkers->horizontalHeaderItem(c)->text();
-        QString marker_series_name = QString("Mkr_%1").arg(trace_name);
+        QString marker_series_name = QStringLiteral("Mkr_%1").arg(trace_name);
         marker_series->setName(marker_series_name);
         seriesList.append(marker_series);
     }
@@ -1674,14 +1674,14 @@ void Qucs_S_SPAR_Viewer::updateTraces()
             verticalLine->append(x, y_axis_max);
             verticalLine->setPen(QPen(Qt::black, 1, Qt::DashLine));
 
-            QString verticalLine_name = QString("Mkr_%1").arg(r);
+            QString verticalLine_name = QStringLiteral("Mkr_%1").arg(r);
             verticalLine->setName(verticalLine_name);
 
             seriesList.append(verticalLine);
 
             QGraphicsTextItem *textItem = new QGraphicsTextItem(chart);
             QString freq_marker = tableMarkers->item(r,0)->text();
-            textItem->setPlainText(QString("%1").arg(freq_marker));
+            textItem->setPlainText(QStringLiteral("%1").arg(freq_marker));
             textItem->setFont(QFont("Arial", 8));
 
             // Get the axes
@@ -1732,7 +1732,7 @@ void Qucs_S_SPAR_Viewer::updateTraces()
       limitLine->append(fstop, val_stop);
       limitLine->setPen(QPen(Qt::black, 2));
 
-      QString limitLine_name = QString("Limit_%1").arg(i);
+      QString limitLine_name = QStringLiteral("Limit_%1").arg(i);
       limitLine->setName(limitLine_name);
 
       seriesList.append(limitLine);
@@ -1841,15 +1841,15 @@ void Qucs_S_SPAR_Viewer::adjust_y_axis_to_trace(QString filename, QString tracen
     qreal minX, maxX, minY, maxY;
 
     if (tracename.at(0) == 'S'){
-        tracename = tracename + QString("_dB");
+        tracename = tracename + QStringLiteral("_dB");
     }
-    if (tracename == QString("|%1|").arg(QChar(0x0394))){
+    if (tracename == QStringLiteral("|%1|").arg(QChar(0x0394))){
         tracename = "delta";
     }
-    if (tracename == QString("%1%2").arg(QChar(0x03BC)).arg(QChar(0x209B))){
+    if (tracename == QStringLiteral("%1%2").arg(QChar(0x03BC)).arg(QChar(0x209B))){
         tracename = "mu";
     }
-    if (tracename == QString("%1%2").arg(QChar(0x03BC)).arg(QChar(0x209A))){
+    if (tracename == QStringLiteral("%1%2").arg(QChar(0x03BC)).arg(QChar(0x209A))){
         tracename = "mu_p";
     }
 
@@ -1992,13 +1992,13 @@ void Qucs_S_SPAR_Viewer::addMarker(double freq){
     int n_markers = List_MarkerNames.size();
     n_markers++;
 
-    QString new_marker_name = QString("Mkr%1").arg(n_markers);
+    QString new_marker_name = QStringLiteral("Mkr%1").arg(n_markers);
     QLabel * new_marker_label = new QLabel(new_marker_name);
     new_marker_label->setObjectName(new_marker_name);
     List_MarkerNames.append(new_marker_label);
     this->MarkersGrid->addWidget(new_marker_label, n_markers, 0);
 
-    QString SpinBox_name = QString("Mkr_SpinBox%1").arg(n_markers);
+    QString SpinBox_name = QStringLiteral("Mkr_SpinBox%1").arg(n_markers);
     QDoubleSpinBox * new_marker_Spinbox = new QDoubleSpinBox();
     new_marker_Spinbox->setObjectName(SpinBox_name);
     new_marker_Spinbox->setMaximum(QSpinBox_x_axis_max->minimum());
@@ -2008,7 +2008,7 @@ void Qucs_S_SPAR_Viewer::addMarker(double freq){
     List_MarkerFreq.append(new_marker_Spinbox);
     this->MarkersGrid->addWidget(new_marker_Spinbox, n_markers, 1);
 
-    QString Combobox_name = QString("Mkr_ComboBox%1").arg(n_markers);
+    QString Combobox_name = QStringLiteral("Mkr_ComboBox%1").arg(n_markers);
     QComboBox * new_marker_Combo = new QComboBox();
     new_marker_Combo->setObjectName(Combobox_name);
     new_marker_Combo->addItems(frequency_units);
@@ -2018,7 +2018,7 @@ void Qucs_S_SPAR_Viewer::addMarker(double freq){
     this->MarkersGrid->addWidget(new_marker_Combo, n_markers, 2);
 
     // Remove button
-    QString DeleteButton_name = QString("Mkr_Delete_Btn%1").arg(n_markers);
+    QString DeleteButton_name = QStringLiteral("Mkr_Delete_Btn%1").arg(n_markers);
     QToolButton * new_marker_removebutton = new QToolButton();
     new_marker_removebutton->setObjectName(DeleteButton_name);
     QIcon icon(":/bitmaps/trash.png"); // Use a resource path or a relative path
@@ -2036,7 +2036,7 @@ void Qucs_S_SPAR_Viewer::addMarker(double freq){
 
     // Add new entry to the table
     tableMarkers->setRowCount(n_markers);
-    QString new_freq = QString("%1 ").arg(QString::number(f_marker, 'f', 2)) + Freq_Marker_Scale;
+    QString new_freq = QStringLiteral("%1 ").arg(QString::number(f_marker, 'f', 2)) + Freq_Marker_Scale;
     QTableWidgetItem *newfreq = new QTableWidgetItem(new_freq);
     tableMarkers->setItem(n_markers-1, 0, newfreq);
 
@@ -2085,7 +2085,7 @@ void Qucs_S_SPAR_Viewer::updateMarkerTable(){
     // Columns are traces. Rows are markers
     for (int c = 0; c<tableMarkers->columnCount(); c++){//Traces
         for (int r = 0; r<tableMarkers->rowCount(); r++){//Marker
-            freq_marker = QString("%1 ").arg(QString::number(List_MarkerFreq[r]->value(), 'f', 1)) + List_MarkerScale[r]->currentText();
+            freq_marker = QStringLiteral("%1 ").arg(QString::number(List_MarkerFreq[r]->value(), 'f', 1)) + List_MarkerScale[r]->currentText();
 
             if (c==0){
                 // First column
@@ -2107,7 +2107,7 @@ void Qucs_S_SPAR_Viewer::updateMarkerTable(){
               trace.append("_dB");
             }
             P = findClosestPoint(datasets[file]["frequency"], datasets[file][trace], targetX);
-            new_val = QString("%1").arg(QString::number(P.y(), 'f', 2));
+            new_val = QStringLiteral("%1").arg(QString::number(P.y(), 'f', 2));
             QTableWidgetItem *new_item = new QTableWidgetItem(new_val);
             tableMarkers->setItem(r, c, new_item);
         }
@@ -2235,7 +2235,7 @@ void Qucs_S_SPAR_Viewer::updateMarkerNames()
   int n_markers = List_MarkerNames.size();
   for (int i = 0; i < n_markers; i++) {
     QLabel * MarkerLabel = List_MarkerNames[i];
-    MarkerLabel->setText(QString("Mkr%1").arg(i+1));
+    MarkerLabel->setText(QStringLiteral("Mkr%1").arg(i+1));
   }
 }
 
@@ -2245,7 +2245,7 @@ void Qucs_S_SPAR_Viewer::updateLimitNames()
   int n_limits = List_LimitNames.size();
   for (int i = 0; i < n_limits; i++) {
     QLabel * LimitLabel = List_LimitNames[i];
-    LimitLabel->setText(QString("Limit %1").arg(i+1));
+    LimitLabel->setText(QStringLiteral("Limit %1").arg(i+1));
   }
 }
 
@@ -2567,13 +2567,13 @@ void Qucs_S_SPAR_Viewer::addLimit(double f_limit1, QString f_limit1_unit, double
 
   QString tooltip_message;
 
-  QString new_limit_name = QString("Limit %1").arg(n_limits);
+  QString new_limit_name = QStringLiteral("Limit %1").arg(n_limits);
   QLabel * new_limit_label = new QLabel(new_limit_name);
   new_limit_label->setObjectName(new_limit_name);
   List_LimitNames.append(new_limit_label);
   this->LimitsGrid->addWidget(new_limit_label, limit_index, 0);
 
-  QString SpinBox_fstart_name = QString("Lmt_Freq_Start_SpinBox_%1").arg(new_limit_name);
+  QString SpinBox_fstart_name = QStringLiteral("Lmt_Freq_Start_SpinBox_%1").arg(new_limit_name);
   QDoubleSpinBox * new_limit_fstart_Spinbox = new QDoubleSpinBox();
   new_limit_fstart_Spinbox->setObjectName(SpinBox_fstart_name);
   new_limit_fstart_Spinbox->setMaximum(QSpinBox_x_axis_max->minimum());
@@ -2584,7 +2584,7 @@ void Qucs_S_SPAR_Viewer::addLimit(double f_limit1, QString f_limit1_unit, double
   List_Limit_Start_Freq.append(new_limit_fstart_Spinbox);
   this->LimitsGrid->addWidget(new_limit_fstart_Spinbox, limit_index, 1);
 
-  QString Combobox_start_name = QString("Lmt_Start_ComboBox_%1").arg(new_limit_name);
+  QString Combobox_start_name = QStringLiteral("Lmt_Start_ComboBox_%1").arg(new_limit_name);
   QComboBox * new_start_limit_Combo = new QComboBox();
   new_start_limit_Combo->setObjectName(Combobox_start_name);
   new_start_limit_Combo->addItems(frequency_units);
@@ -2598,7 +2598,7 @@ void Qucs_S_SPAR_Viewer::addLimit(double f_limit1, QString f_limit1_unit, double
   List_Limit_Start_Freq_Scale.append(new_start_limit_Combo);
   this->LimitsGrid->addWidget(new_start_limit_Combo, limit_index, 2);
 
-  QString SpinBox_fstop_name = QString("Lmt_Freq_Stop_SpinBox_%1").arg(new_limit_name);
+  QString SpinBox_fstop_name = QStringLiteral("Lmt_Freq_Stop_SpinBox_%1").arg(new_limit_name);
   QDoubleSpinBox * new_limit_fstop_Spinbox = new QDoubleSpinBox();
   new_limit_fstop_Spinbox->setObjectName(SpinBox_fstop_name);
   new_limit_fstop_Spinbox->setMaximum(QSpinBox_x_axis_max->minimum());
@@ -2609,7 +2609,7 @@ void Qucs_S_SPAR_Viewer::addLimit(double f_limit1, QString f_limit1_unit, double
   List_Limit_Stop_Freq.append(new_limit_fstop_Spinbox);
   this->LimitsGrid->addWidget(new_limit_fstop_Spinbox, limit_index, 3);
 
-  QString Combobox_stop_name = QString("Lmt_Stop_ComboBox_%1").arg(new_limit_name);
+  QString Combobox_stop_name = QStringLiteral("Lmt_Stop_ComboBox_%1").arg(new_limit_name);
   QComboBox * new_stop_limit_Combo = new QComboBox();
   new_stop_limit_Combo->setObjectName(Combobox_stop_name);
   new_stop_limit_Combo->addItems(frequency_units);
@@ -2625,10 +2625,10 @@ void Qucs_S_SPAR_Viewer::addLimit(double f_limit1, QString f_limit1_unit, double
   this->LimitsGrid->addWidget(new_stop_limit_Combo, limit_index, 4);
 
   // Remove button
-  QString DeleteButton_name = QString("Lmt_Delete_Btn_%1").arg(new_limit_name);
+  QString DeleteButton_name = QStringLiteral("Lmt_Delete_Btn_%1").arg(new_limit_name);
   QToolButton * new_limit_removebutton = new QToolButton();
   new_limit_removebutton->setObjectName(DeleteButton_name);
-  tooltip_message = QString("Remove this limit");
+  tooltip_message = QStringLiteral("Remove this limit");
   new_limit_removebutton->setToolTip(tooltip_message);
   QIcon icon(":/bitmaps/trash.png");
   new_limit_removebutton->setIcon(icon);
@@ -2643,7 +2643,7 @@ void Qucs_S_SPAR_Viewer::addLimit(double f_limit1, QString f_limit1_unit, double
   List_Button_Delete_Limit.append(new_limit_removebutton);
   this->LimitsGrid->addWidget(new_limit_removebutton, limit_index, 5, Qt::AlignCenter);
 
-  QString SpinBox_val_start_name = QString("Lmt_Val_Start_SpinBox_%1").arg(new_limit_name);
+  QString SpinBox_val_start_name = QStringLiteral("Lmt_Val_Start_SpinBox_%1").arg(new_limit_name);
   QDoubleSpinBox * new_limit_val_start_Spinbox = new QDoubleSpinBox();
   new_limit_val_start_Spinbox->setObjectName(SpinBox_val_start_name);
   new_limit_val_start_Spinbox->setMaximum(QSpinBox_y_axis_max->minimum());
@@ -2655,17 +2655,17 @@ void Qucs_S_SPAR_Viewer::addLimit(double f_limit1, QString f_limit1_unit, double
   this->LimitsGrid->addWidget(new_limit_val_start_Spinbox, limit_index+1, 1);
 
   // Coupled spinbox value
-  QString CoupleButton_name = QString("Lmt_Couple_Btn_%1").arg(new_limit_name);
+  QString CoupleButton_name = QStringLiteral("Lmt_Couple_Btn_%1").arg(new_limit_name);
   QPushButton * new_limit_CoupleButton = new QPushButton("<--->");
   new_limit_CoupleButton->setObjectName(CoupleButton_name);
   new_limit_CoupleButton->setChecked(coupled);
-  tooltip_message = QString("Couple start and stop values");
+  tooltip_message = QStringLiteral("Couple start and stop values");
   new_limit_CoupleButton->setToolTip(tooltip_message);
   connect(new_limit_CoupleButton, SIGNAL(clicked(bool)), SLOT(coupleSpinBoxes()));
   List_Couple_Value.append(new_limit_CoupleButton);
   this->LimitsGrid->addWidget(new_limit_CoupleButton, limit_index+1, 2);
 
-  QString SpinBox_val_stop_name = QString("Lmt_Val_Stop_SpinBox_%1").arg(new_limit_name);
+  QString SpinBox_val_stop_name = QStringLiteral("Lmt_Val_Stop_SpinBox_%1").arg(new_limit_name);
   QDoubleSpinBox * new_limit_val_stop_Spinbox = new QDoubleSpinBox();
   new_limit_val_stop_Spinbox->setObjectName(SpinBox_val_stop_name);
   new_limit_val_stop_Spinbox->setMaximum(QSpinBox_y_axis_max->minimum());
@@ -2683,7 +2683,7 @@ void Qucs_S_SPAR_Viewer::addLimit(double f_limit1, QString f_limit1_unit, double
   }
   new_limit_CoupleButton->click();
 
-  QString Separator_name = QString("Lmt_Separator_%1").arg(new_limit_name);
+  QString Separator_name = QStringLiteral("Lmt_Separator_%1").arg(new_limit_name);
   QFrame * new_Separator = new QFrame();
   new_Separator->setObjectName(Separator_name);
   new_Separator->setFrameShape(QFrame::HLine);
@@ -2716,7 +2716,7 @@ void Qucs_S_SPAR_Viewer::coupleSpinBoxes(){
 
   if (button->text() == "<--->"){
     button->setText("<-X->");
-    QString tooltip_message = QString("Uncouple start and stop values");
+    QString tooltip_message = QStringLiteral("Uncouple start and stop values");
     button->setToolTip(tooltip_message);
     QDoubleSpinBox * lower_limit_spinbox = List_Limit_Start_Value.at(index);
     upper_limit_spinbox->setValue(lower_limit_spinbox->value());
@@ -3105,13 +3105,13 @@ void Qucs_S_SPAR_Viewer::loadSession(QString session_file)
     // Add file management widgets
     // Label
     QLabel * Filename_Label = new QLabel(file);
-    Filename_Label->setObjectName(QString("File_") + QString::number(i));
+    Filename_Label->setObjectName(QStringLiteral("File_") + QString::number(i));
     List_FileNames.append(Filename_Label);
     this->FilesGrid->addWidget(List_FileNames.last(), i, 0, 1, 1);
 
     // Create the "Remove" button
     QToolButton * RemoveButton = new QToolButton();
-    RemoveButton->setObjectName(QString("Remove_") + QString::number(i));
+    RemoveButton->setObjectName(QStringLiteral("Remove_") + QString::number(i));
     QIcon icon(":/bitmaps/trash.png"); // Use a resource path or a relative path
     RemoveButton->setIcon(icon);
 

--- a/qucs-s-spar-viewer/qucsattenuator.cpp
+++ b/qucs-s-spar-viewer/qucsattenuator.cpp
@@ -175,10 +175,10 @@ QucsAttenuator::QucsAttenuator()
   powerunits.append("mW");
   powerunits.append("W");
   powerunits.append("dBm");
-  powerunits.append(QString("dB%1V [75%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)));
-  powerunits.append(QString("dB%1V [50%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)));
-  powerunits.append(QString("dBmV [75%1]").arg(QChar(0xa9, 0x03)));
-  powerunits.append(QString("dBmV [50%1]").arg(QChar(0xa9, 0x03)));
+  powerunits.append(QStringLiteral("dB%1V [75%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)));
+  powerunits.append(QStringLiteral("dB%1V [50%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)));
+  powerunits.append(QStringLiteral("dBmV [75%1]").arg(QChar(0xa9, 0x03)));
+  powerunits.append(QStringLiteral("dBmV [50%1]").arg(QChar(0xa9, 0x03)));
   Combo_InputPowerUnits = new QComboBox();
   Combo_InputPowerUnits->addItems(powerunits);
   Combo_InputPowerUnits->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
@@ -695,7 +695,7 @@ void QucsAttenuator::slotCalculate()
       lineEdit_R3->setText(QString::number(Values.R3, 'f', 1));
       lineEdit_R4->setText(QString::number(Values.R4, 'f', 1));
 
-      lineEdit_R1_Pdiss->setText(QString::number(ConvertPowerUnits(Values.PR1, QString("W"), ComboR1_PowerUnits->currentText()), 'f', 5));
+      lineEdit_R1_Pdiss->setText(QString::number(ConvertPowerUnits(Values.PR1, QStringLiteral("W"), ComboR1_PowerUnits->currentText()), 'f', 5));
       lineEdit_R2_Pdiss->setText(QString::number(ConvertPowerUnits(Values.PR2, "W", ComboR2_PowerUnits->currentText()), 'f', 5));
       lineEdit_R3_Pdiss->setText(QString::number(ConvertPowerUnits(Values.PR3, "W", ComboR3_PowerUnits->currentText()), 'f', 5));
       lineEdit_R4_Pdiss->setText(QString::number(ConvertPowerUnits(Values.PR4, "W", ComboR4_PowerUnits->currentText()), 'f', 5));
@@ -743,7 +743,7 @@ void QucsAttenuator::slot_ComboR1PowerUnits_Changed(const QString& new_units)
    //Convert power
    double P = lineEdit_R1_Pdiss->text().toDouble();
    P =ConvertPowerUnits(P, LastUnits[1], new_units);
-   lineEdit_R1_Pdiss->setText(QString("%1").arg(P));
+   lineEdit_R1_Pdiss->setText(QStringLiteral("%1").arg(P));
    LastUnits[1] = new_units;
 
    //Change lineedit input policy
@@ -760,7 +760,7 @@ void QucsAttenuator::slot_ComboR2PowerUnits_Changed(const QString& new_units)
    //Convert power
    double P = lineEdit_R2_Pdiss->text().toDouble();
    P =ConvertPowerUnits(P, LastUnits[2], new_units);
-   lineEdit_R2_Pdiss->setText(QString("%1").arg(P));
+   lineEdit_R2_Pdiss->setText(QStringLiteral("%1").arg(P));
    LastUnits[2] = new_units;
 
    //Change lineedit input policy
@@ -777,7 +777,7 @@ void QucsAttenuator::slot_ComboR3PowerUnits_Changed(const QString& new_units)
    //Convert power
    double P = lineEdit_R3_Pdiss->text().toDouble();
       P =ConvertPowerUnits(P, LastUnits[3], new_units);
-   lineEdit_R3_Pdiss->setText(QString("%1").arg(P));
+   lineEdit_R3_Pdiss->setText(QStringLiteral("%1").arg(P));
    LastUnits[3] = new_units;
 
    //Change lineedit input policy
@@ -794,7 +794,7 @@ void QucsAttenuator::slot_ComboR4PowerUnits_Changed(const QString& new_units)
    //Convert power
    double P = lineEdit_R4_Pdiss->text().toDouble();
    P =ConvertPowerUnits(P, LastUnits[4], new_units);
-   lineEdit_R4_Pdiss->setText(QString("%1").arg(P));
+   lineEdit_R4_Pdiss->setText(QStringLiteral("%1").arg(P));
    LastUnits[4] = new_units;
 
    //Change lineedit input policy
@@ -816,16 +816,16 @@ double QucsAttenuator::ConvertPowerUnits(double Pin, QString from_units, QString
       if (from_units == "dBm")
           Pin = pow(10, 0.1*(Pin-30));//dBm -> W
       else
-          if (from_units == QString("dB%1V [75%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
+          if (from_units == QStringLiteral("dB%1V [75%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
               Pin = pow(10, (0.1*Pin-12))/75;//dBuV [75Ohm] -> W
          else
-             if (from_units == QString("dB%1V [50%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
+             if (from_units == QStringLiteral("dB%1V [50%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
                  Pin = pow(10, (0.1*Pin-12))/50;//dBuV [50Ohm] -> W
              else
-                 if (from_units == QString("dBmV [75%2]").arg(QChar(0xa9, 0x03)))
+                 if (from_units == QStringLiteral("dBmV [75%2]").arg(QChar(0xa9, 0x03)))
                      Pin = pow(10, (0.1*Pin-6))/75;//dBmV [75Ohm] -> W
                  else
-                     if (from_units == QString("dBmV [50%2]").arg(QChar(0xa9, 0x03)))
+                     if (from_units == QStringLiteral("dBmV [50%2]").arg(QChar(0xa9, 0x03)))
                          Pin = pow(10, (0.1*Pin-6))/50;//dBmV [50Ohm] -> W
                      else
                          if (from_units == "mW")
@@ -841,16 +841,16 @@ double QucsAttenuator::ConvertPowerUnits(double Pin, QString from_units, QString
   if (to_units == "dBm")
       return Pin;//Already done
   else
-      if (to_units == QString("dB%1V [75%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
+      if (to_units == QStringLiteral("dB%1V [75%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
           Pin += 108.7506126339170004686755011380612925566374910126647878220;//W -> dBuV [75Ohm]
       else
-          if (to_units == QString("dB%1V [50%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
+          if (to_units == QStringLiteral("dB%1V [50%2]").arg(QChar(0xbc, 0x03)).arg(QChar(0xa9, 0x03)))
               Pin += 106.9897000433601880478626110527550697323181011853789145868;//W -> dBuV [50Ohm]
           else
-              if (to_units == QString("dBmV [75%2]").arg(QChar(0xa9, 0x03)))
+              if (to_units == QStringLiteral("dBmV [75%2]").arg(QChar(0xa9, 0x03)))
                   Pin += 48.7506126339170004686755011380612925566374910126647878220;//W -> dBmV [75Ohm]
               else
-                  if (to_units == QString("dBmV [50%2]").arg(QChar(0xa9, 0x03)))
+                  if (to_units == QStringLiteral("dBmV [50%2]").arg(QChar(0xa9, 0x03)))
                       Pin += 46.9897000433601880478626110527550697323181011853789145868;//W -> dBmV [50Ohm]
 
   return Pin;

--- a/qucs-transcalc/main.cpp
+++ b/qucs-transcalc/main.cpp
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
   QString lang = QucsSettings.Language;
   if(lang.isEmpty())
     lang = QString(QLocale::system().name());
-  tor.load( QString("qucs_") + lang, QucsSettings.LangDir);
+  tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir);
   a.installTranslator( &tor );
 
   QucsTranscalc *qucs = new QucsTranscalc();

--- a/qucs-transcalc/qucstrans.cpp
+++ b/qucs-transcalc/qucstrans.cpp
@@ -1282,7 +1282,7 @@ void QucsTranscalc::slotCopyToClipBoard()
     s +="  <Pac P2 1 270 150 18 -26 0 1 \"2\" 1 \"50 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n";
     s += "  <GND * 1 90 180 0 0 0 0>\n";
     s += "  <GND * 1 270 180 0 0 0 0>\n";
-    s += QString("  <SUBST SubstTC1 1 390 140 -30 24 0 0 \"%1\" 1 \"%2 mm\" 1 \"%3 um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").
+    s += QStringLiteral("  <SUBST SubstTC1 1 390 140 -30 24 0 0 \"%1\" 1 \"%2 mm\" 1 \"%3 um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").
       arg(l->getProperty("Er")).
       arg(l->getProperty("H", UNIT_LENGTH, LENGTH_MM)).
       arg(l->getProperty("T", UNIT_LENGTH, LENGTH_UM)).
@@ -1292,12 +1292,12 @@ void QucsTranscalc::slotCopyToClipBoard()
     s += "  <.SP SPTC1 1 90 240 0 51 0 0 ";
     double freq = l->getProperty("Freq", UNIT_FREQ, FREQ_GHZ);
     if (freq > 0)
-      s += QString("\"log\" 1 \"%1 GHz\" 1 \"%2 GHz\" 1 ").
+      s += QStringLiteral("\"log\" 1 \"%1 GHz\" 1 \"%2 GHz\" 1 ").
     arg(freq / 10).arg(freq * 10);
     else
       s += "\"lin\" 1 \"0 GHz\" 1 \"10 GHz\" 1 ";
     s += "\"51\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n";
-    s += QString("  <MLIN MSTC1 1 180 100 -26 15 0 0 \"SubstTC1\" 1 \"%1 mm\" 1 \"%2 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").
+    s += QStringLiteral("  <MLIN MSTC1 1 180 100 -26 15 0 0 \"SubstTC1\" 1 \"%1 mm\" 1 \"%2 mm\" 1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").
       arg(l->getProperty("W", UNIT_LENGTH, LENGTH_MM)).
       arg(l->getProperty("L", UNIT_LENGTH, LENGTH_MM));
     s += "  <Eqn EqnTC1 1 240 260 -23 12 0 0 \"A=twoport(S,'S','A')\" 1 \"ZL=real(sqrt(A[1,2]/A[2,1]))\" 1 \"yes\" 0>\n";
@@ -1323,7 +1323,7 @@ void QucsTranscalc::slotCopyToClipBoard()
     s += "  <GND * 1 140 230 0 0 0 0>\n";
     s += "  <GND * 1 320 160 0 0 0 0>\n";
     s += "  <GND * 1 280 250 0 0 0 0>\n";
-    s += QString("  <SUBST SubstTC1 1 410 220 -30 24 0 0 \"%1\" 1 \"%2 mm\" 1 \"%3 um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").
+    s += QStringLiteral("  <SUBST SubstTC1 1 410 220 -30 24 0 0 \"%1\" 1 \"%2 mm\" 1 \"%3 um\" 1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n").
       arg(l->getProperty("Er")).
       arg(l->getProperty("H", UNIT_LENGTH, LENGTH_MM)).
       arg(l->getProperty("T", UNIT_LENGTH, LENGTH_UM)).
@@ -1333,12 +1333,12 @@ void QucsTranscalc::slotCopyToClipBoard()
     s += "  <.SP SPTC1 1 100 290 0 51 0 0 ";
     double freq = l->getProperty("Freq", UNIT_FREQ, FREQ_GHZ);
     if (freq > 0)
-      s += QString("\"log\" 1 \"%1 GHz\" 1 \"%2 GHz\" 1 ").
+      s += QStringLiteral("\"log\" 1 \"%1 GHz\" 1 \"%2 GHz\" 1 ").
     arg(freq / 10).arg(freq * 10);
     else
       s += "\"lin\" 1 \"0 GHz\" 1 \"10 GHz\" 1 ";
     s += "\"51\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n";
-    s += QString("  <MCOUPLED MSTC1 1 190 110 -26 37 0 0 \"SubstTC1\" 1 \"%1 mm\" 1 \"%2 mm\" 1 \"%3 mm\" 1 \"Kirschning\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").
+    s += QStringLiteral("  <MCOUPLED MSTC1 1 190 110 -26 37 0 0 \"SubstTC1\" 1 \"%1 mm\" 1 \"%2 mm\" 1 \"%3 mm\" 1 \"Kirschning\" 0 \"Kirschning\" 0 \"26.85\" 0>\n").
       arg(l->getProperty("W", UNIT_LENGTH, LENGTH_MM)).
       arg(l->getProperty("L", UNIT_LENGTH, LENGTH_MM)).
       arg(l->getProperty("S", UNIT_LENGTH, LENGTH_MM));
@@ -1367,12 +1367,12 @@ void QucsTranscalc::slotCopyToClipBoard()
     s += "  <.SP SPTC1 1 90 240 0 51 0 0 ";
     double freq = l->getProperty("Freq", UNIT_FREQ, FREQ_GHZ);
     if (freq > 0)
-      s += QString("\"log\" 1 \"%1 GHz\" 1 \"%2 GHz\" 1 ").
+      s += QStringLiteral("\"log\" 1 \"%1 GHz\" 1 \"%2 GHz\" 1 ").
     arg(freq / 10).arg(freq * 10);
     else
       s += "\"lin\" 1 \"0 GHz\" 1 \"10 GHz\" 1 ";
     s += "\"51\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n";
-    s += QString("  <COAX CXTC1 1 180 100 -26 15 0 0 \"%1\" 1 \"%2\" 0 \"%3\" 0 \"%4 mm\" 1 \"%5 mm\" 1  \"%6 mm\" 1  \"%7\" 0 \"26.85\" 0>\n").
+    s += QStringLiteral("  <COAX CXTC1 1 180 100 -26 15 0 0 \"%1\" 1 \"%2\" 0 \"%3\" 0 \"%4 mm\" 1 \"%5 mm\" 1  \"%6 mm\" 1  \"%7\" 0 \"26.85\" 0>\n").
       arg(l->getProperty("Er")).
       arg(1 / l->getProperty("Sigma")).
       arg(l->getProperty("Mur")).
@@ -1398,7 +1398,7 @@ void QucsTranscalc::slotCopyToClipBoard()
     s +="  <Pac P2 1 270 150 18 -26 0 1 \"2\" 1 \"50 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n";
     s += "  <GND * 1 90 180 0 0 0 0>\n";
     s += "  <GND * 1 270 180 0 0 0 0>\n";
-    s += QString("  <SUBST SubstTC1 1 390 140 -30 24 0 0 \"%1\" 1 \"%2 mm\" 1 \"%3 um\" 1 \"%4\" 1 \"%5\" 1 \"0\" 1>\n").
+    s += QStringLiteral("  <SUBST SubstTC1 1 390 140 -30 24 0 0 \"%1\" 1 \"%2 mm\" 1 \"%3 um\" 1 \"%4\" 1 \"%5\" 1 \"0\" 1>\n").
       arg(l->getProperty("Er")).
       arg(l->getProperty("H", UNIT_LENGTH, LENGTH_MM)).
       arg(l->getProperty("T", UNIT_LENGTH, LENGTH_UM)).
@@ -1407,12 +1407,12 @@ void QucsTranscalc::slotCopyToClipBoard()
     s += "  <.SP SPTC1 1 90 240 0 51 0 0 ";
     double freq = l->getProperty("Freq", UNIT_FREQ, FREQ_GHZ);
     if (freq > 0)
-      s += QString("\"log\" 1 \"%1 GHz\" 1 \"%2 GHz\" 1 ").
+      s += QStringLiteral("\"log\" 1 \"%1 GHz\" 1 \"%2 GHz\" 1 ").
     arg(freq / 10).arg(freq * 10);
     else
       s += "\"lin\" 1 \"0 GHz\" 1 \"10 GHz\" 1 ";
     s += "\"51\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n";
-    s += QString("  <CLIN CLTC1 1 180 100 -26 25 0 0 \"SubstTC1\" 1 \"%1 mm\" 1 \"%2 mm\" 1 \"%3 mm\" 1 \"Air\" 1 \"yes\" 0>\n").
+    s += QStringLiteral("  <CLIN CLTC1 1 180 100 -26 25 0 0 \"SubstTC1\" 1 \"%1 mm\" 1 \"%2 mm\" 1 \"%3 mm\" 1 \"Air\" 1 \"yes\" 0>\n").
       arg(l->getProperty("W", UNIT_LENGTH, LENGTH_MM)).
       arg(l->getProperty("S", UNIT_LENGTH, LENGTH_MM)).
       arg(l->getProperty("L", UNIT_LENGTH, LENGTH_MM));
@@ -1435,7 +1435,7 @@ void QucsTranscalc::slotCopyToClipBoard()
     s +="  <Pac P2 1 270 150 18 -26 0 1 \"2\" 1 \"50 Ohm\" 1 \"0 dBm\" 0 \"1 GHz\" 0 \"26.85\" 0>\n";
     s += "  <GND * 1 90 180 0 0 0 0>\n";
     s += "  <GND * 1 270 180 0 0 0 0>\n";
-    s += QString("  <SUBST SubstTC1 1 390 140 -30 24 0 0 \"%1\" 1 \"%2 mm\" 1 \"%3 um\" 1 \"%4\" 1 \"%5\" 1 \"0\" 1>\n").
+    s += QStringLiteral("  <SUBST SubstTC1 1 390 140 -30 24 0 0 \"%1\" 1 \"%2 mm\" 1 \"%3 um\" 1 \"%4\" 1 \"%5\" 1 \"0\" 1>\n").
       arg(l->getProperty("Er")).
       arg(l->getProperty("H", UNIT_LENGTH, LENGTH_MM)).
       arg(l->getProperty("T", UNIT_LENGTH, LENGTH_UM)).
@@ -1444,12 +1444,12 @@ void QucsTranscalc::slotCopyToClipBoard()
     s += "  <.SP SPTC1 1 90 240 0 51 0 0 ";
     double freq = l->getProperty("Freq", UNIT_FREQ, FREQ_GHZ);
     if (freq > 0)
-      s += QString("\"log\" 1 \"%1 GHz\" 1 \"%2 GHz\" 1 ").
+      s += QStringLiteral("\"log\" 1 \"%1 GHz\" 1 \"%2 GHz\" 1 ").
     arg(freq / 10).arg(freq * 10);
     else
       s += "\"lin\" 1 \"0 GHz\" 1 \"10 GHz\" 1 ";
     s += "\"51\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n";
-    s += QString("  <CLIN CLTC1 1 180 100 -26 25 0 0 \"SubstTC1\" 1 \"%1 mm\" 1 \"%2 mm\" 1 \"%3 mm\" 1 \"Metal\" 1 \"yes\" 0>\n").
+    s += QStringLiteral("  <CLIN CLTC1 1 180 100 -26 25 0 0 \"SubstTC1\" 1 \"%1 mm\" 1 \"%2 mm\" 1 \"%3 mm\" 1 \"Metal\" 1 \"yes\" 0>\n").
       arg(l->getProperty("W", UNIT_LENGTH, LENGTH_MM)).
       arg(l->getProperty("S", UNIT_LENGTH, LENGTH_MM)).
       arg(l->getProperty("L", UNIT_LENGTH, LENGTH_MM));
@@ -1475,12 +1475,12 @@ void QucsTranscalc::slotCopyToClipBoard()
     s += "  <.SP SPTC1 1 90 240 0 51 0 0 ";
     double freq = l->getProperty("Freq", UNIT_FREQ, FREQ_GHZ);
     if (freq > 0)
-      s += QString("\"log\" 1 \"%1 GHz\" 1 \"%2 GHz\" 1 ").
+      s += QStringLiteral("\"log\" 1 \"%1 GHz\" 1 \"%2 GHz\" 1 ").
     arg(freq / 10).arg(freq * 10);
     else
       s += "\"lin\" 1 \"0 GHz\" 1 \"10 GHz\" 1 ";
     s += "\"51\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n";
-    s += QString("  <RECTLINE RLTC1 1 180 100 -26 25 0 0 \"%1 mm\" 1 \"%2 mm\" 1 \"%3 mm\" 1 \"%4\" 0 \"%5\" 0 \"%6\" 0 \"%7\" 0 \"26.85\" 0>\n").
+    s += QStringLiteral("  <RECTLINE RLTC1 1 180 100 -26 25 0 0 \"%1 mm\" 1 \"%2 mm\" 1 \"%3 mm\" 1 \"%4\" 0 \"%5\" 0 \"%6\" 0 \"%7\" 0 \"26.85\" 0>\n").
       arg(l->getProperty("a", UNIT_LENGTH, LENGTH_MM)).
       arg(l->getProperty("b", UNIT_LENGTH, LENGTH_MM)).
       arg(l->getProperty("L", UNIT_LENGTH, LENGTH_MM)).

--- a/qucs/components/ac_sim.cpp
+++ b/qucs/components/ac_sim.cpp
@@ -93,13 +93,13 @@ QString AC_Sim::spice_netlist(bool isXyce)
         Fstop *= fac;
         double Nd = ceil(log10(Fstop/Fstart)); // number of decades
         double Npd = ceil((Np - 1)/Nd); // points per decade
-        s += QString("DEC %1 ").arg(Npd);
+        s += QStringLiteral("DEC %1 ").arg(Npd);
     } else {  // no need conversion
-        s += QString("LIN %1 ").arg(Props.at(3)->Value);
+        s += QStringLiteral("LIN %1 ").arg(Props.at(3)->Value);
     }
     QString fstart = spicecompat::normalize_value(Props.at(1)->Value); // Start freq.
     QString fstop = spicecompat::normalize_value(Props.at(2)->Value); // Stop freq.
-    s += QString("%1 %2 \n").arg(fstart).arg(fstop);
+    s += QStringLiteral("%1 %2 \n").arg(fstart).arg(fstop);
     if (!isXyce) s.remove(0,1);
     return s.toLower();
 

--- a/qucs/components/ampere_ac.cpp
+++ b/qucs/components/ampere_ac.cpp
@@ -84,7 +84,7 @@ QString Ampere_ac::spice_netlist(bool)
 
     QString plus = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
     QString minus = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
-    s += QString(" %1 %2 ").arg(plus).arg(minus);
+    s += QStringLiteral(" %1 %2 ").arg(plus).arg(minus);
 
     QString amperes = spicecompat::normalize_value(Props.at(0)->Value);
     QString freq = spicecompat::normalize_value(Props.at(1)->Value);
@@ -96,6 +96,6 @@ QString Ampere_ac::spice_netlist(bool)
     QString theta = Props.at(3)->Value;
     theta.remove(' ');
     if (theta.isEmpty()) theta="0";
-    s += QString(" DC 0 SIN(0 %1 %2 0 %3 %4) AC %5 ACPHASE %6\n").arg(amperes).arg(freq).arg(theta).arg(phase).arg(amperes).arg(phase);
+    s += QStringLiteral(" DC 0 SIN(0 %1 %2 0 %3 %4) AC %5 ACPHASE %6\n").arg(amperes).arg(freq).arg(theta).arg(phase).arg(amperes).arg(phase);
     return s;
 }

--- a/qucs/components/ampere_dc.cpp
+++ b/qucs/components/ampere_dc.cpp
@@ -64,7 +64,7 @@ QString Ampere_dc::spice_netlist(bool)
     if (plus=="gnd") plus = "0";
     QString minus = Ports.at(0)->Connection->Name;
     if (minus=="gnd") minus = "0";
-    s += QString(" %1 %2 DC %3\n").arg(plus).arg(minus)
+    s += QStringLiteral(" %1 %2 DC %3\n").arg(plus).arg(minus)
             .arg(spicecompat::normalize_value(Props.at(0)->Value));
     return s;
 }

--- a/qucs/components/ampere_noise.cpp
+++ b/qucs/components/ampere_noise.cpp
@@ -96,11 +96,11 @@ QString Ampere_noise::va_code()
 
     if ( e == "0" ) 
     {
-       s += QString("%1 <+ white_noise(%2,\"shot\" );\n").arg(Ipm).arg(u);
+       s += QStringLiteral("%1 <+ white_noise(%2,\"shot\" );\n").arg(Ipm).arg(u);
     }
     else 
     {
-	  s += QString("%1 <+ flicker_noise(%2, %3, \"flicker\" );\n" ).arg(Ipm).arg(u).arg(e);
+	  s += QStringLiteral("%1 <+ flicker_noise(%2, %3, \"flicker\" );\n" ).arg(Ipm).arg(u).arg(e);
     }
 
     return s;

--- a/qucs/components/biast.cpp
+++ b/qucs/components/biast.cpp
@@ -89,7 +89,7 @@ QString BiasT::spice_netlist(bool isXyce)
     QString pin1 = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
     QString pin2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
     QString pin3 = spicecompat::normalize_node_name(Ports.at(2)->Connection->Name);
-    s += QString("C_%1 %2 %3 %4\n").arg(Name).arg(pin1).arg(pin2).arg(C);
-    s += QString("L_%1 %2 %3 %4\n").arg(Name).arg(pin2).arg(pin3).arg(L);
+    s += QStringLiteral("C_%1 %2 %3 %4\n").arg(Name).arg(pin1).arg(pin2).arg(C);
+    s += QStringLiteral("L_%1 %2 %3 %4\n").arg(Name).arg(pin2).arg(pin3).arg(L);
     return s;
 }

--- a/qucs/components/bjt.cpp
+++ b/qucs/components/bjt.cpp
@@ -61,12 +61,12 @@ QString BJT::spice_netlist(bool)
     QString par_str = form_spice_param_list(spice_incompat,spice_tr);
 
     if (getProperty("UseGlobTemp")->Value == "yes") {
-      s += QString(" QMOD_%1 AREA=%2\n").arg(Name).arg(getProperty("Area")->Value);
+      s += QStringLiteral(" QMOD_%1 AREA=%2\n").arg(Name).arg(getProperty("Area")->Value);
     } else {
-      s += QString(" QMOD_%1 AREA=%2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
+      s += QStringLiteral(" QMOD_%1 AREA=%2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
       .arg(getProperty("Temp")->Value);
     }
-    s += QString(".MODEL QMOD_%1 %2 (%3)\n").arg(Name).arg(getProperty("Type")->Value).arg(par_str);
+    s += QStringLiteral(".MODEL QMOD_%1 %2 (%3)\n").arg(Name).arg(getProperty("Type")->Value).arg(par_str);
 
     return s;
 }

--- a/qucs/components/bjtsub.cpp
+++ b/qucs/components/bjtsub.cpp
@@ -220,13 +220,13 @@ QString BJTsub::spice_netlist(bool)
     QString par_str = form_spice_param_list(spice_incompat,spice_tr);
 
     if (getProperty("UseGlobTemp")->Value == "yes") {
-      s += QString(" QMOD_%1 AREA=%2\n").arg(Name).arg(getProperty("Area")->Value);
+      s += QStringLiteral(" QMOD_%1 AREA=%2\n").arg(Name).arg(getProperty("Area")->Value);
     } else {
-      s += QString(" QMOD_%1 AREA=%2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
+      s += QStringLiteral(" QMOD_%1 AREA=%2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
       .arg(getProperty("Temp")->Value);
     }
 
-    s += QString(".MODEL QMOD_%1 %2 (%3)\n").arg(Name).arg(getProperty("Type")->Value).arg(par_str);
+    s += QStringLiteral(".MODEL QMOD_%1 %2 (%3)\n").arg(Name).arg(getProperty("Type")->Value).arg(par_str);
 
     return s;
 }

--- a/qucs/components/capacitor.cpp
+++ b/qucs/components/capacitor.cpp
@@ -57,7 +57,7 @@ QString Capacitor::spice_netlist(bool)
 {
     QString s = spicecompat::check_refdes(Name,SpiceModel);
 
-    s += QString(" %1 %2 ").arg(Ports.at(0)->Connection->Name)
+    s += QStringLiteral(" %1 %2 ").arg(Ports.at(0)->Connection->Name)
             .arg(Ports.at(1)->Connection->Name); // output  nodes
     s.replace(" gnd ", " 0 ");
 
@@ -80,7 +80,7 @@ QString Capacitor::va_code()
     QString Vpm = vacompat::normalize_voltage(plus,minus);
     if (Vpm.startsWith("(-")) Vpm.remove(1,1); // Make capacitor unipolar, remove starting minus
     QString Ipm = vacompat::normalize_current(plus,minus,true); 
-    s  += QString("%1  <+ ddt( %2 *  %3  );\n").arg(Ipm).arg(Vpm).arg(val);
+    s  += QStringLiteral("%1  <+ ddt( %2 *  %3  );\n").arg(Ipm).arg(Vpm).arg(val);
             
     return s;
 }

--- a/qucs/components/capq.cpp
+++ b/qucs/components/capq.cpp
@@ -112,15 +112,15 @@ QString CapQ::spice_netlist(bool isXyce)
     QString double_pi = "8*atan(1)";
     QString mode = getProperty("Mode")->Value;
     if (mode == "Constant") {
-        res_eq = QString("%1*(%2)*hertz/(%3)").arg(double_pi).arg(C).arg(Q);
+        res_eq = QStringLiteral("%1*(%2)*hertz/(%3)").arg(double_pi).arg(C).arg(Q);
     } else if (mode == "Linear") {
-        res_eq = QString("%1*(%2)*(%3)/(%4)").arg(double_pi).arg(C).arg(f0).arg(Q);
+        res_eq = QStringLiteral("%1*(%2)*(%3)/(%4)").arg(double_pi).arg(C).arg(f0).arg(Q);
     } else if (mode == "SquareRoot") {
-        res_eq = QString("%1*(%2)*sqrt(hertz*(%3))/(%4)").arg(double_pi).arg(C).arg(f0).arg(Q);
+        res_eq = QStringLiteral("%1*(%2)*sqrt(hertz*(%3))/(%4)").arg(double_pi).arg(C).arg(f0).arg(Q);
     }
 
-    s = QString("%1 %2 %3 C='%4'\n").arg(Cname).arg(pin1).arg(pin2).arg(C);
-    s += QString("%1 %2 %3 R='1/((%4)+1e-8)'\n").arg(Rname).arg(pin1).arg(pin2).arg(res_eq);
+    s = QStringLiteral("%1 %2 %3 C='%4'\n").arg(Cname).arg(pin1).arg(pin2).arg(C);
+    s += QStringLiteral("%1 %2 %3 R='1/((%4)+1e-8)'\n").arg(Rname).arg(pin1).arg(pin2).arg(res_eq);
 
     return s;
 }

--- a/qucs/components/cccs.cpp
+++ b/qucs/components/cccs.cpp
@@ -93,11 +93,11 @@ QString CCCS::va_code()
     
     QString Vpm = vacompat::normalize_voltage(P1,P2);
     QString Ipm = vacompat::normalize_current(P1,P2,true);  
-    s += QString(" %1  <+  %2 * 1e3;\n").arg(Ipm).arg(Vpm);
+    s += QStringLiteral(" %1  <+  %2 * 1e3;\n").arg(Ipm).arg(Vpm);
     QString Vpm2 = vacompat::normalize_voltage(P4,P3);
     QString Ipm2 = vacompat::normalize_current(P4,P3,true); 
-    s += QString("%1  <+   %2 * 1e-9;\n").arg(Ipm2).arg(Vpm2);
-    s += QString("%1  <+   %2 * 1e3 * %3 ;\n").arg(Ipm2).arg(Vpm).arg(Gain);
+    s += QStringLiteral("%1  <+   %2 * 1e-9;\n").arg(Ipm2).arg(Vpm2);
+    s += QStringLiteral("%1  <+   %2 * 1e3 * %3 ;\n").arg(Ipm2).arg(Vpm).arg(Gain);
     
     return s;
 }
@@ -106,11 +106,11 @@ QString CCCS::spice_netlist(bool)
     QString s = spicecompat::check_refdes(Name,SpiceModel); // spice CCCS consists two sources: output source
                         // and zero value controlling source
     QString val = spicecompat::normalize_value(Props.at(0)->Value);
-    s += QString(" %1 %2 ").arg(Ports.at(1)->Connection->Name)
+    s += QStringLiteral(" %1 %2 ").arg(Ports.at(1)->Connection->Name)
             .arg(Ports.at(2)->Connection->Name); // output source nodes
     s.replace(" gnd ", " 0 ");
-    s += QString(" V%1 %2\n").arg(Name).arg(val);
-    s += QString("V%1 %2 %3 DC 0\n").arg(Name).arg(Ports.at(0)->Connection->Name)
+    s += QStringLiteral(" V%1 %2\n").arg(Name).arg(val);
+    s += QStringLiteral("V%1 %2 %3 DC 0\n").arg(Name).arg(Ports.at(0)->Connection->Name)
             .arg(Ports.at(3)->Connection->Name);   // controlling 0V source
 
     return s;

--- a/qucs/components/ccvs.cpp
+++ b/qucs/components/ccvs.cpp
@@ -92,11 +92,11 @@ QString CCVS::va_code()
     
     QString Vpm = vacompat::normalize_voltage(P1,P2);
     QString Ipm = vacompat::normalize_current(P1,P2,true);  
-    s += QString(" %1  <+  %2 * 1e3;\n").arg(Ipm).arg(Vpm);
+    s += QStringLiteral(" %1  <+  %2 * 1e3;\n").arg(Ipm).arg(Vpm);
     QString Vpm2 = vacompat::normalize_voltage(P3,P4);
     QString Ipm2 = vacompat::normalize_current(P3,P4,true); 
-    s += QString("%1  <+  -(%2 * 1e3);\n").arg(Ipm2).arg(Vpm2);
-    s += QString("%1  <+  -(%2 * 1e6*  %3) ;\n").arg(Ipm2).arg(Vpm).arg(Gain);
+    s += QStringLiteral("%1  <+  -(%2 * 1e3);\n").arg(Ipm2).arg(Vpm2);
+    s += QStringLiteral("%1  <+  -(%2 * 1e6*  %3) ;\n").arg(Ipm2).arg(Vpm).arg(Gain);
     
     return s;
 }
@@ -107,11 +107,11 @@ QString CCVS::spice_netlist(bool)
     QString s = spicecompat::check_refdes(Name,SpiceModel); // spice CCVS consists two sources: output source
                         // and zero value controlling source
     QString val = spicecompat::normalize_value(Props.at(0)->Value);
-    s += QString(" %1 %2 ").arg(Ports.at(1)->Connection->Name)
+    s += QStringLiteral(" %1 %2 ").arg(Ports.at(1)->Connection->Name)
             .arg(Ports.at(2)->Connection->Name); // output source nodes
     s.replace(" gnd ", " 0 ");
-    s += QString(" V%1 %2\n").arg(Name).arg(val);
-    s += QString("V%1 %2 %3 DC 0 \n").arg(Name).arg(Ports.at(0)->Connection->Name)
+    s += QStringLiteral(" V%1 %2\n").arg(Name).arg(val);
+    s += QStringLiteral("V%1 %2 %3 DC 0 \n").arg(Name).arg(Ports.at(0)->Connection->Name)
             .arg(Ports.at(3)->Connection->Name);   // controlling 0V source
 
     return s;

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -750,7 +750,7 @@ QString Component::form_spice_param_list(QStringList &ignore_list, QStringList &
                 nam = Props.at(i)->Name;
             }
             QString val = spicecompat::normalize_value(Props.at(i)->Value);
-            par_str += QString("%1=%2 ").arg(nam).arg(val);
+            par_str += QStringLiteral("%1=%2 ").arg(nam).arg(val);
         }
 
     }
@@ -759,7 +759,7 @@ QString Component::form_spice_param_list(QStringList &ignore_list, QStringList &
 }
 
 QString Component::spice_netlist(bool) {
-    return QString("\n"); // ignore if not implemented
+    return QStringLiteral("\n"); // ignore if not implemented
 }
 
 QString Component::va_code() {
@@ -1551,7 +1551,7 @@ QString GateComponent::spice_netlist(bool isXyce) {
     }
     s += "] " + Ports.at(0)->Connection->Name;
     s += " " + tmp_model + "\n";
-    s += QString(".model %1 %2(rise_delay=%3 fall_delay=%3 input_load=5e-13)\n")
+    s += QStringLiteral(".model %1 %2(rise_delay=%3 fall_delay=%3 input_load=5e-13)\n")
             .arg(tmp_model).arg(type).arg(td);
     return s;
 }
@@ -1801,11 +1801,11 @@ Component *getComponentFromName(QString &Line, Schematic *p) {
                 c = new Subcircuit();
                 // Hack: insert dummy File property before the first property
                 int pos1 = Line.indexOf('"');
-                QString filestr = QString("\"%1.sch\" 1 ").arg(cstr);
+                QString filestr = QStringLiteral("\"%1.sch\" 1 ").arg(cstr);
                 Line.insert(pos1, filestr);
             } else return 0;
         } else {
-            QString err_msg = QString("Schematic loading error! Unknown device %1").arg(cstr);
+            QString err_msg = QStringLiteral("Schematic loading error! Unknown device %1").arg(cstr);
             qCritical() << err_msg;
             return 0;
         }

--- a/qucs/components/d_flipflop.cpp
+++ b/qucs/components/d_flipflop.cpp
@@ -138,9 +138,9 @@ QString D_FlipFlop::spice_netlist(bool isXyce)
     s += " " + D + " " + CLK + " " + SET + " " + RESET + " " + Q + " " + QB;
 
     s += " " + tmp_model + "\n";
-    s += QString(".model %1 d_dff(clk_delay=%2 set_delay=%2 reset_delay=%2 rise_delay=%2 fall_delay=%2)\n")
+    s += QStringLiteral(".model %1 d_dff(clk_delay=%2 set_delay=%2 reset_delay=%2 rise_delay=%2 fall_delay=%2)\n")
             .arg(tmp_model).arg(td);
-    s += QString("C%1 QB_%1 0 1e-9 \n").arg(Name); // capacitor load for unused QB pin
+    s += QStringLiteral("C%1 QB_%1 0 1e-9 \n").arg(Name); // capacitor load for unused QB pin
 
     return s;
 }

--- a/qucs/components/dcblock.cpp
+++ b/qucs/components/dcblock.cpp
@@ -76,6 +76,6 @@ QString dcBlock::spice_netlist(bool isXyce)
   QString val = spicecompat::normalize_value(getProperty("C")->Value);
   QString s;
   QString name = spicecompat::check_refdes(Name, SpiceModel);
-  s = QString("%1 %2 %3 %4\n").arg(name, p1, p2, val);
+  s = QStringLiteral("%1 %2 %3 %4\n").arg(name, p1, p2, val);
   return s;
 }

--- a/qucs/components/dcfeed.cpp
+++ b/qucs/components/dcfeed.cpp
@@ -77,6 +77,6 @@ QString dcFeed::spice_netlist(bool isXyce)
   QString val = spicecompat::normalize_value(getProperty("L")->Value);
   QString s;
   QString name = spicecompat::check_refdes(Name, SpiceModel);
-  s = QString("%1 %2 %3 %4\n").arg(name, p1, p2, val);
+  s = QStringLiteral("%1 %2 %3 %4\n").arg(name, p1, p2, val);
   return s;
 }

--- a/qucs/components/dff_SR.cpp
+++ b/qucs/components/dff_SR.cpp
@@ -193,7 +193,7 @@ QString dff_SR::spice_netlist(bool isXyce)
     s += " " + D + " " + CLK + " " + SET + " " + RESET + " " + Q + " " + QB;
 
     s += " " + tmp_model + "\n";
-    s += QString(".model %1 d_dff(clk_delay=%2 set_delay=%2 reset_delay=%2 rise_delay=%2 fall_delay=%2)\n")
+    s += QStringLiteral(".model %1 d_dff(clk_delay=%2 set_delay=%2 reset_delay=%2 rise_delay=%2 fall_delay=%2)\n")
             .arg(tmp_model).arg(td);
     return s;
 }

--- a/qucs/components/digi_source.cpp
+++ b/qucs/components/digi_source.cpp
@@ -222,7 +222,7 @@ QString Digi_Source::spice_netlist(bool)
     evenValue = V;
   }
 
-  s += QString("DC %1 PWL(0 ").arg(evenValue);
+  s += QStringLiteral("DC %1 PWL(0 ").arg(evenValue);
   s += evenValue;
 
   for (int i = 0; i < timesList.size(); i++) {
@@ -232,7 +232,7 @@ QString Digi_Source::spice_netlist(bool)
 
     if (i == 0) {
       // first time step
-      s += QString(" %1 %2").arg(timeValue).arg(evenValue);
+      s += QStringLiteral(" %1 %2").arg(timeValue).arg(evenValue);
       time += timeValue;
 
     } else {
@@ -241,7 +241,7 @@ QString Digi_Source::spice_netlist(bool)
         risingTime = time + changingTime;
         time += timeValue;
 
-        s += QString(" %1 %2 %3 %2")
+        s += QStringLiteral(" %1 %2 %3 %2")
                       .arg(risingTime)
                       .arg(oddValue)
                       .arg(time)
@@ -249,7 +249,7 @@ QString Digi_Source::spice_netlist(bool)
         // last time step
         if (timeStep == timesList.last().toLower()) {
             fallingTime = time + changingTime;
-            s += QString(" %1 0 %2 0")
+            s += QStringLiteral(" %1 0 %2 0")
                           .arg(fallingTime)
                           .arg(fallingTime + changingTime)
                           .toUpper();
@@ -258,7 +258,7 @@ QString Digi_Source::spice_netlist(bool)
         // times of even time step
         fallingTime = time + changingTime;
         time += timeValue;
-        s += QString(" %1 %2 %3 %2")
+        s += QStringLiteral(" %1 %2 %3 %2")
                       .arg(fallingTime)
                       .arg(evenValue)
                       .arg(time)
@@ -266,7 +266,7 @@ QString Digi_Source::spice_netlist(bool)
         // last time step
         if (timeStep == timesList.last().toLower()) {
             fallingTime = time + changingTime;
-            s += QString(" %1 0 %2 0")
+            s += QStringLiteral(" %1 0 %2 0")
                      .arg(fallingTime)
                      .arg(fallingTime + changingTime)
                      .toUpper();

--- a/qucs/components/diode.cpp
+++ b/qucs/components/diode.cpp
@@ -136,23 +136,23 @@ QString Diode::spice_netlist(bool isXyce)
             } else {
                 nam = Props.at(i)->Name;
             }
-            par_str += QString("%1=%2 ")
+            par_str += QStringLiteral("%1=%2 ")
                            .arg(nam, spicecompat::normalize_value(Props.at(i)->Value));
         }
 
     }
 
     if (getProperty("UseGlobTemp")->Value == "yes") {
-      s += QString(" DMOD_%1 AREA=%2\n").arg(Name).arg(getProperty("Area")->Value);
+      s += QStringLiteral(" DMOD_%1 AREA=%2\n").arg(Name).arg(getProperty("Area")->Value);
     } else {
-      s += QString(" DMOD_%1 AREA=%2 Temp=%3\n").arg(Name).arg(getProperty("Area")->Value)
+      s += QStringLiteral(" DMOD_%1 AREA=%2 Temp=%3\n").arg(Name).arg(getProperty("Area")->Value)
       .arg(getProperty("Temp")->Value);
     }
 
     if (isXyce) {
-        s += QString(".MODEL DMOD_%1 D (LEVEL = 2 %2)\n").arg(Name).arg(par_str);
+        s += QStringLiteral(".MODEL DMOD_%1 D (LEVEL = 2 %2)\n").arg(Name).arg(par_str);
     } else {
-        s += QString(".MODEL DMOD_%1 D (%2)\n").arg(Name).arg(par_str);
+        s += QStringLiteral(".MODEL DMOD_%1 D (%2)\n").arg(Name).arg(par_str);
     }
 
 

--- a/qucs/components/eqndefined.cpp
+++ b/qucs/components/eqndefined.cpp
@@ -129,10 +129,10 @@ QString EqnDefined::spice_netlist(bool isXyce)
             QString plus = Ports.at(2*i)->Connection->Name;
             QString minus = Ports.at(2*i+1)->Connection->Name;
             if (used_currents.contains(i)) { // if current is used add sensing source V=0
-                s += QString("V_%1sens_%2 %3 %4 DC 0\n").arg(Name).arg(i).arg(plus).arg(plus+"_sens");
+                s += QStringLiteral("V_%1sens_%2 %3 %4 DC 0\n").arg(Name).arg(i).arg(plus).arg(plus+"_sens");
                 plus = plus+"_sens";
             }
-            s += QString("B%1I%2 %3 %4 I=%5\n").arg(Name).arg(i).arg(plus)
+            s += QStringLiteral("B%1I%2 %3 %4 I=%5\n").arg(Name).arg(i).arg(plus)
                     .arg(minus).arg(Itokens.join(""));
 
             QString Qeqn = Props.at(2*(i+1)+1)->Value; // parse charge equation only for Xyce
@@ -144,9 +144,9 @@ QString EqnDefined::spice_netlist(bool isXyce)
                 spicecompat::convert_functions(Qtokens,isXyce);
                 subsVoltages(Qtokens,Nbranch);
                 subsCurrents(Qtokens);
-                s += QString("G%1Q%2 %3 %4 n%1Q%2 %4 1.0\n").arg(Name).arg(i).arg(plus).arg(minus);
-                s += QString("L%1Q%2 n%1Q%2 %3 1.0\n").arg(Name).arg(i).arg(minus);
-                s += QString("B%1Q%2 n%1Q%2 %3 I=-(%4)\n").arg(Name).arg(i).arg(minus).arg(Qtokens.join(""));
+                s += QStringLiteral("G%1Q%2 %3 %4 n%1Q%2 %4 1.0\n").arg(Name).arg(i).arg(plus).arg(minus);
+                s += QStringLiteral("L%1Q%2 n%1Q%2 %3 1.0\n").arg(Name).arg(i).arg(minus);
+                s += QStringLiteral("B%1Q%2 n%1Q%2 %3 I=-(%4)\n").arg(Name).arg(i).arg(minus).arg(Qtokens.join(""));
             }
         }
     } else {
@@ -172,8 +172,8 @@ QString EqnDefined::va_code()
                 spicecompat::splitEqn(Ieqn,Itokens);
                 vacompat::convert_functions(Itokens);
                 subsVoltages(Itokens,Nbranch);
-                if (plus=="gnd") s += QString("%1 <+ -(%2);\n").arg(Ipm).arg(Itokens.join(""));
-                else s += QString("%1 <+ %2;\n").arg(Ipm).arg(Itokens.join(""));
+                if (plus=="gnd") s += QStringLiteral("%1 <+ -(%2);\n").arg(Ipm).arg(Itokens.join(""));
+                else s += QStringLiteral("%1 <+ %2;\n").arg(Ipm).arg(Itokens.join(""));
             }
             QString Qeqn = Props.at(2*(i+1)+1)->Value; // parse charge equation only for Xyce
             if (Qeqn!="0") {
@@ -181,8 +181,8 @@ QString EqnDefined::va_code()
                 spicecompat::splitEqn(Qeqn,Qtokens);
                 vacompat::convert_functions(Qtokens);
                 subsVoltages(Qtokens,Nbranch);
-                if (plus=="gnd") s += QString("%1 <+ -ddt( %2 );\n").arg(Ipm).arg(Qtokens.join(""));
-		else s += QString("%1 <+ ddt( %2 );\n").arg(Ipm).arg(Qtokens.join(""));
+                if (plus=="gnd") s += QStringLiteral("%1 <+ -ddt( %2 );\n").arg(Ipm).arg(Qtokens.join(""));
+		else s += QStringLiteral("%1 <+ ddt( %2 );\n").arg(Ipm).arg(Qtokens.join(""));
             }
         }
     } else {
@@ -245,7 +245,7 @@ void EqnDefined::subsCurrents(QStringList &tokens)
         if (curr_pattern.match(*it).hasMatch()) {
             QString curr = *it;
             int branch = curr.remove('I').toInt();
-            *it = QString("i(V_%1sens_%2)").arg(Name).arg(branch-1);
+            *it = QStringLiteral("i(V_%1sens_%2)").arg(Name).arg(branch-1);
         }
     }
 }

--- a/qucs/components/equation.cpp
+++ b/qucs/components/equation.cpp
@@ -101,7 +101,7 @@ QString Equation::getVAvariables()
         vars.append(Props.at(i)->Name);
     }
 
-    return QString("real %1;\n").arg(vars.join(", "));
+    return QStringLiteral("real %1;\n").arg(vars.join(", "));
 }
 
 QString Equation::getVAExpressions()
@@ -111,7 +111,7 @@ QString Equation::getVAExpressions()
         QStringList tokens;
         spicecompat::splitEqn(Props.at(i)->Value,tokens);
         vacompat::convert_functions(tokens);
-        s += QString("%1=%2;\n").arg(Props.at(i)->Name).arg(tokens.join(""));
+        s += QStringLiteral("%1=%2;\n").arg(Props.at(i)->Name).arg(tokens.join(""));
     }
     return s;
 }
@@ -155,7 +155,7 @@ QString Equation::getExpression(bool isXyce)
         }
 
         if (!spicecompat::containNodes(tokens,ng_vars)) {
-            s += QString(".PARAM %1=%2\n").arg(Props.at(i)->Name).arg(eqn);
+            s += QStringLiteral(".PARAM %1=%2\n").arg(Props.at(i)->Name).arg(eqn);
         }
     }
     return s;
@@ -194,7 +194,7 @@ QString Equation::getEquations(QString sim, QStringList &dep_vars)
             if ( used_sim.toLower() == "tran" ) used_sim = "tr";
             if ( (sim.startsWith(used_sim.toLower())) || (used_sim=="all") ) {
                 eqn = tokens.join("");
-                s += QString("let %1=%2\n").arg(Props.at(i)->Name).arg(eqn);
+                s += QStringLiteral("let %1=%2\n").arg(Props.at(i)->Name).arg(eqn);
                 dep_vars.append(Props.at(i)->Name);
             }
         }
@@ -224,7 +224,7 @@ QString Equation::getNgspiceScript()
         eqn = tokens.join("");
 
         if (!spicecompat::containNodes(tokens,ng_vars)) {
-            s += QString("let %1=%2\n").arg(Props.at(i)->Name).arg(eqn);
+            s += QStringLiteral("let %1=%2\n").arg(Props.at(i)->Name).arg(eqn);
         }
     }
     return s;

--- a/qucs/components/gyrator.cpp
+++ b/qucs/components/gyrator.cpp
@@ -91,7 +91,7 @@ QString Gyrator::spice_netlist(bool)
     if (n3=="gnd") n3="0";
     QString n4 = Ports.at(3)->Connection->Name;
     if (n4=="gnd") n4="0";
-    s +=  QString("B%1_1 %2 %3 I=(1/(%4))*(V(%5)-V(%6))\n").arg(Name).arg(n1).arg(n4).arg(R).arg(n2).arg(n3);
-    s +=  QString("B%1_2 %2 %3 I=-1.0*(1/(%4))*(V(%5)-V(%6))\n").arg(Name).arg(n2).arg(n3).arg(R).arg(n1).arg(n4);
+    s +=  QStringLiteral("B%1_1 %2 %3 I=(1/(%4))*(V(%5)-V(%6))\n").arg(Name).arg(n1).arg(n4).arg(R).arg(n2).arg(n3);
+    s +=  QStringLiteral("B%1_2 %2 %3 I=-1.0*(1/(%4))*(V(%5)-V(%6))\n").arg(Name).arg(n2).arg(n3).arg(R).arg(n1).arg(n4);
     return s;
 }

--- a/qucs/components/hb_sim.cpp
+++ b/qucs/components/hb_sim.cpp
@@ -67,13 +67,13 @@ QString HB_Sim::spice_netlist(bool isXyce)
 {
     QString s="";
     if (isXyce) {  // Only in Xyce
-        s += QString(".options hbint numfreq=%1 STARTUPPERIODS=2\n").arg(Props.at(1)->Value);
+        s += QStringLiteral(".options hbint numfreq=%1 STARTUPPERIODS=2\n").arg(Props.at(1)->Value);
         QStringList freqs = Props.at(0)->Value.split(QRegularExpression("\\s+(?=[0-9])"));
         // split frequencyes list by space before digit
         for (QStringList::iterator it = freqs.begin();it != freqs.end(); it++) {
             (*it) = spicecompat::normalize_value(*it);
         }
-        s += QString(".HB %1\n").arg(freqs.join(" "));
+        s += QStringLiteral(".HB %1\n").arg(freqs.join(" "));
     }
     return s;
 }

--- a/qucs/components/iexp.cpp
+++ b/qucs/components/iexp.cpp
@@ -101,7 +101,7 @@ QString iExp::spice_netlist(bool)
    QString Tr = spicecompat::normalize_value(Props.at(4)->Value);
    QString Tf = spicecompat::normalize_value(Props.at(5)->Value);
 
-    s += QString(" DC 0 EXP(%1 %2 %3 %4 %5 %6) AC 0\n").arg(U1).arg(U2).arg(T1).arg(Tr).arg(T2).arg(Tf);
+    s += QStringLiteral(" DC 0 EXP(%1 %2 %3 %4 %5 %6) AC 0\n").arg(U1).arg(U2).arg(T1).arg(Tr).arg(T2).arg(Tf);
     return s;
 }
 

--- a/qucs/components/ifile.cpp
+++ b/qucs/components/ifile.cpp
@@ -116,13 +116,13 @@ QString iFile::spice_netlist(bool isXyce)
     QString modname = "mod_" + Model + Name;
     QString p1 = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
     QString p2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
-    s += QString(" %id([%1 %2]) %3\n").arg(p2).arg(p1).arg(modname);
+    s += QStringLiteral(" %id([%1 %2]) %3\n").arg(p2).arg(p1).arg(modname);
     QString file = getSubcircuitFile();
     QString sc = getProperty("G")->Value;
     QString step = "false";
     QString delay = getProperty("T")->Value;
     if (getProperty("Interpolator")->Value != "linear") step = "true";
-    s += QString(".MODEL %1 filesource (file=\"%2\" amplscale=[%3] amplstep=%4 "
+    s += QStringLiteral(".MODEL %1 filesource (file=\"%2\" amplscale=[%3] amplstep=%4 "
                  "amploffset=[0] timeoffset=%5 timescale=1)\n")
             .arg(modname).arg(file).arg(sc).arg(step).arg(delay);
 

--- a/qucs/components/indq.cpp
+++ b/qucs/components/indq.cpp
@@ -100,7 +100,7 @@ QString IndQ::spice_netlist(bool isXyce)
     pin1 = spicecompat::normalize_node_name(pin1);
     QString pin2 = Ports.at(1)->Connection->Name;
     pin2 = spicecompat::normalize_node_name(pin2);
-    QString pin_int = QString("_net_%1").arg(Name);
+    QString pin_int = QStringLiteral("_net_%1").arg(Name);
     QString Lname = spicecompat::check_refdes(Name, SpiceModel);
     QString Rname = "R" + Name;
 
@@ -114,15 +114,15 @@ QString IndQ::spice_netlist(bool isXyce)
     QString double_pi = "8*atan(1)";
     QString mode = getProperty("Mode")->Value;
     if (mode == "Constant") {
-        res_eq = QString("%1*(%2)*hertz/(%3)").arg(double_pi).arg(L).arg(Q);
+        res_eq = QStringLiteral("%1*(%2)*hertz/(%3)").arg(double_pi).arg(L).arg(Q);
     } else if (mode == "Linear") {
-        res_eq = QString("%1*(%2)*(%3)/(%4)").arg(double_pi).arg(L).arg(f0).arg(Q);
+        res_eq = QStringLiteral("%1*(%2)*(%3)/(%4)").arg(double_pi).arg(L).arg(f0).arg(Q);
     } else if (mode == "SquareRoot") {
-        res_eq = QString("%1*(%2)*sqrt(hertz*(%3))/(%4)").arg(double_pi).arg(L).arg(f0).arg(Q);
+        res_eq = QStringLiteral("%1*(%2)*sqrt(hertz*(%3))/(%4)").arg(double_pi).arg(L).arg(f0).arg(Q);
     }
 
-    s = QString("%1 %2 %3 L='%4'\n").arg(Lname).arg(pin1).arg(pin_int).arg(L);
-    s += QString("%1 %2 %3 R='%4'\n").arg(Rname).arg(pin_int).arg(pin2).arg(res_eq);
+    s = QStringLiteral("%1 %2 %3 L='%4'\n").arg(Lname).arg(pin1).arg(pin_int).arg(L);
+    s += QStringLiteral("%1 %2 %3 R='%4'\n").arg(Rname).arg(pin_int).arg(pin2).arg(res_eq);
 
     return s;
 }

--- a/qucs/components/inductor.cpp
+++ b/qucs/components/inductor.cpp
@@ -62,7 +62,7 @@ QString Inductor::spice_netlist(bool)
 {
     QString s = spicecompat::check_refdes(Name,SpiceModel);
 
-    s += QString(" %1 %2 ").arg(Ports.at(0)->Connection->Name)
+    s += QStringLiteral(" %1 %2 ").arg(Ports.at(0)->Connection->Name)
             .arg(Ports.at(1)->Connection->Name); // output source nodes
     s.replace(" gnd ", " 0 ");
 
@@ -85,7 +85,7 @@ QString Inductor::va_code()
     QString s = "";
     QString Vpm = vacompat::normalize_voltage(plus,minus,true);
     QString Ipm = vacompat::normalize_current(plus,minus);
-    s += QString("%1  <+ ddt( %2 *  %3  );\n").arg(Vpm).arg(Ipm).arg(val);
+    s += QStringLiteral("%1  <+ ddt( %2 *  %3  );\n").arg(Vpm).arg(Ipm).arg(val);
     return s;
 
 }

--- a/qucs/components/iprobe.cpp
+++ b/qucs/components/iprobe.cpp
@@ -81,7 +81,7 @@ Element* iProbe::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
 QString iProbe::spice_netlist(bool)
 {
-    QString s = QString("V%1 %2 %3 DC 0\n").arg(Name).arg(Ports.at(0)->Connection->Name)
+    QString s = QStringLiteral("V%1 %2 %3 DC 0\n").arg(Name).arg(Ports.at(0)->Connection->Name)
             .arg(Ports.at(1)->Connection->Name);
     return s;
 }
@@ -95,9 +95,9 @@ QString iProbe::getProbeVariable(bool isXyce)
 {
     QString s;
     if (isXyce) {
-        s = QString("I(V%1)").arg(Name);
+        s = QStringLiteral("I(V%1)").arg(Name);
     } else {
-        s = QString("V%1#branch").arg(Name);
+        s = QStringLiteral("V%1#branch").arg(Name);
     }
     return s;
 }

--- a/qucs/components/ipulse.cpp
+++ b/qucs/components/ipulse.cpp
@@ -117,7 +117,7 @@ QString iPulse::spice_netlist(bool)
     Pw = Pw - TfVal*fac;
     Per = 1.0e9*Pw;
 
-    s += QString(" DC 0 PULSE(%1 %2 %3 %4 %5 %6 %7) AC 0\n").arg(VL).arg(VH).arg(T1).arg(Tr).arg(Tf).arg(Pw).arg(Per);
+    s += QStringLiteral(" DC 0 PULSE(%1 %2 %3 %4 %5 %6 %7) AC 0\n").arg(VL).arg(VH).arg(T1).arg(Tr).arg(Tf).arg(Pw).arg(Per);
 
     return s;
 }

--- a/qucs/components/irect.cpp
+++ b/qucs/components/irect.cpp
@@ -106,7 +106,7 @@ QString iRect::spice_netlist(bool)
    misc::str2num(Props.at(4)->Value,Tfval,unit,fac); 
      T = Tfval*fac+T;    
      
-    s += QString(" DC 0 PULSE( 0  -%1 %2 %3 %4 %5 %6)  AC 0\n").arg(U).arg(Td).arg(Tr).arg(Tf).arg(TH).arg(T);
+    s += QStringLiteral(" DC 0 PULSE( 0  -%1 %2 %3 %4 %5 %6)  AC 0\n").arg(U).arg(Td).arg(Tr).arg(Tf).arg(TH).arg(T);
 
     return s;
 }

--- a/qucs/components/jfet.cpp
+++ b/qucs/components/jfet.cpp
@@ -125,13 +125,13 @@ QString JFET::spice_netlist(bool isXyce)
     QString jfet_type = getProperty("Type")->Value.at(0).toUpper();
 
     if (getProperty("UseGlobTemp")->Value == "yes") {
-      s += QString(" JMOD_%1 %2\n").arg(Name).arg(getProperty("Area")->Value);
+      s += QStringLiteral(" JMOD_%1 %2\n").arg(Name).arg(getProperty("Area")->Value);
     } else {
-      s += QString(" JMOD_%1 %2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
+      s += QStringLiteral(" JMOD_%1 %2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
       .arg(getProperty("Temp")->Value);
     }
 
-    s += QString(".MODEL JMOD_%1 %2JF (%3)\n").arg(Name).arg(jfet_type).arg(par_str);
+    s += QStringLiteral(".MODEL JMOD_%1 %2JF (%3)\n").arg(Name).arg(jfet_type).arg(par_str);
 
     return s;
 }

--- a/qucs/components/jkff_SR.cpp
+++ b/qucs/components/jkff_SR.cpp
@@ -203,7 +203,7 @@ QString jkff_SR::spice_netlist(bool isXyce)
     s += " " + J + " " + K + " " + CLK + " " + SET + " " + RESET + " " + Q + " " + QB;
 
     s += " " + tmp_model + "\n";
-    s += QString(".model %1 d_jkff(clk_delay=%2 set_delay=%2 reset_delay=%2 rise_delay=%2 fall_delay=%2)\n")
+    s += QStringLiteral(".model %1 d_jkff(clk_delay=%2 set_delay=%2 reset_delay=%2 rise_delay=%2 fall_delay=%2)\n")
             .arg(tmp_model).arg(td);
     return s;
 }

--- a/qucs/components/logical_buf.cpp
+++ b/qucs/components/logical_buf.cpp
@@ -145,7 +145,7 @@ QString Logical_Buf::spice_netlist(bool isXyce)
     s += " " + Ports.at(1)->Connection->Name;
     s += " " + Ports.at(0)->Connection->Name;
     s += " " + tmp_model + "\n";
-    s += QString(".model %1 d_buffer(rise_delay=%2 fall_delay=%2 input_load=5e-13)\n")
+    s += QStringLiteral(".model %1 d_buffer(rise_delay=%2 fall_delay=%2 input_load=5e-13)\n")
             .arg(tmp_model).arg(td);
     return s;
 }

--- a/qucs/components/logical_inv.cpp
+++ b/qucs/components/logical_inv.cpp
@@ -162,7 +162,7 @@ QString Logical_Inv::spice_netlist(bool isXyce)
     s += " " + Ports.at(1)->Connection->Name;
     s += " " + Ports.at(0)->Connection->Name;
     s += " " + tmp_model + "\n";
-    s += QString(".model %1 d_inverter(rise_delay=%2 fall_delay=%2 input_load=5e-13)\n")
+    s += QStringLiteral(".model %1 d_inverter(rise_delay=%2 fall_delay=%2 input_load=5e-13)\n")
             .arg(tmp_model).arg(td);
     return s;
 }

--- a/qucs/components/mosfet.cpp
+++ b/qucs/components/mosfet.cpp
@@ -193,13 +193,13 @@ QString MOSFET::spice_netlist(bool isXyce)
     ps *= fac;
 
     if (getProperty("UseGlobTemp")->Value == "yes") {
-      s += QString(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7\n")
+      s += QStringLiteral(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7\n")
       .arg(Name).arg(l).arg(w).arg(ad).arg(as).arg(pd).arg(ps);
     } else {
-      s += QString(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7 Temp=%8\n")
+      s += QStringLiteral(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7 Temp=%8\n")
       .arg(Name).arg(l).arg(w).arg(ad).arg(as).arg(pd).arg(ps).arg(getProperty("Temp")->Value);
     }
-    s += QString(".MODEL MMOD_%1 %2MOS (%3)\n").arg(Name).arg(mosfet_type).arg(par_str);
+    s += QStringLiteral(".MODEL MMOD_%1 %2MOS (%3)\n").arg(Name).arg(mosfet_type).arg(par_str);
 
     return s;
 }

--- a/qucs/components/mosfet_sub.cpp
+++ b/qucs/components/mosfet_sub.cpp
@@ -202,13 +202,13 @@ QString MOSFET_sub::spice_netlist(bool isXyce)
     ps *= fac;
 
     if (getProperty("UseGlobTemp")->Value == "yes") {
-      s += QString(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7\n")
+      s += QStringLiteral(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7\n")
       .arg(Name).arg(l).arg(w).arg(ad).arg(as).arg(pd).arg(ps);
     } else {
-      s += QString(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7 Temp=%8\n")
+      s += QStringLiteral(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7 Temp=%8\n")
       .arg(Name).arg(l).arg(w).arg(ad).arg(as).arg(pd).arg(ps).arg(getProperty("Temp")->Value);
     }
-    s += QString(".MODEL MMOD_%1 %2MOS (%3)\n").arg(Name).arg(mosfet_type).arg(par_str);
+    s += QStringLiteral(".MODEL MMOD_%1 %2MOS (%3)\n").arg(Name).arg(mosfet_type).arg(par_str);
 
     return s;
 }

--- a/qucs/components/mutual.cpp
+++ b/qucs/components/mutual.cpp
@@ -92,15 +92,15 @@ QString Mutual::spice_netlist(bool isXyce)
     QString k1 = "K" + Name;
     QString ind1 = spicecompat::normalize_value(getProperty("L1")->Value);
     QString ind2 = spicecompat::normalize_value(getProperty("L2")->Value);
-    QString s = QString("%1 %2 %3 %4\n").arg(l1)
+    QString s = QStringLiteral("%1 %2 %3 %4\n").arg(l1)
             .arg(spicecompat::normalize_node_name(Ports.at(0)->Connection->Name))
             .arg(spicecompat::normalize_node_name(Ports.at(3)->Connection->Name))
             .arg(ind1);
-    s += QString("%1 %2 %3 %4\n").arg(l2)
+    s += QStringLiteral("%1 %2 %3 %4\n").arg(l2)
             .arg(spicecompat::normalize_node_name(Ports.at(1)->Connection->Name))
             .arg(spicecompat::normalize_node_name(Ports.at(2)->Connection->Name))
             .arg(ind2);
-    s += QString("%1 %2 %3 %4\n").arg(k1).arg(l1).arg(l2)
+    s += QStringLiteral("%1 %2 %3 %4\n").arg(k1).arg(l1).arg(l2)
             .arg(spicecompat::normalize_value(getProperty("k")->Value));
     return s;
 }

--- a/qucs/components/mutual2.cpp
+++ b/qucs/components/mutual2.cpp
@@ -127,23 +127,23 @@ QString Mutual2::spice_netlist(bool isXyce)
     QString ind1 = spicecompat::normalize_value(getProperty("L1")->Value);
     QString ind2 = spicecompat::normalize_value(getProperty("L2")->Value);
     QString ind3 = spicecompat::normalize_value(getProperty("L3")->Value);
-    QString s = QString("%1 %2 %3 %4\n").arg(l1)
+    QString s = QStringLiteral("%1 %2 %3 %4\n").arg(l1)
             .arg(spicecompat::normalize_node_name(Ports.at(0)->Connection->Name))
             .arg(spicecompat::normalize_node_name(Ports.at(5)->Connection->Name))
             .arg(ind1);
-    s += QString("%1 %2 %3 %4\n").arg(l2)
+    s += QStringLiteral("%1 %2 %3 %4\n").arg(l2)
             .arg(spicecompat::normalize_node_name(Ports.at(4)->Connection->Name))
             .arg(spicecompat::normalize_node_name(Ports.at(3)->Connection->Name))
             .arg(ind2);
-    s += QString("%1 %2 %3 %4\n").arg(l3)
+    s += QStringLiteral("%1 %2 %3 %4\n").arg(l3)
             .arg(spicecompat::normalize_node_name(Ports.at(1)->Connection->Name))
             .arg(spicecompat::normalize_node_name(Ports.at(2)->Connection->Name))
             .arg(ind3);
-    s += QString("%1 %2 %3 %4\n").arg(k12).arg(l1).arg(l2)
+    s += QStringLiteral("%1 %2 %3 %4\n").arg(k12).arg(l1).arg(l2)
             .arg(spicecompat::normalize_value(getProperty("k12")->Value));
-    s += QString("%1 %2 %3 %4\n").arg(k13).arg(l1).arg(l3)
+    s += QStringLiteral("%1 %2 %3 %4\n").arg(k13).arg(l1).arg(l3)
             .arg(spicecompat::normalize_value(getProperty("k12")->Value));
-    s += QString("%1 %2 %3 %4\n").arg(k23).arg(l2).arg(l3)
+    s += QStringLiteral("%1 %2 %3 %4\n").arg(k23).arg(l2).arg(l3)
             .arg(spicecompat::normalize_value(getProperty("k23")->Value));
     return s;
 }

--- a/qucs/components/mutualx.cpp
+++ b/qucs/components/mutualx.cpp
@@ -128,7 +128,7 @@ QString MutualX::netlist()
     delete [] k_matrix;
 
 
-    s += QString(" L=\"[%1]\" k=\"[%2]\"\n").arg(L,k);
+    s += QStringLiteral(" L=\"[%1]\" k=\"[%2]\"\n").arg(L,k);
 
     return s;
 }
@@ -239,7 +239,7 @@ QString MutualX::spice_netlist(bool isXyce)
         QString li = "L" + Name + "_L" + QString::number(i+1);
         QString prop_l = "L" + QString::number(i+1);
         QString ind = spicecompat::normalize_value(getProperty(prop_l)->Value);
-        s += QString("%1 %2 %3 %4\n").arg(li)
+        s += QStringLiteral("%1 %2 %3 %4\n").arg(li)
                 .arg(spicecompat::normalize_node_name(Ports.at(2*i)->Connection->Name))
                 .arg(spicecompat::normalize_node_name(Ports.at(2*i+1)->Connection->Name))
                 .arg(ind);
@@ -254,7 +254,7 @@ QString MutualX::spice_netlist(bool isXyce)
             auto pp = getProperty("k" + QString::number(i+1) + QString::number(j+1));
             if (pp == nullptr) continue;
             QString val_k = spicecompat::normalize_value(pp->Value);
-            s += QString("%1 %2 %3 %4\n").arg(kij).arg(li).arg(lj).arg(val_k);
+            s += QStringLiteral("%1 %2 %3 %4\n").arg(kij).arg(li).arg(lj).arg(val_k);
         }
     }
     return s;

--- a/qucs/components/opamp.cpp
+++ b/qucs/components/opamp.cpp
@@ -87,14 +87,14 @@ QString OpAmp::spice_netlist(bool isXyce)
     QString Vmax = spicecompat::normalize_value(Props.at(1)->Value);
 
     QString s;
-    s = QString("B_%1 %2 0 V = ").arg(Name).arg(out);
+    s = QStringLiteral("B_%1 %2 0 V = ").arg(Name).arg(out);
 
     if (isXyce) {
-        s += QString("%1*V(%2,%3)*stp(%4-%1*V(%2,%3))*stp(%1*V(%2,%3)-(-%4))"
+        s += QStringLiteral("%1*V(%2,%3)*stp(%4-%1*V(%2,%3))*stp(%1*V(%2,%3)-(-%4))"
                     "+%4*stp(%1*V(%2,%3)-%4)"
                     "+(-%4)*stp((-%4)-%1*V(%2,%3))\n").arg(G).arg(in_p).arg(in_m).arg(Vmax);
     } else {
-        s += QString("%1*V(%2,%3)*u(%4-%1*V(%2,%3))*u(%1*V(%2,%3)-(-%4))"
+        s += QStringLiteral("%1*V(%2,%3)*u(%4-%1*V(%2,%3))*u(%1*V(%2,%3)-(-%4))"
                     "+%4*u(%1*V(%2,%3)-%4)"
                     "+(-%4)*u((-%4)-%1*V(%2,%3))\n").arg(G).arg(in_p).arg(in_m).arg(Vmax);
     }

--- a/qucs/components/optimizedialog.cpp
+++ b/qucs/components/optimizedialog.cpp
@@ -91,7 +91,7 @@ OptimizeDialog::OptimizeDialog(Optimize_Sim *c_, Schematic *d_)
   Tab2->setLayout(gp2);
 
   MethodCombo = new QComboBox();
-  MethodCombo->insertItems(-1, QString("DE/best/1/exp;"
+  MethodCombo->insertItems(-1, QStringLiteral("DE/best/1/exp;"
 				       "DE/rand/1/exp;"
 				       "DE/rand-to-best/1/exp;"
 				       "DE/best/2/exp;"
@@ -887,7 +887,7 @@ void OptimizeDialog::slotCreateEqn()
    }
  }
 
- s += QString("\"yes\" 0>\n" // Export yes, no display
+ s += QStringLiteral("\"yes\" 0>\n" // Export yes, no display
               "</Components>\n"
 	      "<Wires>\n"
 	      "</Wires>\n"

--- a/qucs/components/param_sweep.cpp
+++ b/qucs/components/param_sweep.cpp
@@ -91,11 +91,11 @@ QString Param_Sweep::getNgspiceBeforeSim(QString sim, int lvl)
     step_var.remove(QRegularExpression("[\\.\\[\\]@:]"));
 
     s = "option interp\n";
-    s += QString("let number_%1 = 0\n").arg(step_var);
-    if (lvl==0) s += QString("echo \"STEP %1.%2\" > spice4qucs.%3.cir.res\n").arg(sim).arg(step_var).arg(sim);
-    else s += QString("echo \"STEP %1.%2\" > spice4qucs.%3.cir.res%4\n").arg(sim).arg(step_var).arg(sim).arg(lvl);
+    s += QStringLiteral("let number_%1 = 0\n").arg(step_var);
+    if (lvl==0) s += QStringLiteral("echo \"STEP %1.%2\" > spice4qucs.%3.cir.res\n").arg(sim).arg(step_var).arg(sim);
+    else s += QStringLiteral("echo \"STEP %1.%2\" > spice4qucs.%3.cir.res%4\n").arg(sim).arg(step_var).arg(sim).arg(lvl);
 
-    s += QString("foreach  %1_act ").arg(step_var);
+    s += QStringLiteral("foreach  %1_act ").arg(step_var);
 
     if((type == "list") || (type == "const")) {
         QString list_str = getProperty("Values")->Value;
@@ -103,7 +103,7 @@ QString Param_Sweep::getNgspiceBeforeSim(QString sim, int lvl)
         list_str.chop(1);
         QStringList List = list_str.split(";");
         for(int i = 0; i < List.length(); i++) {
-            s += QString("%1 ").arg(List[i]);
+            s += QStringLiteral("%1 ").arg(List[i]);
         }
     } else {
         double start,stop,step,fac,points,ostart,ostop;
@@ -120,7 +120,7 @@ QString Param_Sweep::getNgspiceBeforeSim(QString sim, int lvl)
         if(type == "lin") {
             step = (stop-start)/(points-1);
             while ( points > 0 ) {
-                s += QString("%1 ").arg(start);
+                s += QStringLiteral("%1 ").arg(start);
                 start += step;
                 points -= 1;
             }
@@ -130,7 +130,7 @@ QString Param_Sweep::getNgspiceBeforeSim(QString sim, int lvl)
             step = (stop - start)/(points - 1);
 
             while ( points > 0 ) {
-                s += QString("%1 ").arg(pow(10, start));
+                s += QStringLiteral("%1 ").arg(pow(10, start));
                 start += step;
                 points -= 1;
             }
@@ -152,13 +152,13 @@ QString Param_Sweep::getNgspiceBeforeSim(QString sim, int lvl)
         if (step_var == "temp" || step_var == "temper") temper_sweep = true;
 
         if (temper_sweep) { // Sweep temperature
-          s += QString("option temp = $%1_act%2").arg(step_var).arg(nline_char);
+          s += QStringLiteral("option temp = $%1_act%2").arg(step_var).arg(nline_char);
         } else if (compfound) { // Sweep device
-          s += QString("alter %1 = $%2_act%3").arg(par).arg(step_var).arg(nline_char);
+          s += QStringLiteral("alter %1 = $%2_act%3").arg(par).arg(step_var).arg(nline_char);
         } else if (par.startsWith("@")) { // Sweep model
-          s += QString("altermod %1 = $%2_act%3").arg(par).arg(step_var).arg(nline_char);
+          s += QStringLiteral("altermod %1 = $%2_act%3").arg(par).arg(step_var).arg(nline_char);
         } else { // Sweep .PARAM variable
-          s += QString("alterparam %1 = $%2_act%3reset%3").arg(par).arg(step_var).arg(nline_char);
+          s += QStringLiteral("alterparam %1 = $%2_act%3reset%3").arg(par).arg(step_var).arg(nline_char);
         }
     }
     return s;
@@ -176,9 +176,9 @@ QString Param_Sweep::getNgspiceAfterSim(QString sim, int lvl)
 
     s = "set appendwrite\n";
 
-    if (lvl==0) s += QString("echo \"$&number_%1  $%2_act\" >> spice4qucs.%3.cir.res\n").arg(par).arg(par).arg(sim);
-    else s += QString("echo \"$&number_%1\" $%1_act >> spice4qucs.%2.cir.res%3\n").arg(par).arg(sim).arg(lvl);
-    s += QString("let number_%1 = number_%1 + 1\n").arg(par);
+    if (lvl==0) s += QStringLiteral("echo \"$&number_%1  $%2_act\" >> spice4qucs.%3.cir.res\n").arg(par).arg(par).arg(sim);
+    else s += QStringLiteral("echo \"$&number_%1\" $%1_act >> spice4qucs.%2.cir.res%3\n").arg(par).arg(sim).arg(lvl);
+    s += QStringLiteral("let number_%1 = number_%1 + 1\n").arg(par);
 
     s += "end\n";
     s += "unset appendwrite\n";
@@ -189,7 +189,7 @@ QString Param_Sweep::getCounterVar()
 {
     QString par = getProperty("Param")->Value;
     par.remove(QRegularExpression("[\\.\\[\\]@:]"));
-    QString s = QString("number_%1").arg(par);
+    QString s = QStringLiteral("number_%1").arg(par);
     return s;
 }
 
@@ -205,7 +205,7 @@ QString Param_Sweep::spice_netlist(bool isXyce)
             QString list = getProperty("Values")->Value;
             list.remove('[').remove(']');
             list = list.split(';').join(" ");
-            s = QString(".STEP %1 LIST %2\n").arg(var).arg(list);
+            s = QStringLiteral(".STEP %1 LIST %2\n").arg(var).arg(list);
             return s.toLower();
         }
     }
@@ -221,11 +221,11 @@ QString Param_Sweep::spice_netlist(bool isXyce)
 
     if (Props.at(0)->Value.toLower().startsWith("dc")) {
         QString src = getProperty("Param")->Value;
-        s = QString("DC %1 %2 %3 %4\n").arg(src).arg(start).arg(stop).arg(step);
+        s = QStringLiteral("DC %1 %2 %3 %4\n").arg(src).arg(start).arg(stop).arg(step);
         if (isXyce) s.prepend('.');
     } else if (isXyce) {
         QString var = getProperty("Param")->Value;
-        s = QString(".STEP %1 %2 %3 %4\n").arg(var).arg(start).arg(stop).arg(step);
+        s = QStringLiteral(".STEP %1 %2 %3 %4\n").arg(var).arg(start).arg(stop).arg(step);
     } else {
         s = "";
     }

--- a/qucs/components/potentiometer.cpp
+++ b/qucs/components/potentiometer.cpp
@@ -121,7 +121,7 @@ QString potentiometer::spice_netlist(bool isXyce)
     QString pin1 = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
     QString pin2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
     QString pin3 = spicecompat::normalize_node_name(Ports.at(2)->Connection->Name);
-    s += QString("R%1_1 %2 %3 R='(%4)*(%5)/(%6)'\n").arg(Name).arg(pin1).arg(pin2).arg(R).arg(rot).arg(max_rot);
-    s += QString("R%1_2 %2 %3 R='(%4)*(1.0-(%5)/(%6))'\n").arg(Name).arg(pin2).arg(pin3).arg(R).arg(rot).arg(max_rot);
+    s += QStringLiteral("R%1_1 %2 %3 R='(%4)*(%5)/(%6)'\n").arg(Name).arg(pin1).arg(pin2).arg(R).arg(rot).arg(max_rot);
+    s += QStringLiteral("R%1_2 %2 %3 R='(%4)*(1.0-(%5)/(%6))'\n").arg(Name).arg(pin2).arg(pin3).arg(R).arg(rot).arg(max_rot);
     return s;
 }

--- a/qucs/components/relais.cpp
+++ b/qucs/components/relais.cpp
@@ -115,9 +115,9 @@ QString Relais::spice_netlist(bool isXyce)
     QString Roff = spicecompat::normalize_value(Props.at(3)->Value);
 
     if (isXyce) {
-        s += QString(".MODEL %1 vswitch von=%2 voff=%3 ron=%4 roff=%5 \n").arg(model).arg(Vt).arg(Vt-Vh).arg(Ron).arg(Roff);
+        s += QStringLiteral(".MODEL %1 vswitch von=%2 voff=%3 ron=%4 roff=%5 \n").arg(model).arg(Vt).arg(Vt-Vh).arg(Ron).arg(Roff);
     } else {
-        s += QString(".MODEL %1 sw vt=%2 vh=%3 ron=%4 roff=%5 \n").arg(model).arg(Vt).arg(Vh).arg(Ron).arg(Roff);
+        s += QStringLiteral(".MODEL %1 sw vt=%2 vh=%3 ron=%4 roff=%5 \n").arg(model).arg(Vt).arg(Vh).arg(Ron).arg(Roff);
     }
 
     return s;

--- a/qucs/components/resistor.cpp
+++ b/qucs/components/resistor.cpp
@@ -57,14 +57,14 @@ QString Resistor::spice_netlist(bool )
 {
     QString s = spicecompat::check_refdes(Name,SpiceModel);
 
-    s += QString(" %1 %2 ").arg(Ports.at(0)->Connection->Name)
+    s += QStringLiteral(" %1 %2 ").arg(Ports.at(0)->Connection->Name)
             .arg(Ports.at(1)->Connection->Name); // output 2 nodes
     s.replace(" gnd ", " 0 ");
 
     QString Tc1 = getProperty("Tc1")->Value;
     QString Tc2 = getProperty("Tc2")->Value;
 
-    s += QString(" %1").arg(spicecompat::normalize_value(Props.at(0)->Value));
+    s += QStringLiteral(" %1").arg(spicecompat::normalize_value(Props.at(0)->Value));
 
     if (!Tc1.isEmpty()) {
         s += " tc1=" + Tc1;
@@ -74,7 +74,7 @@ QString Resistor::spice_netlist(bool )
         s += " tc2=" + Tc2;
     }
 
-    s += QString(" \n");
+    s += QStringLiteral(" \n");
 
     return s;
 }
@@ -89,9 +89,9 @@ QString Resistor::va_code()
     QString Vpm = vacompat::normalize_voltage(plus,minus);
     QString Ipm = vacompat::normalize_current(plus,minus,true);
     
-    if (plus=="gnd") s += QString("%1 <+ -(%2/( %3 ));\n").arg(Ipm).arg(Vpm).arg(val);
-    else s+= QString("%1 <+ %2/( %3 );\n").arg(Ipm).arg(Vpm).arg(val);
-    s += QString("%1 <+ white_noise( 4.0*`P_K*( %2 + 273.15) / ( %3 ), \"thermal\" );\n")
+    if (plus=="gnd") s += QStringLiteral("%1 <+ -(%2/( %3 ));\n").arg(Ipm).arg(Vpm).arg(val);
+    else s+= QStringLiteral("%1 <+ %2/( %3 );\n").arg(Ipm).arg(Vpm).arg(val);
+    s += QStringLiteral("%1 <+ white_noise( 4.0*`P_K*( %2 + 273.15) / ( %3 ), \"thermal\" );\n")
                  .arg(Ipm).arg(valTemp).arg(val);
                   
     return s;

--- a/qucs/components/rlcg.cpp
+++ b/qucs/components/rlcg.cpp
@@ -105,8 +105,8 @@ QString RLCG::spice_netlist(bool isXyce)
     QString G = spicecompat::normalize_value(getProperty("G")->Value);
     QString LEN = spicecompat::normalize_value(getProperty("Length")->Value);
     QString modname = "mod_" + Name;
-    s += QString("O%1 %2 0 %3 0 %4\n").arg(Name).arg(in).arg(out).arg(modname);
-    s += QString(".MODEL %1 LTRA(R=%2 C=%3 L=%4 G=%5 LEN=%6)\n")
+    s += QStringLiteral("O%1 %2 0 %3 0 %4\n").arg(Name).arg(in).arg(out).arg(modname);
+    s += QStringLiteral(".MODEL %1 LTRA(R=%2 C=%3 L=%4 G=%5 LEN=%6)\n")
             .arg(modname).arg(R).arg(C).arg(L).arg(G).arg(LEN);
     return s;
 }

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -96,7 +96,7 @@ Element* Source_ac::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
 QString Source_ac::ngspice_netlist()
 {
-    QString s = QString("V%1").arg(Name);
+    QString s = QStringLiteral("V%1").arg(Name);
     for (Port *p1 : Ports) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
@@ -116,12 +116,12 @@ QString Source_ac::ngspice_netlist()
         en_tran = false;
     }
 
-    s += QString(" dc 0 ac %1").arg(vamp);
+    s += QStringLiteral(" dc 0 ac %1").arg(vamp);
     if (en_tran) {
-        s += QString(" SIN(0 %1 %2)").arg(vamp).arg(f);
+        s += QStringLiteral(" SIN(0 %1 %2)").arg(vamp).arg(f);
     }
-    s += QString(" portnum %1").arg(getProperty("Num")->Value);
-    s += QString(" z0 %1").arg(z0);
+    s += QStringLiteral(" portnum %1").arg(getProperty("Num")->Value);
+    s += QStringLiteral(" z0 %1").arg(z0);
     s += "\n";
     return s;
 }
@@ -134,7 +134,7 @@ QString Source_ac::xyce_netlist()
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names
     }
-    s += QString(" port=%1 ").arg(getProperty("Num")->Value);
+    s += QStringLiteral(" port=%1 ").arg(getProperty("Num")->Value);
     QString s_z0 = spicecompat::normalize_value(getProperty("Z")->Value);
     double z0 = s_z0.toDouble();
     QString s_p = spicecompat::normalize_value(getProperty("P")->Value);
@@ -149,11 +149,11 @@ QString Source_ac::xyce_netlist()
         en_tran = false;
     }
 
-    s += QString(" z0=%1 ").arg(s_z0);
+    s += QStringLiteral(" z0=%1 ").arg(s_z0);
     QString f = spicecompat::normalize_value(getProperty("f")->Value);
-    s += QString(" AC %1 ").arg(vamp);
+    s += QStringLiteral(" AC %1 ").arg(vamp);
     if (en_tran) {
-        s += QString(" SIN 0 %1 %2").arg(vamp).arg(f);
+        s += QStringLiteral(" SIN 0 %1 %2").arg(vamp).arg(f);
     }
     s += "\n";
     return s;

--- a/qucs/components/sp_sim.cpp
+++ b/qucs/components/sp_sim.cpp
@@ -122,12 +122,12 @@ QStringList SP_Sim::getNgspiceExtraVariables()
     int port_number = getSPortsNumber();
     for (int i = 0; i < port_number; i++) {
         for (int j = 0; j < port_number; j++) {
-            QString tail = QString("_%1_%2").arg(i+1).arg(j+1);
-            vars.append(QString("S%1").arg(tail));
-            vars.append(QString("Y%1").arg(tail));
-            vars.append(QString("Z%1").arg(tail));
+            QString tail = QStringLiteral("_%1_%2").arg(i+1).arg(j+1);
+            vars.append(QStringLiteral("S%1").arg(tail));
+            vars.append(QStringLiteral("Y%1").arg(tail));
+            vars.append(QStringLiteral("Z%1").arg(tail));
             if (donoise) {
-                vars.append(QString("Cy%1").arg(tail));
+                vars.append(QStringLiteral("Cy%1").arg(tail));
             }
         }
     }
@@ -146,12 +146,12 @@ QStringList SP_Sim::getXyceExtraVariables()
     int ports_num = getSPortsNumber();
     for (int i = 0; i < ports_num; i++) {
         for (int j = 0; j < ports_num; j++) {
-            QString tail = QString("(%1,%2)").arg(i+1).arg(j+1);
-            vars.append(QString("sdb%1").arg(tail));
-            vars.append(QString("s%1").arg(tail));
-            vars.append(QString("sp%1").arg(tail));
-            vars.append(QString("y%1").arg(tail));
-            vars.append(QString("z%1").arg(tail));
+            QString tail = QStringLiteral("(%1,%2)").arg(i+1).arg(j+1);
+            vars.append(QStringLiteral("sdb%1").arg(tail));
+            vars.append(QStringLiteral("s%1").arg(tail));
+            vars.append(QStringLiteral("sp%1").arg(tail));
+            vars.append(QStringLiteral("y%1").arg(tail));
+            vars.append(QStringLiteral("z%1").arg(tail));
         }
     }
     return vars;
@@ -171,13 +171,13 @@ QString SP_Sim::getSweepString()
         Fstop *= fac;
         double Nd = ceil(log10(Fstop/Fstart)); // number of decades
         double Npd = ceil((Np - 1)/Nd); // points per decade
-        s += QString("DEC %1 ").arg(Npd);
+        s += QStringLiteral("DEC %1 ").arg(Npd);
     } else {  // no need conversion
-        s += QString("LIN %1 ").arg(Props.at(3)->Value);
+        s += QStringLiteral("LIN %1 ").arg(Props.at(3)->Value);
     }
     QString fstart = spicecompat::normalize_value(Props.at(1)->Value); // Start freq.
     QString fstop = spicecompat::normalize_value(Props.at(2)->Value); // Stop freq.
-    s += QString("%1 %2").arg(fstart).arg(fstop); 
+    s += QStringLiteral("%1 %2").arg(fstart).arg(fstop);
     return s;
 }
 
@@ -199,7 +199,7 @@ QString SP_Sim::xyce_netlist()
     s += ".PRINT ac format=std file=spice4qucs_sparam.prn ";
     for (int i = 0; i < ports_num; i++) {
         for (int j = 0; j < ports_num; j++) {
-            s += QString(" sdb(%1,%2) s(%1,%2) sp(%1,%2) y(%1,%2) z(%1,%2) ").arg(i+1).arg(j+1);
+            s += QStringLiteral(" sdb(%1,%2) s(%1,%2) sp(%1,%2) y(%1,%2) z(%1,%2) ").arg(i+1).arg(j+1);
         }
     }
     s += "\n";*/

--- a/qucs/components/sparamfile.cpp
+++ b/qucs/components/sparamfile.cpp
@@ -206,10 +206,10 @@ QString SParamFile::spice_netlist(bool isXyce)
         for(int i = 0; i < Np; i++) {
             QString p_in = spicecompat::normalize_node_name(Ports.at(i)->Connection->Name);
             QString p_com = spicecompat::normalize_node_name(Ports.at(Np)->Connection->Name);
-            s += QString(" %1 %2").arg(p_in).arg(p_com);
+            s += QStringLiteral(" %1 %2").arg(p_in).arg(p_com);
         }
-        s += QString(" %1\n").arg(s_mod);
-        s += QString(".MODEL %1 LIN TSTONEFILE=%2\n").arg(s_mod)
+        s += QStringLiteral(" %1\n").arg(s_mod);
+        s += QStringLiteral(".MODEL %1 LIN TSTONEFILE=%2\n").arg(s_mod)
                 .arg(getSubcircuitFile());
     } else {
         s += SpiceModel+Name;

--- a/qucs/components/spicedialog.cpp
+++ b/qucs/components/spicedialog.cpp
@@ -309,7 +309,7 @@ void SpiceDialog::slotButtBrowse()
       this,
       tr("Select a file"),
       currDir,
-      tr("SPICE netlist") + QString(" (") + QucsSettings.spiceExtensions.join(" ") + QString(");;")
+      tr("SPICE netlist") + QStringLiteral(" (") + QucsSettings.spiceExtensions.join(" ") + QStringLiteral(");;")
       + tr("All Files") + " (*.*)");
 
   if(!s.isEmpty()) {

--- a/qucs/components/spicefile.cpp
+++ b/qucs/components/spicefile.cpp
@@ -43,10 +43,10 @@ SpiceFile::SpiceFile()
 {
   Description = QObject::tr("SPICE netlist file");
   // Property descriptions not needed, but must not be empty !
-  Props.append(new Property("File", "", true, QString("x")));
-  Props.append(new Property("Ports", "", false, QString("x")));
-  Props.append(new Property("Sim", "yes", false, QString("x")));
-  Props.append(new Property("Preprocessor", "none", false, QString("x")));
+  Props.append(new Property("File", "", true, QStringLiteral("x")));
+  Props.append(new Property("Ports", "", false, QStringLiteral("x")));
+  Props.append(new Property("Sim", "yes", false, QStringLiteral("x")));
+  Props.append(new Property("Preprocessor", "none", false, QStringLiteral("x")));
   withSim = false;
 
   Model = "SPICE";

--- a/qucs/components/subcircuit.cpp
+++ b/qucs/components/subcircuit.cpp
@@ -231,7 +231,7 @@ QString Subcircuit::spice_netlist(bool) {
   }
   s += " " + misc::properName(f);
   for (qsizetype i = 1; i < Props.size(); i++) {
-    s += QString(" %1=%2").arg(
+    s += QStringLiteral(" %1=%2").arg(
         Props.at(i)->Name, spicecompat::normalize_value(Props.at(i)->Value));
   }
   s += "\n";

--- a/qucs/components/switch.cpp
+++ b/qucs/components/switch.cpp
@@ -90,7 +90,7 @@ QString Switch::spice_netlist(bool)
   QString port1 = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
   QString port2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
 
-  s += QString(" %1 %2 control_net%3 0 switch_model%3\n").arg(port1).arg(port2).arg(Name);
+  s += QStringLiteral(" %1 %2 control_net%3 0 switch_model%3\n").arg(port1).arg(port2).arg(Name);
 
   QString init = spicecompat::normalize_value(getProperty("init")->Value);
   QString times = spicecompat::normalize_value(getProperty("time")->Value);
@@ -123,7 +123,7 @@ QString Switch::spice_netlist(bool)
     evenValue = "0";
   }
 
-  s += QString("V%1 control_net%1 0 DC %2 PWL(0 %2").arg(Name).arg(oddValue);
+  s += QStringLiteral("V%1 control_net%1 0 DC %2 PWL(0 %2").arg(Name).arg(oddValue);
 
   for (int i = 0; i < timesList.size(); i++) {
     QString timeStep = timesList[i].toLower();
@@ -132,29 +132,29 @@ QString Switch::spice_netlist(bool)
 
     if (i == 0) {
         time += timeValue - changingTime;
-        s += QString(" %1 %2").arg(time).arg(oddValue);
+        s += QStringLiteral(" %1 %2").arg(time).arg(oddValue);
         time += changingTime;
-        s += QString(" %1 %2").arg(time).arg(evenValue);
+        s += QStringLiteral(" %1 %2").arg(time).arg(evenValue);
 
     } else {
         if (i % 2 == 1) {
             time += timeValue- changingTime;
-            s += QString(" %1 %2").arg(time).arg(evenValue);
+            s += QStringLiteral(" %1 %2").arg(time).arg(evenValue);
             time += changingTime;
-            s += QString(" %1 %2").arg(time).arg(oddValue);
+            s += QStringLiteral(" %1 %2").arg(time).arg(oddValue);
         }
         else{
             time += timeValue- changingTime;
-            s += QString(" %1 %2").arg(time).arg(oddValue);
+            s += QStringLiteral(" %1 %2").arg(time).arg(oddValue);
             time += changingTime;
-            s += QString(" %1 %2").arg(time).arg(evenValue);
+            s += QStringLiteral(" %1 %2").arg(time).arg(evenValue);
         }
     }
   }
 
   s += ")\n";
 
-  s += QString(".model switch_model%1 sw vt =0.5 ron =%2 roff =%3\n").arg(Name).arg(Ron).arg(Roff);
+  s += QStringLiteral(".model switch_model%1 sw vt =0.5 ron =%2 roff =%3\n").arg(Name).arg(Ron).arg(Roff);
   return s;
 }
 

--- a/qucs/components/tff_SR.cpp
+++ b/qucs/components/tff_SR.cpp
@@ -193,7 +193,7 @@ QString tff_SR::spice_netlist(bool isXyce)
     s += " " + T + " " + CLK + " " + SET + " " + RESET + " " + Q + " " + QB;
 
     s += " " + tmp_model + "\n";
-    s += QString(".model %1 d_tff(clk_delay=%2 set_delay=%2 reset_delay=%2 rise_delay=%2 fall_delay=%2)\n")
+    s += QStringLiteral(".model %1 d_tff(clk_delay=%2 set_delay=%2 reset_delay=%2 rise_delay=%2 fall_delay=%2)\n")
             .arg(tmp_model).arg(td);
     return s;
 }

--- a/qucs/components/tr_sim.cpp
+++ b/qucs/components/tr_sim.cpp
@@ -104,7 +104,7 @@ QString TR_Sim::spice_netlist(bool isXyce)
     Npoints = Props.at(3)->Value.toDouble();
     Tstep = (Tstop-Tstart)/(Npoints-1);
 
-    s += QString(" %1 %2 %3 ").arg(Tstep).arg(Tstop).arg(Tstart);
+    s += QStringLiteral(" %1 %2 %3 ").arg(Tstep).arg(Tstop).arg(Tstart);
 
     QString max_step = spicecompat::normalize_value(getProperty("MaxStep")->Value);
     if (max_step!="0") s+= max_step;

--- a/qucs/components/vacomponent.cpp
+++ b/qucs/components/vacomponent.cpp
@@ -304,15 +304,15 @@ QString vacomponent::spice_netlist(bool isXyce)
     for(const auto pp: Ports) {
         s += pp->Connection->Name + " ";
     }
-    QString tmp_model = QString("mod_%1_%2").arg(Model).arg(Name);
+    QString tmp_model = QStringLiteral("mod_%1_%2").arg(Model).arg(Name);
     s += tmp_model + "\n";
     QString par_str;
     for(int i = 0; i < Props.count(); i++) {
-        par_str += QString("%1=%2 ")
+        par_str += QStringLiteral("%1=%2 ")
                 .arg(Props.at(i)->Name)
                 .arg(Props.at(i)->Value);
     }
-    s += QString(".MODEL %1 %2 %3\n").arg(tmp_model)
+    s += QStringLiteral(".MODEL %1 %2 %3\n").arg(tmp_model)
                                       .arg(Model)
                                       .arg(par_str);
     return s;

--- a/qucs/components/vccs.cpp
+++ b/qucs/components/vccs.cpp
@@ -95,11 +95,11 @@ QString VCCS::va_code()
     
     QString Vpm = vacompat::normalize_voltage(P1,P2);
     QString Ipm = vacompat::normalize_current(P1,P2,true);  
-    s += QString(" %1  <+  %2 * 1e-9;\n").arg(Ipm).arg(Vpm);
+    s += QStringLiteral(" %1  <+  %2 * 1e-9;\n").arg(Ipm).arg(Vpm);
     QString Vpm2 = vacompat::normalize_voltage(P4,P3);
     QString Ipm2 = vacompat::normalize_current(P4,P3,true); 
-    s += QString("%1  <+   %2 * 1e-9;\n").arg(Ipm2).arg(Vpm2);
-    s += QString("%1  <+   %2 * %3 ;\n").arg(Ipm2).arg(Vpm).arg(Gain);
+    s += QStringLiteral("%1  <+   %2 * 1e-9;\n").arg(Ipm2).arg(Vpm2);
+    s += QStringLiteral("%1  <+   %2 * %3 ;\n").arg(Ipm2).arg(Vpm).arg(Gain);
     
     return s;
 

--- a/qucs/components/vcresistor.cpp
+++ b/qucs/components/vcresistor.cpp
@@ -101,11 +101,11 @@ QString vcresistor::netlist()
   QString out1 = Ports.at(2)->Connection->Name;
   QString out2 = Ports.at(3)->Connection->Name;
   QString gain = getProperty("gain")->Value;
-  s = QString("EDD:%1 %2 %3 %4 %5 I1=\"%1.I1\" Q1=\"%1.Q1\" I2=\"%1.I2\" Q2=\"%1.Q2\"\n").arg(EDD_Name,in1,in2,out1,out2);
-  s += QString("Eqn:Eqn%1I1 %1.I1=\"0\" Export=\"no\"\n").arg(EDD_Name);
-  s += QString("Eqn:Eqn%1Q1 %1.Q1=\"0\" Export=\"no\"\n").arg(EDD_Name);
-  s += QString("Eqn:Eqn%1I2 %1.I2=\"V2/(1e-20+abs(V1*(%2)))\" Export=\"no\"\n").arg(EDD_Name,gain);
-  s += QString("Eqn:Eqn%1Q2 %1.Q2=\"0\" Export=\"no\"\n").arg(EDD_Name);
+  s = QStringLiteral("EDD:%1 %2 %3 %4 %5 I1=\"%1.I1\" Q1=\"%1.Q1\" I2=\"%1.I2\" Q2=\"%1.Q2\"\n").arg(EDD_Name,in1,in2,out1,out2);
+  s += QStringLiteral("Eqn:Eqn%1I1 %1.I1=\"0\" Export=\"no\"\n").arg(EDD_Name);
+  s += QStringLiteral("Eqn:Eqn%1Q1 %1.Q1=\"0\" Export=\"no\"\n").arg(EDD_Name);
+  s += QStringLiteral("Eqn:Eqn%1I2 %1.I2=\"V2/(1e-20+abs(V1*(%2)))\" Export=\"no\"\n").arg(EDD_Name,gain);
+  s += QStringLiteral("Eqn:Eqn%1Q2 %1.Q2=\"0\" Export=\"no\"\n").arg(EDD_Name);
   return s;
 }
 
@@ -118,7 +118,7 @@ QString vcresistor::spice_netlist(bool isXyce)
   QString in2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
   QString out1 = spicecompat::normalize_node_name(Ports.at(2)->Connection->Name);
   QString out2 = spicecompat::normalize_node_name(Ports.at(3)->Connection->Name);
-  s = QString("R%1 %2 %3 R='1e-15+abs(V(%4,%5)*(%6))'\n").arg(Name, out1, out2, in1, in2, gain);
+  s = QStringLiteral("R%1 %2 %3 R='1e-15+abs(V(%4,%5)*(%6))'\n").arg(Name, out1, out2, in1, in2, gain);
   return s;
 }
 

--- a/qucs/components/vcvs.cpp
+++ b/qucs/components/vcvs.cpp
@@ -97,11 +97,11 @@ QString VCVS::va_code()
     
     QString Vpm = vacompat::normalize_voltage(P1,P2);
     QString Ipm = vacompat::normalize_current(P1,P2,true);  
-    s += QString(" %1  <+  %2 * 1e-9;\n").arg(Ipm).arg(Vpm);
+    s += QStringLiteral(" %1  <+  %2 * 1e-9;\n").arg(Ipm).arg(Vpm);
     QString Vpm2 = vacompat::normalize_voltage(P3,P4);
     QString Ipm2 = vacompat::normalize_current(P3,P4,true); 
-    s += QString("%1  <+  -(%2 * 1e3);\n").arg(Ipm2).arg(Vpm2);
-    s += QString("%1  <+  -(%2 * 1e3*  %3) ;\n").arg(Ipm2).arg(Vpm).arg(Gain);
+    s += QStringLiteral("%1  <+  -(%2 * 1e3);\n").arg(Ipm2).arg(Vpm2);
+    s += QStringLiteral("%1  <+  -(%2 * 1e3*  %3) ;\n").arg(Ipm2).arg(Vpm).arg(Gain);
     
     return s;
  }

--- a/qucs/components/vexp.cpp
+++ b/qucs/components/vexp.cpp
@@ -102,6 +102,6 @@ QString vExp::spice_netlist(bool)
    QString Tr = spicecompat::normalize_value(Props.at(4)->Value);
    QString Tf = spicecompat::normalize_value(Props.at(5)->Value);
 
-    s += QString(" DC 0 EXP(%1 %2 %3 %4 %5 %6) AC 0\n").arg(U1).arg(U2).arg(T1).arg(Tr).arg(T2).arg(Tf);
+    s += QStringLiteral(" DC 0 EXP(%1 %2 %3 %4 %5 %6) AC 0\n").arg(U1).arg(U2).arg(T1).arg(Tr).arg(T2).arg(Tf);
     return s;
 }

--- a/qucs/components/vfile.cpp
+++ b/qucs/components/vfile.cpp
@@ -119,13 +119,13 @@ QString vFile::spice_netlist(bool isXyce)
     QString modname = "mod_" + Model + Name;
     QString p1 = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
     QString p2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
-    s += QString(" %vd([%1 %2]) %3\n").arg(p1).arg(p2).arg(modname);
+    s += QStringLiteral(" %vd([%1 %2]) %3\n").arg(p1).arg(p2).arg(modname);
     QString file = getSubcircuitFile();
     QString sc = getProperty("G")->Value;
     QString step = "false";
     QString delay = getProperty("T")->Value;
     if (getProperty("Interpolator")->Value != "linear") step = "true";
-    s += QString(".MODEL %1 filesource (file=\"%2\" amplscale=[%3] amplstep=%4 "
+    s += QStringLiteral(".MODEL %1 filesource (file=\"%2\" amplscale=[%3] amplstep=%4 "
                  "amploffset=[0] timeoffset=%5 timescale=1)\n")
             .arg(modname).arg(file).arg(sc).arg(step).arg(delay);
 

--- a/qucs/components/volt_ac.cpp
+++ b/qucs/components/volt_ac.cpp
@@ -106,7 +106,7 @@ QString Volt_ac::spice_netlist(bool)
     QString VO = spicecompat::normalize_value(getProperty("VO")->Value);
     QString TD = spicecompat::normalize_value(getProperty("TD")->Value);
 
-    s += QString(" DC %1 SIN(%1 %2 %3 %4 %5 %6) AC %7 ACPHASE %8\n")
+    s += QStringLiteral(" DC %1 SIN(%1 %2 %3 %4 %5 %6) AC %7 ACPHASE %8\n")
             .arg(VO).arg(volts).arg(freq).arg(TD).arg(theta).arg(phase).arg(volts).arg(phase);
     return s;
 }

--- a/qucs/components/volt_dc.cpp
+++ b/qucs/components/volt_dc.cpp
@@ -68,7 +68,7 @@ QString Volt_dc::spice_netlist(bool)
         s += " "+ nam;   // node names
     }
 
-    s += QString(" DC %1\n").arg(spicecompat::normalize_value(Props.at(0)->Value));
+    s += QStringLiteral(" DC %1\n").arg(spicecompat::normalize_value(Props.at(0)->Value));
     return s;
 }
 

--- a/qucs/components/vprobe.cpp
+++ b/qucs/components/vprobe.cpp
@@ -80,7 +80,7 @@ QString vProbe::getProbeVariable(bool)
 
 QString vProbe::spice_netlist(bool)
 {
-    QString s = QString("E%1 %2 0 %3 %4 1.0\nR%1%2 %2 0 1E8\nR%1%3 %3 %4 1E8\n").arg(Name).arg(Name)
+    QString s = QStringLiteral("E%1 %2 0 %3 %4 1.0\nR%1%2 %2 0 1E8\nR%1%3 %3 %4 1E8\n").arg(Name).arg(Name)
             .arg(Ports.at(0)->Connection->Name).arg(Ports.at(1)->Connection->Name);
     return s;
 }

--- a/qucs/components/vpulse.cpp
+++ b/qucs/components/vpulse.cpp
@@ -101,7 +101,7 @@ QString vPulse::spice_netlist(bool)
     Pw = Pw - TfVal*fac;
     Per = 1.0e9*Pw;
 
-    s += QString(" DC 0 PULSE(%1 %2 %3 %4 %5 %6 %7) AC 0\n").arg(VL).arg(VH).arg(T1).arg(Tr).arg(Tf).arg(Pw).arg(Per);
+    s += QStringLiteral(" DC 0 PULSE(%1 %2 %3 %4 %5 %6 %7) AC 0\n").arg(VL).arg(VH).arg(T1).arg(Tr).arg(Tf).arg(Pw).arg(Per);
 
     return s;
 }

--- a/qucs/components/vrect.cpp
+++ b/qucs/components/vrect.cpp
@@ -92,7 +92,7 @@ QString vRect::spice_netlist(bool)
     QString TH = spicecompat::normalize_value(getProperty("TH")->Value);
     QString TL = spicecompat::normalize_value(getProperty("TL")->Value);
 
-    s += QString(" DC 0 PULSE( %1 %2 %3 %4 %5 %6 {(%7)+(%8)+(%9)+(%10)} )  AC 0\n")
+    s += QStringLiteral(" DC 0 PULSE( %1 %2 %3 %4 %5 %6 {(%7)+(%8)+(%9)+(%10)} )  AC 0\n")
              .arg(U0).arg(U).arg(Td).arg(Tr).arg(Tf).arg(TH).arg(TH).arg(TL).arg(Tr).arg(Tf);
 
     return s;

--- a/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/diagrams/diagramdialog.cpp
@@ -804,7 +804,7 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
   if(ColorButt) {
     if(!currentGraph) {
       QColor selectedColor(DefaultColors[GraphList->count()%NumDefaultColors]);
-      QString stylesheet = QString("QPushButton {background-color: %1};").arg(selectedColor.name());
+      QString stylesheet = QStringLiteral("QPushButton {background-color: %1};").arg(selectedColor.name());
       ColorButt->setStyleSheet(stylesheet);
       misc::setPickerColor(ColorButt, selectedColor);
     }
@@ -987,7 +987,7 @@ void DiagramDialog::slotTakeVar(QTableWidgetItem* Item)
         g->Color = misc::getWidgetBackgroundColor(ColorButt);
         g->Thick = Property2->text().toInt();
         QColor selectedColor(DefaultColors[GraphList->count()%NumDefaultColors]);
-        QString stylesheet = QString("QPushButton {background-color: %1};").arg(selectedColor.name());
+        QString stylesheet = QStringLiteral("QPushButton {background-color: %1};").arg(selectedColor.name());
         ColorButt->setStyleSheet(stylesheet);
         misc::setPickerColor(ColorButt, selectedColor);
         if(g->Var.right(3) == ".Vb")   // harmonic balance output ?
@@ -1052,7 +1052,7 @@ void DiagramDialog::SelectGraph(Graph *g)
   if(Diag->Name != "Tab") {
     if(Diag->Name != "Truth") {
       Property2->setText(QString::number(g->Thick));
-      QString stylesheet = QString("QPushButton {background-color: %1};").arg(g->Color.name());
+      QString stylesheet = QStringLiteral("QPushButton {background-color: %1};").arg(g->Color.name());
       ColorButt->setStyleSheet(stylesheet);
       misc::setPickerColor(ColorButt,g->Color);
       PropertyBox->setCurrentIndex(g->Style);
@@ -1106,7 +1106,7 @@ void DiagramDialog::slotDeleteGraph()
   if(Diag->Name != "Tab") {
     if(Diag->Name != "Truth") {
       QColor selectedColor(DefaultColors[GraphList->count()%NumDefaultColors]);
-      QString stylesheet = QString("QPushButton {background-color: %1};").arg(selectedColor.name());
+      QString stylesheet = QStringLiteral("QPushButton {background-color: %1};").arg(selectedColor.name());
       ColorButt->setStyleSheet(stylesheet);
       misc::setPickerColor(ColorButt,selectedColor);
       Property2->setText("0");
@@ -1384,7 +1384,7 @@ void DiagramDialog::slotSetColor()
 {
   QColor c = QColorDialog::getColor(misc::getWidgetBackgroundColor(ColorButt),this);
   if(!c.isValid()) return;
-  QString stylesheet = QString("QPushButton {background-color: %1};").arg(c.name());
+  QString stylesheet = QStringLiteral("QPushButton {background-color: %1};").arg(c.name());
   ColorButt->setStyleSheet(stylesheet);
   misc::setPickerColor(ColorButt,c);
 

--- a/qucs/dialogs/aboutdialog.cpp
+++ b/qucs/dialogs/aboutdialog.cpp
@@ -124,7 +124,7 @@ AboutDialog::AboutDialog(QWidget *parent)
   //all->setSpacing(0);
 
   QLabel *iconLabel = new QLabel();
-  iconLabel->setPixmap(QPixmap(QString(":/bitmaps/hicolor/scalable/apps/qucs.svg")));
+  iconLabel->setPixmap(QPixmap(QStringLiteral(":/bitmaps/hicolor/scalable/apps/qucs.svg")));
 
   QWidget *hbox = new QWidget();
   QHBoxLayout *hl = new QHBoxLayout(hbox);

--- a/qucs/dialogs/exportdialog.cpp
+++ b/qucs/dialogs/exportdialog.cpp
@@ -172,12 +172,12 @@ void ExportDialog::setFileName()
 
   if (fileName.isEmpty()) return;
 
-  if (selectedFilter.contains("*.png", Qt::CaseInsensitive)) filterExtension = QString(".png");
-  if (selectedFilter.contains("*.jpg", Qt::CaseInsensitive)) filterExtension = QString(".jpg");
-  if (selectedFilter.contains("*.svg", Qt::CaseInsensitive)) filterExtension = QString(".svg");
-  if (selectedFilter.contains("*.pdf", Qt::CaseInsensitive)) filterExtension = QString(".pdf");
-  if (selectedFilter.contains("*.pdf_tex", Qt::CaseInsensitive)) filterExtension = QString(".pdf_tex");
-  if (selectedFilter.contains("*.eps", Qt::CaseInsensitive)) filterExtension = QString(".eps");
+  if (selectedFilter.contains("*.png", Qt::CaseInsensitive)) filterExtension = QStringLiteral(".png");
+  if (selectedFilter.contains("*.jpg", Qt::CaseInsensitive)) filterExtension = QStringLiteral(".jpg");
+  if (selectedFilter.contains("*.svg", Qt::CaseInsensitive)) filterExtension = QStringLiteral(".svg");
+  if (selectedFilter.contains("*.pdf", Qt::CaseInsensitive)) filterExtension = QStringLiteral(".pdf");
+  if (selectedFilter.contains("*.pdf_tex", Qt::CaseInsensitive)) filterExtension = QStringLiteral(".pdf_tex");
+  if (selectedFilter.contains("*.eps", Qt::CaseInsensitive)) filterExtension = QStringLiteral(".eps");
 
   QFileInfo fileInfo(fileName);
 

--- a/qucs/dialogs/importdialog.cpp
+++ b/qucs/dialogs/importdialog.cpp
@@ -139,7 +139,7 @@ void ImportDialog::slotBrowse()
 {
   QString s = QFileDialog::getOpenFileName(
      this, tr("Enter a Data File Name"),
-     lastImportDir.isEmpty() ? QString(".") : lastImportDir,
+     lastImportDir.isEmpty() ? QStringLiteral(".") : lastImportDir,
      tr("All known")+
      " (*.s?p *.csv *.citi *.cit *.asc *.mdl *.vcd *.dat *.cir *.dat.ngspice *.dat.xyce *.dat.spopus);;"+
      tr("Touchstone files")+" (*.s?p);;"+
@@ -167,7 +167,7 @@ void ImportDialog::slotSaveBrowse()
 {
     QString s = QFileDialog::getSaveFileName(
        this, tr("Enter a Data File Name"),
-       lastImportDir.isEmpty() ? QString(".") : lastImportDir,
+       lastImportDir.isEmpty() ? QStringLiteral(".") : lastImportDir,
        tr("All known")+
        " (*.s?p *.csv *.dat *.cir *.net *.lib);;"+
        tr("Touchstone files")+" (*.s?p);;"+

--- a/qucs/dialogs/librarydialog.cpp
+++ b/qucs/dialogs/librarydialog.cpp
@@ -502,7 +502,7 @@ void LibraryDialog::slotSave()
         AbstractSpiceKernel *kern = new AbstractSpiceKernel(Doc);
         QStringList err_lst;
         if (!kern->checkSchematic(err_lst)) {
-             ErrText->insertPlainText(QString("Component %1 contains SPICE-incompatible components.\n"
+             ErrText->insertPlainText(QStringLiteral("Component %1 contains SPICE-incompatible components.\n"
                                 "Check these components: %2 \n")
                     .arg(Doc->DocName).arg(err_lst.join("; ")));
         }

--- a/qucs/dialogs/loaddialog.cpp
+++ b/qucs/dialogs/loaddialog.cpp
@@ -307,7 +307,7 @@ void LoadDialog::slotChangeIcon()
       QString line = in.readLine();
       if (line.contains("BitmapFile")){
           QString change =
-                  QString("  \"BitmapFile\" : \"%1\",").arg(newIcon);
+                  QStringLiteral("  \"BitmapFile\" : \"%1\",").arg(newIcon);
           QString stmp = change + "\n";
           ba.append(stmp.toLatin1());
       }

--- a/qucs/dialogs/matchdialog.cpp
+++ b/qucs/dialogs/matchdialog.cpp
@@ -856,15 +856,15 @@ QString MatchDialog::calcMatchingLC(double r_real, double r_imag, double Z0,
   QString laddercode = "", series_element, shunt_element;
   // serial component
   if (X1 < 0.0) // capacitance ?
-    series_element = QString("CS:%1;").arg(-1.0 / Omega / X1);
+    series_element = QStringLiteral("CS:%1;").arg(-1.0 / Omega / X1);
   else // inductance
-    series_element = QString("LS:%1;").arg(X1 / Omega);
+    series_element = QStringLiteral("LS:%1;").arg(X1 / Omega);
 
   // parallel component
   if (X2 < 0.0) // inductance ?
-    shunt_element = QString("LP:%1;").arg(-1.0 / Omega / X2);
+    shunt_element = QStringLiteral("LP:%1;").arg(-1.0 / Omega / X2);
   else // capacitance
-    shunt_element = QString("CP:%1;").arg(X2 / Omega);
+    shunt_element = QStringLiteral("CP:%1;").arg(X2 / Omega);
 
   (r_real < 0) ? laddercode = shunt_element + series_element
                : laddercode = series_element + shunt_element;
@@ -924,8 +924,8 @@ bool MatchDialog::calcMatchingCircuit(double S11real, double S11imag, double Z0,
 
   if (SP_Block) {
     laddercode.append("S2P:Freq;");
-    laddercode.prepend(QString("P1:%1;").arg(Z0));
-    laddercode.append(QString("ZL:%1#%2;").arg(RL).arg(XL));
+    laddercode.prepend(QStringLiteral("P1:%1;").arg(Z0));
+    laddercode.append(QStringLiteral("ZL:%1#%2;").arg(RL).arg(XL));
   } else // Add tags instead of a S-param simulation
   {
     laddercode.prepend("LBL:Port 1;");
@@ -1023,15 +1023,15 @@ bool MatchDialog::calc2PortMatch(double S11real, double S11imag, double S22real,
     OutputLadderCode = flipLadderCode(OutputLadderCode);
 
   if (SP_Block) {
-    InputLadderCode.prepend(QString("S2P:%1;").arg(
+    InputLadderCode.prepend(QStringLiteral("S2P:%1;").arg(
         Freq)); // Add the s-param simulation to the circuit code
-    InputLadderCode.prepend(QString("P1:%1;").arg(Z1)); // Port 1
-    OutputLadderCode.append(QString("P2:%1;").arg(Z2)); // Port 2
+    InputLadderCode.prepend(QStringLiteral("P1:%1;").arg(Z1)); // Port 1
+    OutputLadderCode.append(QStringLiteral("P2:%1;").arg(Z2)); // Port 2
   } else { // Use labels instead of the S-param simulation
-    InputLadderCode.prepend(QString("LBL:Port 1;")); // Port 1
-    OutputLadderCode.append(QString("LBL:Port 2;")); // Port 2
+    InputLadderCode.prepend(QStringLiteral("LBL:Port 1;")); // Port 1
+    OutputLadderCode.append(QStringLiteral("LBL:Port 2;")); // Port 2
   }
-  QString laddercode = InputLadderCode + QString("DEV:0") + OutputLadderCode;
+  QString laddercode = InputLadderCode + QStringLiteral("DEV:0") + OutputLadderCode;
   int x_pos = 0;
   SchematicParser(laddercode, x_pos, Freq, Substrate, microsyn);
 
@@ -1256,22 +1256,22 @@ QString MatchDialog::calcSingleStub(double r_real, double r_imag, double Z0,
   // String code
   QString laddercode;
   if ((open_short) && (!BalancedStubs))
-    laddercode = QString("OL:%1#%2;TL:%1#%3;")
+    laddercode = QStringLiteral("OL:%1#%2;TL:%1#%3;")
                      .arg(Z0)
                      .arg(lstub)
                      .arg(d); // Line + Open stub
   if ((open_short) && (BalancedStubs))
-    laddercode = QString("OU:%1#%2;OL:%1#%2;TL:%1#%3;")
+    laddercode = QStringLiteral("OU:%1#%2;OL:%1#%2;TL:%1#%3;")
                      .arg(Z0)
                      .arg(lstub)
                      .arg(d); // Open circuit balanced stubs
   if ((!open_short) && (!BalancedStubs))
-    laddercode = QString("SL:%1#%2;TL:%1#%3;")
+    laddercode = QStringLiteral("SL:%1#%2;TL:%1#%3;")
                      .arg(Z0)
                      .arg(lstub)
                      .arg(d); // Line + Short circuited stub
   if ((!open_short) && (BalancedStubs))
-    laddercode = QString("SU:%1#%2;SL:%1#%2;TL:%1#%3;")
+    laddercode = QStringLiteral("SU:%1#%2;SL:%1#%2;TL:%1#%3;")
                      .arg(Z0)
                      .arg(lstub)
                      .arg(d); // Short circuited balanced stubs
@@ -1348,25 +1348,25 @@ QString MatchDialog::calcDoubleStub(double r_real, double r_imag, double Z0,
 
   QString laddercode;
   if ((open_short) && (BalancedStubs))
-    laddercode = QString("OU:%1#%2;OL:%1#%2;TL:%1#%3;OU:%1#%4;OL:%1#%4;")
+    laddercode = QStringLiteral("OU:%1#%2;OL:%1#%2;TL:%1#%3;OU:%1#%4;OL:%1#%4;")
                      .arg(Z0)
                      .arg(lstub2)
                      .arg(d)
                      .arg(lstub1);
   if ((open_short) && (!BalancedStubs))
-    laddercode = QString("OL:%1#%2;TL:%1#%3;OL:%1#%4;")
+    laddercode = QStringLiteral("OL:%1#%2;TL:%1#%3;OL:%1#%4;")
                      .arg(Z0)
                      .arg(lstub2)
                      .arg(d)
                      .arg(lstub1);
   if ((!open_short) && (BalancedStubs))
-    laddercode = QString("SU:%1#%2;SL:%1#%2;TL:%1#%3;SU:%1#%4;SL:%1#%4;")
+    laddercode = QStringLiteral("SU:%1#%2;SL:%1#%2;TL:%1#%3;SU:%1#%4;SL:%1#%4;")
                      .arg(Z0)
                      .arg(lstub2)
                      .arg(d)
                      .arg(lstub1);
   if ((!open_short) && (!BalancedStubs))
-    laddercode = QString("SL:%1#%2;TL:%1#%3;SL:%1#%4;")
+    laddercode = QStringLiteral("SL:%1#%2;TL:%1#%3;SL:%1#%4;")
                      .arg(Z0)
                      .arg(lstub2)
                      .arg(d)
@@ -1413,7 +1413,7 @@ QString MatchDialog::calcBinomialLines(double r_real, double r_imag, double Z0,
     Ci = BinomialCoeffs(order - 1, i - 1);
     Zi = exp(log(Zaux) + (Ci / pow(2, order - 1)) * log(RL / Z0));
     Zaux = Zi;
-    laddercode += QString("TL:%1#%2;").arg(Zi).arg(l4);
+    laddercode += QStringLiteral("TL:%1#%2;").arg(Zi).arg(l4);
   }
   return laddercode;
 }
@@ -1507,7 +1507,7 @@ QString MatchDialog::calcChebyLines(double r_real, double r_imag, double Z0,
     (RL < Z0) ? Zi = exp(log(Zaux) - gamma * w[i])
               : Zi = exp(log(Zaux) + gamma * w[i]); // When RL<Z0, Z_{i}<Z_{i-1}
     Zaux = Zi;
-    laddercode += QString("TL:%1#%2;").arg(Zi).arg(l4);
+    laddercode += QStringLiteral("TL:%1#%2;").arg(Zi).arg(l4);
   }
   return laddercode;
 }
@@ -1549,14 +1549,14 @@ QString MatchDialog::calcMatchingCascadedLCSections(double r_real,
     Q = sqrt(Raux / R - 1);
     C = Q / (w * Raux);
     L = Q * R / w;
-    s += QString("CP:%1;LS:%2;").arg(C).arg(L);
+    s += QStringLiteral("CP:%1;LS:%2;").arg(C).arg(L);
     Raux = R;
   }
 
   Q = sqrt(R / R2 - 1);
   C = Q / (w * R);
   L = Q * R2 / w;
-  s += QString("CP:%1;LS:%2;").arg(C).arg(L);
+  s += QStringLiteral("CP:%1;LS:%2;").arg(C).arg(L);
 
   if (RL > RS) // Flip string
   {
@@ -1581,7 +1581,7 @@ QString MatchDialog::calcMatchingLambda8Lambda4(double r_real, double r_imag,
   r2z(RL, XL, Z0);
   double Zmm = sqrt(RL * RL + XL * XL);
   double Zm = sqrt((Z0 * RL * Zmm) / (Zmm - XL));
-  return QString("TL:%1#%2;TL:%3#%4;").arg(Zm).arg(l4).arg(Zmm).arg(l8);
+  return QStringLiteral("TL:%1#%2;TL:%3#%4;").arg(Zm).arg(l4).arg(Zmm).arg(l8);
 }
 
 // Given a string code of inductors, capacitors and transmission lines, it
@@ -1653,17 +1653,17 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
     // components, wires and paintings in the schematic
     if (!tag.compare("P1")) // Port 1 component
     {
-      componentstr += QString("<Pac P1 1 %2 -30 18 -26 0 1 \"1\" 1 \"%1\" 1 "
+      componentstr += QStringLiteral("<Pac P1 1 %2 -30 18 -26 0 1 \"1\" 1 \"%1\" 1 "
                               "\"0 dBm\" 0 \"1 GHz\" 0>\n")
                           .arg(misc::num2str(value, 3, "Ohm")) // reference impedance
                           .arg(x_pos);
-      componentstr += QString("<GND * 1 %1 0 0 0 0 0>\n").arg(x_pos);
-      wirestr += QString("<%1 -60 %1 -120>\n").arg(x_pos);
-      wirestr += QString("<%1 -120 %2 -120>\n").arg(x_pos).arg(x_pos + 120);
+      componentstr += QStringLiteral("<GND * 1 %1 0 0 0 0 0>\n").arg(x_pos);
+      wirestr += QStringLiteral("<%1 -60 %1 -120>\n").arg(x_pos);
+      wirestr += QStringLiteral("<%1 -120 %2 -120>\n").arg(x_pos).arg(x_pos + 120);
       x_pos += 120;
     } else if (!tag.compare("LBL")) // Label
     {
-      paintingstr += QString("<Text %1 -150 12 #000000 0 \"%2\">\n")
+      paintingstr += QStringLiteral("<Text %1 -150 12 #000000 0 \"%2\">\n")
                          .arg(x_pos)
                          .arg(component); // Add 'Port 1' or 'Port 2' label
       x_pos += 50;
@@ -1671,36 +1671,36 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
                                    // from P1 because of the wiring)
     {
       x_pos += 100;
-      componentstr += QString("<Pac P2 1 %2 -30 18 -26 0 1 \"1\" 1 \"%1\" 1 "
+      componentstr += QStringLiteral("<Pac P2 1 %2 -30 18 -26 0 1 \"1\" 1 \"%1\" 1 "
                               "\"0 dBm\" 0 \"1 GHz\" 0>\n")
                           .arg(misc::num2str(value, 3, "Ohm")) // reference impedance
                           .arg(x_pos);
-      componentstr += QString("<GND * 1 %1 0 0 0 0 0>\n").arg(x_pos);
-      wirestr += QString("<%1 -60 %1 -120>\n").arg(x_pos); // Vertical wire
-      wirestr += QString("<%1 -120 %2 -120>\n")
+      componentstr += QStringLiteral("<GND * 1 %1 0 0 0 0 0>\n").arg(x_pos);
+      wirestr += QStringLiteral("<%1 -60 %1 -120>\n").arg(x_pos); // Vertical wire
+      wirestr += QStringLiteral("<%1 -120 %2 -120>\n")
                      .arg(x_pos - 100)
                      .arg(x_pos);   // Horizontal wire
     } else if (!tag.compare("DEV")) // Device painting
     {
-      paintingstr += QString("<Text %1 -150 12 #000000 0 \"Device\">\n")
+      paintingstr += QStringLiteral("<Text %1 -150 12 #000000 0 \"Device\">\n")
                          .arg(x_pos + 70); // Add 'Device' label
       paintingstr +=
-          QString("<Rectangle %1 -160 90 50 #000000 0 1 #c0c0c0 1 0>\n")
+          QStringLiteral("<Rectangle %1 -160 90 50 #000000 0 1 #c0c0c0 1 0>\n")
               .arg(x_pos + 50); // Box surrounding the 'Device' label
       x_pos += 200;
     } else if (!tag.compare("LS")) // Series inductor
     {
       QString val = misc::num2str(value, 3, "H"); // Add prefix, unit - 3 significant digits
-      componentstr += QString("<L L1 1 %1 -120 -26 10 0 0 \"%2\" 1 "
+      componentstr += QStringLiteral("<L L1 1 %1 -120 -26 10 0 0 \"%2\" 1 "
                               " 0>\n")
                           .arg(x_pos + 60)
                           .arg(val);
-      wirestr += QString("<%1 -120 %2 -120 "
+      wirestr += QStringLiteral("<%1 -120 %2 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos)
                      .arg(x_pos + 30);
-      wirestr += QString("<%1 -120 %2 -120 "
+      wirestr += QStringLiteral("<%1 -120 %2 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos + 90)
@@ -1709,16 +1709,16 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
     } else if (!tag.compare("CS")) // Series capacitor
     {
       QString val = misc::num2str(value, 3, "F"); // Add prefix, unit - 3 significant digits
-      componentstr += QString("<C C1 1 %1 -120 -26 17 0 0 \"%2\" 1 "
+      componentstr += QStringLiteral("<C C1 1 %1 -120 -26 17 0 0 \"%2\" 1 "
                               " 0>\n")
                           .arg(x_pos + 60)
                           .arg(val);
-      wirestr += QString("<%1 -120 %2 -120 "
+      wirestr += QStringLiteral("<%1 -120 %2 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos)
                      .arg(x_pos + 30);
-      wirestr += QString("<%1 -120 %2 -120 "
+      wirestr += QStringLiteral("<%1 -120 %2 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos + 90)
@@ -1727,16 +1727,16 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
     } else if (!tag.compare("LP")) // Shunt inductor
     {
       QString val = misc::num2str(value, 3, "H"); // Add prefix, unit - 3 significant digits
-      componentstr += QString("<GND * 1 %1 0 0 0 0 0>\n").arg(x_pos);
-      componentstr += QString("<L L1 1 %1 -30 5 -20 0 1 \"%2\" 1 "
+      componentstr += QStringLiteral("<GND * 1 %1 0 0 0 0 0>\n").arg(x_pos);
+      componentstr += QStringLiteral("<L L1 1 %1 -30 5 -20 0 1 \"%2\" 1 "
                               " 0>\n")
                           .arg(x_pos)
                           .arg(val);
-      wirestr += QString("<%1 -60 %1 -120 "
+      wirestr += QStringLiteral("<%1 -60 %1 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos);
-      wirestr += QString("<%1 -120 %2 -120 "
+      wirestr += QStringLiteral("<%1 -120 %2 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos - 20)
@@ -1745,16 +1745,16 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
     } else if (!tag.compare("CP")) // Shunt capacitor
     {
       QString val = misc::num2str(value, 3, "F"); // Add prefix, unit - 3 significant digits
-      componentstr += QString("<GND * 1 %1 0 0 0 0 0>\n").arg(x_pos);
-      componentstr += QString("<C C1 1 %1 -30 15 -20 0 1 \"%2\" 1 "
+      componentstr += QStringLiteral("<GND * 1 %1 0 0 0 0 0>\n").arg(x_pos);
+      componentstr += QStringLiteral("<C C1 1 %1 -30 15 -20 0 1 \"%2\" 1 "
                               " 0>\n")
                           .arg(x_pos)
                           .arg(val);
-      wirestr += QString("<%1 -60 %1 -120 "
+      wirestr += QStringLiteral("<%1 -60 %1 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos);
-      wirestr += QString("<%1 -120 %2 -120 "
+      wirestr += QStringLiteral("<%1 -120 %2 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos - 20)
@@ -1771,7 +1771,7 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         QString val_length =
           misc::num2str(value2 / sqrt(er), 3, "m"); // Add prefix, unit - 3 significant digits
         componentstr +=
-            QString("<MLIN MS1 1 %3 -120 -26 20 0 0 \"Sub1\" 1 \"%1\" 1 \"%2\" "
+            QStringLiteral("<MLIN MS1 1 %3 -120 -26 20 0 0 \"Sub1\" 1 \"%1\" 1 \"%2\" "
                     "1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
                 .arg(val_width)
                 .arg(val_length)
@@ -1781,18 +1781,18 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         QString val_impedance = misc::num2str(value, 3, "Ohm");
         // Add prefix, unit - 3 significant digits
         QString val_length = misc::num2str(value2, 3, "m");
-        componentstr += QString("<TLIN Line1 1 %3 -120 -26 20 0 0 \"%1\" 1 "
+        componentstr += QStringLiteral("<TLIN Line1 1 %3 -120 -26 20 0 0 \"%1\" 1 "
                                 "\"%2\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
                             .arg(val_impedance)
                             .arg(val_length)
                             .arg(x_pos + 60);
       }
-      wirestr += QString("<%1 -120 %2 -120 "
+      wirestr += QStringLiteral("<%1 -120 %2 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos)
                      .arg(x_pos + 30);
-      wirestr += QString("<%1 -120 %2 -120 "
+      wirestr += QStringLiteral("<%1 -120 %2 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos + 90)
@@ -1809,7 +1809,7 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         // Add prefix, unit - 3 significant digits
         QString val_length = misc::num2str(value2 / sqrt(er), 3, "m");
         componentstr +=
-            QString("<MLIN MS1 1 %3 -180 30 -30 0 1 \"Sub1\" 1 \"%1\" 1 \"%2\" "
+            QStringLiteral("<MLIN MS1 1 %3 -180 30 -30 0 1 \"Sub1\" 1 \"%1\" 1 \"%2\" "
                     "1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
                 .arg(val_width)
                 .arg(val_length)
@@ -1819,17 +1819,17 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         QString val_impedance = misc::num2str(value, 3, "Ohm");
         // Add prefix, unit - 3 significant digits
         QString val_length = misc::num2str(value2, 3, "m");
-        componentstr += QString("<TLIN Line1 1 %3 -180 30 -30 0 1 \"%1\" 1 "
+        componentstr += QStringLiteral("<TLIN Line1 1 %3 -180 30 -30 0 1 \"%1\" 1 "
                                 "\"%2\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
                             .arg(val_impedance)
                             .arg(val_length)
                             .arg(x_pos);
       }
-      wirestr += QString("<%1 -150 %1 -120 "
+      wirestr += QStringLiteral("<%1 -150 %1 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos);
-      wirestr += QString("<%1 -120 %2 -120 "
+      wirestr += QStringLiteral("<%1 -120 %2 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos)
@@ -1847,7 +1847,7 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         // Add suffix mm, cm - 3 significant digits
         QString val_length = misc::num2str(value2 / sqrt(er), 3, "m");
         componentstr +=
-            QString("<MLIN MS1 1 %3 -60 -26 30 0 1 \"Sub1\" 1 \"%1\" 1 \"%2\" "
+            QStringLiteral("<MLIN MS1 1 %3 -60 -26 30 0 1 \"Sub1\" 1 \"%1\" 1 \"%2\" "
                     "1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
                 .arg(val_width)
                 .arg(val_length)
@@ -1857,17 +1857,17 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         QString val_impedance = misc::num2str(value, 3, "Ohm");
         // Add suffix mm, cm - 3 significant digits
         QString val_length = misc::num2str(value2, 3, "m");
-        componentstr += QString("<TLIN Line1 1 %3 -60 -26 30 0 1 \"%1\" 1 "
+        componentstr += QStringLiteral("<TLIN Line1 1 %3 -60 -26 30 0 1 \"%1\" 1 "
                                 "\"%2\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
                             .arg(val_impedance)
                             .arg(val_length)
                             .arg(x_pos);
       }
-      wirestr += QString("<%1 -90 %1 -120 "
+      wirestr += QStringLiteral("<%1 -90 %1 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos);
-      wirestr += QString("<%1 -120 %2 -120 "
+      wirestr += QStringLiteral("<%1 -120 %2 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos - 20)
@@ -1882,7 +1882,7 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         QString val_width = misc::num2str(width, 3, "m");
         QString val_length = misc::num2str(value2 / sqrt(er), 3, "m");
         componentstr +=
-            QString("<MLIN MS1 1 %3 -180 30 -30 0 1 \"Sub1\" 1 \"%1\" 1 \"%2\" "
+            QStringLiteral("<MLIN MS1 1 %3 -180 30 -30 0 1 \"Sub1\" 1 \"%1\" 1 \"%2\" "
                     "1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
                 .arg(val_width)
                 .arg(val_length)
@@ -1890,18 +1890,18 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
       } else {
         QString val_impedance = misc::num2str(value, 3, "Ohm");
         QString val_length = misc::num2str(value2, 3, "m");
-        componentstr += QString("<TLIN Line1 1 %3 -180 30 -30 0 1 \"%1\" 1 "
+        componentstr += QStringLiteral("<TLIN Line1 1 %3 -180 30 -30 0 1 \"%1\" 1 "
                                 "\"%2\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
                             .arg(val_impedance)
                             .arg(val_length)
                             .arg(x_pos);
       }
-      componentstr += QString("<GND * 1 %1 -210 0 0 0 2>\n").arg(x_pos);
-      wirestr += QString("<%1 -150 %1 -120 "
+      componentstr += QStringLiteral("<GND * 1 %1 -210 0 0 0 2>\n").arg(x_pos);
+      wirestr += QStringLiteral("<%1 -150 %1 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos);
-      wirestr += QString("<%1 -120 %2 -120 "
+      wirestr += QStringLiteral("<%1 -120 %2 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos)
@@ -1917,7 +1917,7 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         QString val_width = misc::num2str(width, 3, "m");
         QString val_length = misc::num2str(value2 / sqrt(er), 3, "m");
         componentstr +=
-            QString("<MLIN MS1 1 %3 -60 30 -30 0 1 \"Sub1\" 1 \"%1\" 1 \"%2\" "
+            QStringLiteral("<MLIN MS1 1 %3 -60 30 -30 0 1 \"Sub1\" 1 \"%1\" 1 \"%2\" "
                     "1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
                 .arg(val_width)
                 .arg(val_length)
@@ -1925,18 +1925,18 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
       } else {
         QString val_impedance = misc::num2str(value, 3, "Ohm");
         QString val_length = misc::num2str(value2, 3, "m");
-        componentstr += QString("<TLIN Line1 1 %3 -60 20 30 0 1 \"%1\" 1 "
+        componentstr += QStringLiteral("<TLIN Line1 1 %3 -60 20 30 0 1 \"%1\" 1 "
                                 "\"%2\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
                             .arg(val_impedance)
                             .arg(val_length)
                             .arg(x_pos);
       }
-      componentstr += QString("<GND * 1 %1 -30 0 0 0 0>\n").arg(x_pos);
-      wirestr += QString("<%1 -90 %1 -120 "
+      componentstr += QStringLiteral("<GND * 1 %1 -30 0 0 0 0>\n").arg(x_pos);
+      wirestr += QStringLiteral("<%1 -90 %1 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos);
-      wirestr += QString("<%1 -120 %2 -120 "
+      wirestr += QStringLiteral("<%1 -120 %2 -120 "
                          " 0 0 0 "
                          ">\n")
                      .arg(x_pos - 20)
@@ -1952,16 +1952,16 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
       QString val_freq_stop = misc::num2str(freq_stop, 3, "Hz");
 
       componentstr +=
-          QString("<.SP SP1 1 0 100 0 67 0 0 \"lin\" 1 \"%1\" 1 \"%2\" 1 "
+          QStringLiteral("<.SP SP1 1 0 100 0 67 0 0 \"lin\" 1 \"%1\" 1 \"%2\" 1 "
                   "\"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n")
               .arg((val_freq_start))
               .arg((val_freq_stop));
 
       if (laddercode.indexOf("P2") == -1) // One port simulation
-        componentstr += QString("<Eqn Eqn1 1 200 100 -28 15 0 0 "
+        componentstr += QStringLiteral("<Eqn Eqn1 1 200 100 -28 15 0 0 "
                                 "\"S11_dB=dB(S[1,1])\" 1 \"yes\" 0>\n");
       else // Two ports simulation
-        componentstr += QString("<Eqn Eqn1 1 200 100 -28 15 0 0 "
+        componentstr += QStringLiteral("<Eqn Eqn1 1 200 100 -28 15 0 0 "
                                 "\"S11_dB=dB(S[1,1])\" 1 \"S21_dB=dB(S[2,1])\" "
                                 "1 \"S22_dB=dB(S[2,2])\" 1 \"yes\" 0>\n");
     } else if (!tag.compare("ZL")) // Complex load
@@ -1979,11 +1979,11 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
                 "<R R1 1 %1 -30 15 -26 0 -1 \"%2\" 1 \"26.85\" 0 \"US\" 0>\n")
                 .arg(x_pos)
                 .arg(val_Res);
-        componentstr += QString("<C C1 1 %1 -90 15 -26 0 -1 \"%2\" 1 0>\n")
+        componentstr += QStringLiteral("<C C1 1 %1 -90 15 -26 0 -1 \"%2\" 1 0>\n")
                             .arg(x_pos)
                             .arg(val_Cap);
         paintingstr +=
-            QString("<Text %1 50 12 #000000 0 \"%4-j%5 %2 @ %3\">\n")
+            QStringLiteral("<Text %1 50 12 #000000 0 \"%4-j%5 %2 @ %3\">\n")
                 .arg(x_pos)
                 .arg(QChar(0x2126))
                 .arg(misc::num2str(Freq, 3, "Hz"))
@@ -1998,11 +1998,11 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
                 "<R R1 1 %1 -30 15 -26 0 -1 \"%2\" 1 \"26.85\" 0 \"US\" 0>\n")
                 .arg(x_pos)
                 .arg(val_Res);
-        componentstr += QString("<L L1 1 %1 -90 15 -26 0 -1 \"%2\" 1 0>\n")
+        componentstr += QStringLiteral("<L L1 1 %1 -90 15 -26 0 -1 \"%2\" 1 0>\n")
                             .arg(x_pos)
                             .arg(val_Ind);
         paintingstr +=
-            QString("<Text %1 50 12 #000000 0 \"%4+j%5 %2 @ %3\">\n")
+            QStringLiteral("<Text %1 50 12 #000000 0 \"%4+j%5 %2 @ %3\">\n")
                 .arg(x_pos)
                 .arg(QChar(0x2126))
                 .arg(misc::num2str(Freq, 3, "Hz"))
@@ -2016,8 +2016,8 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
                 "<R R1 1 %1 -30 15 -26 0 -1 \"%2\" 1 \"26.85\" 0 \"US\" 0>\n")
                 .arg(x_pos)
                 .arg(val_Res);
-        wirestr += QString("<%1 -60 %1 -120>\n").arg(x_pos); // Vertical wire
-        paintingstr += QString("<Text %1 50 12 #000000 0 \"%4 %2 @ %3\">\n")
+        wirestr += QStringLiteral("<%1 -60 %1 -120>\n").arg(x_pos); // Vertical wire
+        paintingstr += QStringLiteral("<Text %1 50 12 #000000 0 \"%4 %2 @ %3\">\n")
                            .arg(x_pos)
                            .arg(QChar(0x2126))
                            .arg(misc::num2str(Freq, 3, "Hz"))
@@ -2030,9 +2030,9 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
                 "<L L1 1 %1 -30 15 -26 0 -1 \"%2\" 1 \"26.85\" 0 \"US\" 0>\n")
                 .arg(x_pos)
                 .arg(val_Ind);
-        wirestr += QString("<%1 -60 %1 -120>\n").arg(x_pos); // Vertical wire
+        wirestr += QStringLiteral("<%1 -60 %1 -120>\n").arg(x_pos); // Vertical wire
         paintingstr +=
-            QString("<Text %1 50 12 #000000 0 \"j%4 %2 @ %3\">\n")
+            QStringLiteral("<Text %1 50 12 #000000 0 \"j%4 %2 @ %3\">\n")
                 .arg(x_pos)
                 .arg(QChar(0x2126))
                 .arg(misc::num2str(Freq, 3, "Hz"))
@@ -2046,22 +2046,22 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
                 "<C C1 1 %1 -30 15 -26 0 -1 \"%2\" 1 \"26.85\" 0 \"US\" 0>\n")
                 .arg(x_pos)
                 .arg(val_Cap);
-        wirestr += QString("<%1 -60 %1 -120>\n").arg(x_pos); // Vertical wire
+        wirestr += QStringLiteral("<%1 -60 %1 -120>\n").arg(x_pos); // Vertical wire
         paintingstr +=
-            QString("<Text %1 50 12 #000000 0 \"-j%4 %2 @ %3\">\n")
+            QStringLiteral("<Text %1 50 12 #000000 0 \"-j%4 %2 @ %3\">\n")
                 .arg(x_pos)
                 .arg(QChar(0x2126))
                 .arg(misc::num2str(Freq, 3, "Hz"))
                 .arg(fabs(XL));
       }
-      wirestr += QString("<%1 -120 %2 -120>\n")
+      wirestr += QStringLiteral("<%1 -120 %2 -120>\n")
                      .arg(x_pos - 100)
                      .arg(x_pos); // Horizontal wire
-      componentstr += QString("<GND * 1 %1 0 0 -1 0 0>\n").arg(x_pos);
+      componentstr += QStringLiteral("<GND * 1 %1 0 0 -1 0 0>\n").arg(x_pos);
 
       // Box surrounding the load
       paintingstr +=
-          QString("<Rectangle %1 -150 200 200 #000000 0 1 #c0c0c0 1 0>\n")
+          QStringLiteral("<Rectangle %1 -150 200 200 #000000 0 1 #c0c0c0 1 0>\n")
               .arg(x_pos - 30);
     }
   }
@@ -2069,7 +2069,7 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
   // Substrate
   if (microsyn)
     componentstr +=
-        QString("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" "
+        QStringLiteral("<SUBST Sub1 1 400 200 -30 24 0 0 \"%1\" 1 \"%2mm\" 1 \"%3um\" "
                 "1 \"%4\" 1 \"%5\" 1 \"%6\" 1>\n")
             .arg(Substrate.er)
             .arg(Substrate.height * 1e3)

--- a/qucs/dialogs/simmessage.cpp
+++ b/qucs/dialogs/simmessage.cpp
@@ -609,7 +609,7 @@ void SimMessage::startSimulator()
   // append process PATH
   // insert Qucs bin dir, so ASCO can find qucsator
   env.insert("PATH", env.value("PATH") + sep + QucsSettings.BinDir );
-  if (Program.endsWith(QString("asco") + executableSuffix)) {
+  if (Program.endsWith(QStringLiteral("asco") + executableSuffix)) {
 #ifdef Q_OS_UNIX
     QDir tempDir(QucsSettings.tempFilesDir.absolutePath());
     QString tmpdir = tempDir.filePath("qucs_ascodir"); // ASCO doesn't accept qucsator_rf name

--- a/qucs/dialogs/sweepdialog.cpp
+++ b/qucs/dialogs/sweepdialog.cpp
@@ -261,7 +261,7 @@ Graph* SweepDialog::setBiasPoints(QHash<QString,double> *NodeVals)
           else
             pn->Name = "0A";
       } else {
-          QString src_nam = QString("V"+pc->Name+"#branch").toLower();
+          QString src_nam = QStringLiteral("V%1#branch").arg(pc->Name).toLower();
           if (NodeVals->contains(src_nam)) {
               pn->Name = misc::num2str(NodeVals->value(src_nam))+"A";
           } else pn->Name = "0A";

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -207,7 +207,7 @@ void AbstractSpiceKernel::startNetlist(QTextStream &stream, bool xyce)
                 else continue;
                 QString ic = pw->Label->initValue;
                 if (!ic.isEmpty()) {
-                    QString ic_str = QString(".IC v(%1)=%2\n").arg(label).arg(ic);
+                    QString ic_str = QStringLiteral(".IC v(%1)=%2\n").arg(label).arg(ic);
                     stream<<ic_str;
                 }
             }
@@ -220,7 +220,7 @@ void AbstractSpiceKernel::startNetlist(QTextStream &stream, bool xyce)
                 else continue;
                 QString ic = pw->Label->initValue;
                 if (!ic.isEmpty()) {
-                    QString ic_str = QString(".IC v(%1)=%2\n").arg(label).arg(ic);
+                    QString ic_str = QStringLiteral(".IC v(%1)=%2\n").arg(label).arg(ic);
                     stream<<ic_str;
                 }
             }
@@ -274,7 +274,7 @@ void AbstractSpiceKernel::createSubNetlsit(QTextStream &stream, bool lib)
 {
     QString header;
     QString f = misc::properFileName(Sch->DocName);
-    header = QString(".SUBCKT %1 ").arg(misc::properName(f));
+    header = QStringLiteral(".SUBCKT %1 ").arg(misc::properName(f));
 
     QList< QPair<int,QString> > ports;
     if(!prepareSpiceNetlist(stream,true)) {
@@ -1277,14 +1277,14 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             if (hasDblParSweep) indep_cnt =  sim_points.count()/(swp_var_val.count()*swp_var2_val.count());
             else indep_cnt = sim_points.count()/swp_var_val.count();
             if (!indep.isEmpty()) {
-                ds_stream<<QString("<indep %1 %2>\n").arg(indep).arg(indep_cnt); // output indep var: TODO: parameter sweep
+                ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(indep).arg(indep_cnt); // output indep var: TODO: parameter sweep
                 for (int i=0;i<indep_cnt;i++) {
                     ds_stream<<QString::number(sim_points.at(i).at(0),'e',12)<<"\n";
                 }
                 ds_stream<<"</indep>\n";
             }
 
-            ds_stream<<QString("<indep %1 %2>\n").arg(swp_var).arg(swp_var_val.count());
+            ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(swp_var).arg(swp_var_val.count());
             for (const QString& val : swp_var_val) {
                 ds_stream<<val<<"\n";
             }
@@ -1292,7 +1292,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             if (indep.isEmpty()) indep = swp_var;
             else indep += " " + swp_var;
             if (hasDblParSweep) {
-                ds_stream<<QString("<indep %1 %2>\n").arg(swp_var2).arg(swp_var2_val.count());
+                ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(swp_var2).arg(swp_var2_val.count());
                 for (const QString& val : swp_var2_val) {
                     ds_stream<<val<<"\n";
                 }
@@ -1300,7 +1300,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
                 indep += " " + swp_var2;
             }
         } else if (!indep.isEmpty()) {
-            ds_stream<<QString("<indep %1 %2>\n").arg(indep).arg(sim_points.count()); // output indep var: TODO: parameter sweep
+            ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(indep).arg(sim_points.count()); // output indep var: TODO: parameter sweep
             for (auto& sim_point : sim_points) {
                 ds_stream<<QString::number(sim_point.at(0),'e',12)<<"\n";
             }
@@ -1308,8 +1308,8 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
         }
 
         for(int i=1;i<var_list.count();i++) { // output dep var
-            if (indep.isEmpty()) ds_stream<<QString("<indep %1 %2>\n").arg(var_list.at(i)).arg(sim_points.count());
-            else ds_stream<<QString("<dep %1 %2>\n").arg(var_list.at(i)).arg(indep);
+            if (indep.isEmpty()) ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(var_list.at(i)).arg(sim_points.count());
+            else ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var_list.at(i)).arg(indep);
             for (auto& sim_point : sim_points) {
                 if (isComplex) {
                     double re=sim_point.at(2*(i-1)+1);

--- a/qucs/extsimkernels/customsimdialog.cpp
+++ b/qucs/extsimkernels/customsimdialog.cpp
@@ -186,7 +186,7 @@ void CustomSimDialog::slotFindVars()
     }
 
     for(QStringList::iterator it = vars.begin();it != vars.end(); it++) {
-        if (!(it->endsWith("#branch"))) *it=QString("V(%1)").arg(*it);
+        if (!(it->endsWith("#branch"))) *it=QStringLiteral("V(%1)").arg(*it);
     }
 
 

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -78,7 +78,7 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
     bool found = findMathFuncInc(mathf_inc);
     // Let to simulate schematic without mathfunc.inc file
     if (found && QucsSettings.DefaultSimulator != spicecompat::simSpiceOpus)
-        stream<<QString(".INCLUDE \"%1\"\n").arg(mathf_inc);
+        stream<<QStringLiteral(".INCLUDE \"%1\"\n").arg(mathf_inc);
 
     stream<<collectSpiceLibs(Sch); // collect libraries on the top of netlist
     if(!prepareSpiceNetlist(stream)) return; // Unable to perform spice simulation
@@ -135,7 +135,7 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
             for(const auto &file : osdi_files) {
                 QString abs_file = QucsSettings.QucsWorkDir.absolutePath() +
                         QDir::separator() + file;
-                stream<<QString("pre_osdi '%1'\n").arg(abs_file);
+                stream<<QStringLiteral("pre_osdi '%1'\n").arg(abs_file);
             }
         }
     }
@@ -173,9 +173,9 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
         QString nods;
         for (const QString& nod : vars) {
             if ( nod.endsWith("#branch") )
-                nods.append(QString("i(%1) ").arg(nod.section('#', 0, 0)));
+                nods.append(QStringLiteral("i(%1) ").arg(nod.section('#', 0, 0)));
             else
-                nods.append(QString("v(%1) ").arg(nod));
+                nods.append(QStringLiteral("v(%1) ").arg(nod));
         }
 
         for ( unsigned int i = 0 ; i < Sch->DocComps.count() ; i++ ) {
@@ -260,8 +260,8 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
             outputs.append("spice4qucs." + sim_name + ".cir.noise");
             if ( hasParSWP ) {  // Set necessary plot number to output Noise spectrum
                 // each step of parameter sweep creates new couple of noise plots
-                spiceNetlist.append(QString("let noise_%1 = 2*%1+1\n").arg(cnt_var));
-                spiceNetlist.append(QString("setplot noise$&noise_%1\n").arg(cnt_var));
+                spiceNetlist.append(QStringLiteral("let noise_%1 = 2*%1+1\n").arg(cnt_var));
+                spiceNetlist.append(QStringLiteral("setplot noise$&noise_%1\n").arg(cnt_var));
             } else {  // Set Noise1 plot to output noise spectrum
                 spiceNetlist.append("setplot noise1\n");
             }
@@ -289,8 +289,8 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
         } else if ( sim_typ == ".FFT" ) {
             freqSims++;
             spiceNetlist.append(pc->getSpiceNetlist());
-            spiceNetlist.append(QString("linearize %1\n").arg(nods));
-            spiceNetlist.append(QString("fft %1\n").arg(nods));
+            spiceNetlist.append(QStringLiteral("linearize %1\n").arg(nods));
+            spiceNetlist.append(QStringLiteral("fft %1\n").arg(nods));
         } else if ( sim_typ == ".DC" ) {
             dcSims++;
             spiceNetlist.append(pc->getSpiceNetlist());
@@ -317,7 +317,7 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
 
         if ( sim_typ == ".DC" ) {
             QString out = "spice4qucs." + sim_name + ".ngspice.dc.print";
-            spiceNetlist.append(QString("print %1 > %2\n").arg(nods).arg(out));
+            spiceNetlist.append(QStringLiteral("print %1 > %2\n").arg(nods).arg(out));
             outputs.append(out);
         } else if ( (sim_typ != ".PZ") && (sim_typ != ".SENS") && (sim_typ != ".SENS_AC") ) {
             nods = nods.simplified();
@@ -325,13 +325,13 @@ void Ngspice::createNetlist(QTextStream &stream, int ,
                 QString basenam = "spice4qucs";
                 QString filename;
                 if ( hasParSWP && hasDblSWP )
-                    filename = QString("%1.%2._swp_swp.plot").arg(basenam).arg(sim_name);
+                    filename = QStringLiteral("%1.%2._swp_swp.plot").arg(basenam).arg(sim_name);
                 else if ( hasParSWP )
-                    filename = QString("%1.%2._swp.plot").arg(basenam).arg(sim_name);
+                    filename = QStringLiteral("%1.%2._swp.plot").arg(basenam).arg(sim_name);
                 else
-                    filename = QString("%1.%2.plot").arg(basenam).arg(sim_name);
+                    filename = QStringLiteral("%1.%2.plot").arg(basenam).arg(sim_name);
                 filename.replace(' ', '_'); // Ngspice cannot understand spaces in filename
-                spiceNetlist.append(QString("write %1 %2\n").arg(filename).arg(nods));
+                spiceNetlist.append(QStringLiteral("write %1 %2\n").arg(filename).arg(nods));
                 outputs.append(filename);
             }
         }
@@ -481,7 +481,7 @@ void Ngspice::slotSimulate()
     //startNgSpice(tmp_path);
     SimProcess->setWorkingDirectory(workdir);
     qDebug()<<workdir;
-    QString cmd = QString("\"%1\" %2 %3").arg(simulator_cmd,simulator_parameters,netfile);
+    QString cmd = QStringLiteral("\"%1\" %2 %3").arg(simulator_cmd,simulator_parameters,netfile);
     QStringList cmd_args = misc::parseCmdArgs(cmd);
     QString ngsp_cmd = cmd_args.at(0);
     cmd_args.removeAt(0);
@@ -553,7 +553,7 @@ bool Ngspice::findMathFuncInc(QString &mathf_inc)
 {
     QDir qucs_root(QucsSettings.BinDir);
     qucs_root.cdUp();
-    mathf_inc = QString("%1/share/" QUCS_NAME "/xspice_cmlib/include/ngspice_mathfunc.inc")
+    mathf_inc = QStringLiteral("%1/share/" QUCS_NAME "/xspice_cmlib/include/ngspice_mathfunc.inc")
             .arg(qucs_root.absolutePath());
     return QFile::exists(mathf_inc);
 }
@@ -596,8 +596,8 @@ void Ngspice::SaveNetlist(QString filename)
     }
     else
     {
-        QString msg=QString("Tried to save netlist \nin %1\n(could not open for writing!)").arg(filename);
-        QString final_msg=QString("%1\n This could be an error in the QSettings settings file\n(usually in ~/.config/qucs/qucs_s.conf)\nThe value for S4Q_workdir (default:/spice4qucs) needs to be writeable!\nFor a Simulation Simulation will raise error! (most likely S4Q_workdir does not exists)").arg(msg);
+        QString msg=QStringLiteral("Tried to save netlist \nin %1\n(could not open for writing!)").arg(filename);
+        QString final_msg=QStringLiteral("%1\n This could be an error in the QSettings settings file\n(usually in ~/.config/qucs/qucs_s.conf)\nThe value for S4Q_workdir (default:/spice4qucs) needs to be writeable!\nFor a Simulation Simulation will raise error! (most likely S4Q_workdir does not exists)").arg(msg);
         QMessageBox::critical(nullptr,tr("Problem with SaveNetlist"),final_msg,QMessageBox::Ok);
     }
 }

--- a/qucs/extsimkernels/qucs2spice.cpp
+++ b/qucs/extsimkernels/qucs2spice.cpp
@@ -157,11 +157,11 @@ QString qucs2spice::convert_diode(QString line,bool xyce)
     name =  name.right(name.size()-idx-1); // name
     QString K = lst.takeFirst();
     QString A = lst.takeFirst();
-    s += QString("D%1 %2 %3 DMOD_%4 \n").arg(name).arg(A).arg(K).arg(name);
+    s += QStringLiteral("D%1 %2 %3 DMOD_%4 \n").arg(name).arg(A).arg(K).arg(name);
     QString mod_params = lst.join(" ");
     mod_params.remove('\"');
-    if (xyce) s += QString(".MODEL DMOD_%1 D(LEVEL=2 %2) \n").arg(name).arg(mod_params);
-    else  s += QString(".MODEL DMOD_%1 D(%2) \n").arg(name).arg(mod_params);
+    if (xyce) s += QStringLiteral(".MODEL DMOD_%1 D(LEVEL=2 %2) \n").arg(name).arg(mod_params);
+    else  s += QStringLiteral(".MODEL DMOD_%1 D(%2) \n").arg(name).arg(mod_params);
     return s;
 }
 
@@ -198,11 +198,11 @@ QString qucs2spice::convert_mosfet(QString line, bool xyce)
             par_lst.append(s1); // usual parameter
         }
     }
-    s += QString("M%1 %2 %3 %4 %5 MMOD_%6 %7 %8 \n").arg(name).arg(D).arg(G).arg(S).arg(Sub)
+    s += QStringLiteral("M%1 %2 %3 %4 %5 MMOD_%6 %7 %8 \n").arg(name).arg(D).arg(G).arg(S).arg(Sub)
             .arg(name).arg(L).arg(W);
     QString mod_params = par_lst.join(" ");
     mod_params.remove('\"');
-    s += QString(".MODEL MMOD_%1 %2(%3) \n").arg(name).arg(Typ).arg(mod_params);
+    s += QStringLiteral(".MODEL MMOD_%1 %2(%3) \n").arg(name).arg(Typ).arg(mod_params);
     if (xyce) s.replace("Vt0=","VtO=");
     return s;
 }
@@ -230,10 +230,10 @@ QString qucs2spice::convert_jfet(const QString& line, bool xyce)
             par_lst.append(s1); // usual parameter
         }
     }
-    s += QString("J%1 %2 %3 %4 JMOD_%5 \n").arg(name).arg(D).arg(G).arg(S).arg(name);
+    s += QStringLiteral("J%1 %2 %3 %4 JMOD_%5 \n").arg(name).arg(D).arg(G).arg(S).arg(name);
     QString mod_params = par_lst.join(" ");
     mod_params.remove('\"');
-    s += QString(".MODEL JMOD_%1 %2(%3) \n").arg(name).arg(Typ).arg(mod_params);
+    s += QStringLiteral(".MODEL JMOD_%1 %2(%3) \n").arg(name).arg(Typ).arg(mod_params);
     if (xyce) s.replace(" Vt0="," VtO=");
     return s;
 }
@@ -272,10 +272,10 @@ QString qucs2spice::convert_bjt(const QString& line)
             if (!is_incompat) par_lst.append(s1); // usual parameter
         }
     }
-    s += QString("Q%1 %2 %3 %4 %5 QMOD_%6 \n").arg(name).arg(C).arg(B).arg(E).arg(Sub).arg(name);
+    s += QStringLiteral("Q%1 %2 %3 %4 %5 QMOD_%6 \n").arg(name).arg(C).arg(B).arg(E).arg(Sub).arg(name);
     QString mod_params = par_lst.join(" ");
     mod_params.remove('\"');
-    s += QString(".MODEL QMOD_%1 %2(%3) \n").arg(name).arg(Typ).arg(mod_params);
+    s += QStringLiteral(".MODEL QMOD_%1 %2(%3) \n").arg(name).arg(Typ).arg(mod_params);
     return s;
 }
 
@@ -306,8 +306,8 @@ QString qucs2spice::convert_ccs(const QString& line, bool voltage)
     QString s;
     if (voltage) s="H";
     else s="F";
-    s += QString("%1 %2 %3 V%4 %5\n").arg(name).arg(nod1).arg(nod2).arg(name).arg(val); // output source nodes
-    s += QString("V%1 %2 %3 DC 0\n").arg(name).arg(nod0).arg(nod3);   // controlling 0V source
+    s += QStringLiteral("%1 %2 %3 V%4 %5\n").arg(name).arg(nod1).arg(nod2).arg(name).arg(val); // output source nodes
+    s += QStringLiteral("V%1 %2 %3 DC 0\n").arg(name).arg(nod0).arg(nod3);   // controlling 0V source
     return s;
 }
 
@@ -339,7 +339,7 @@ QString qucs2spice::convert_vcs(const QString& line,bool voltage)
     QString s;
     if (voltage) s="E";
     else s="G";
-    s += QString("%1 %2 %3 %4 %5 %6\n").arg(name).arg(nod1).arg(nod2).arg(nod0).arg(nod3).arg(val);
+    s += QStringLiteral("%1 %2 %3 %4 %5 %6\n").arg(name).arg(nod1).arg(nod2).arg(nod0).arg(nod3).arg(val);
     return s;
 }
 
@@ -386,16 +386,16 @@ QString qucs2spice::convert_edd(const QString& line, QStringList &EqnsAndVars)
         QString plus = nods.at(2*i+1);
         QString minus = nods.at(2*i);
 
-        s += QString("BI%1_%2 %3 %4 I=%5\n").arg(nam).arg(i).arg(plus).arg(minus).arg(Itokens.join(""));
+        s += QStringLiteral("BI%1_%2 %3 %4 I=%5\n").arg(nam).arg(i).arg(plus).arg(minus).arg(Itokens.join(""));
         // charge part
         QString Qvar = line.section('"',2*i+3,2*i+3,QString::SectionSkipEmpty);
         QString Qeqn = EqnsAndVars.at(EqnsAndVars.indexOf(Qvar)+1);
         Qeqn.remove(' ');
         QRegularExpression zero_pattern("0+(\\.*0+|)");
         if (!zero_pattern.match(Qeqn).hasMatch()) {
-            s += QString("G%1Q%2 %3 %4 n%1Q%2 %4 1.0\n").arg(nam).arg(i).arg(plus).arg(minus);
-            s += QString("L%1Q%2 n%1Q%2 %3 1.0\n").arg(nam).arg(i).arg(minus);
-            s += QString("B%1Q%2 n%1Q%2 %3 I=-(%4)\n").arg(nam).arg(i).arg(minus).arg(Qeqn);
+            s += QStringLiteral("G%1Q%2 %3 %4 n%1Q%2 %4 1.0\n").arg(nam).arg(i).arg(plus).arg(minus);
+            s += QStringLiteral("L%1Q%2 n%1Q%2 %3 1.0\n").arg(nam).arg(i).arg(minus);
+            s += QStringLiteral("B%1Q%2 n%1Q%2 %3 I=-(%4)\n").arg(nam).arg(i).arg(minus).arg(Qeqn);
         }
     }
 
@@ -430,7 +430,7 @@ QString qucs2spice::convert_subckt(QString line)
         it++;
         QString val = (*it);
         val.remove(' ');
-        s += QString("%1=%2 ").arg(var).arg(val);
+        s += QStringLiteral("%1=%2 ").arg(var).arg(val);
     }
     s += '\n';
 
@@ -448,8 +448,8 @@ QString qucs2spice::convert_gyrator(QString line)
     QString n3 = lst.takeFirst();
     QString n4 = lst.takeFirst();
     QString R = line.section('"',1,1);
-    s +=  QString("B%1_1 %2 %3 I=(1/(%4))*(V(%5)-V(%6))\n").arg(Name).arg(n1).arg(n4).arg(R).arg(n2).arg(n3);
-    s +=  QString("B%1_2 %2 %3 I=-1.0*(1/(%4))*(V(%5)-V(%6))\n").arg(Name).arg(n2).arg(n3).arg(R).arg(n1).arg(n4);
+    s +=  QStringLiteral("B%1_1 %2 %3 I=(1/(%4))*(V(%5)-V(%6))\n").arg(Name).arg(n1).arg(n4).arg(R).arg(n2).arg(n3);
+    s +=  QStringLiteral("B%1_2 %2 %3 I=-1.0*(1/(%4))*(V(%5)-V(%6))\n").arg(Name).arg(n2).arg(n3).arg(R).arg(n1).arg(n4);
     return s;
 }
 
@@ -489,7 +489,7 @@ void qucs2spice::subsVoltages(QStringList &tokens, QStringList& nods)
             QString minus = nods.at(2*(i-1));
             //if (plus=="gnd") plus="0";
             //if (minus=="gnd") minus="0";
-            *it = QString("(V(%1)-V(%2))").arg(plus).arg(minus);
+            *it = QStringLiteral("(V(%1)-V(%2))").arg(plus).arg(minus);
         }
     }
 }

--- a/qucs/extsimkernels/s2spice.cpp
+++ b/qucs/extsimkernels/s2spice.cpp
@@ -69,7 +69,7 @@ bool S2Spice::convertTouchstone(QTextStream *stream)
     /* build first line of output file */
     (*stream) << ".SUBCKT " + device_name;
     for (int i = 0; i <= ports; i++) {
-        (*stream) << QString(" %1").arg(i+1);
+        (*stream) << QStringLiteral(" %1").arg(i+1);
     }
     (*stream) << "\n";
 
@@ -120,8 +120,8 @@ bool S2Spice::convertTouchstone(QTextStream *stream)
     /* define resistances for Spice model */
 
     for ( int i = 0; i < ports; i++ ) {
-        (*stream) << QString("R%1N %2 %3 %4\n").arg(i+1).arg(i+1).arg(10*(i+1)).arg(-z[i]);
-        (*stream) << QString("R%1P %2 %3 %4\n").arg(i+1).arg(10*(i+1)).arg(10*(i+1)+1).arg(2*z[i]);
+        (*stream) << QStringLiteral("R%1N %2 %3 %4\n").arg(i+1).arg(i+1).arg(10*(i+1)).arg(-z[i]);
+        (*stream) << QStringLiteral("R%1P %2 %3 %4\n").arg(i+1).arg(10*(i+1)).arg(10*(i+1)+1).arg(2*z[i]);
     }
     (*stream) << "\n";
 
@@ -190,15 +190,15 @@ bool S2Spice::convertTouchstone(QTextStream *stream)
             //fprintf( out, "*S%d%d FREQ " FORM  PHASE "\n", i + 1, j + 1 );
             model_cnt++;
             if ( j + 1 == ports ) {
-                (*stream) << QString("A%1%2 %vd(%6 %7) %vd(%3%4, %5) xfer%8\n")
+                (*stream) << QStringLiteral("A%1%2 %vd(%6 %7) %vd(%3%4, %5) xfer%8\n")
                         .arg(i+1).arg(j+1).arg(i+1).arg(j+1).arg(ports + 1).arg(10 * (j + 1))
                          .arg(ports + 1).arg(model_cnt);
             } else {
-                (*stream) << QString("A%1%2 %vd(%7 %8) %vd(%3%4, %5%6) xfer%9\n")
+                (*stream) << QStringLiteral("A%1%2 %vd(%7 %8) %vd(%3%4, %5%6) xfer%9\n")
                         .arg(i + 1).arg(j + 1).arg(i + 1).arg(j + 1).arg(i + 1)
                         .arg(j + 2).arg(10 * (j + 1)).arg(ports + 1).arg(model_cnt);
             }
-            (*stream) << QString(".model xfer%1 xfer R_I=true table=[\n").arg(model_cnt);
+            (*stream) << QStringLiteral(".model xfer%1 xfer R_I=true table=[\n").arg(model_cnt);
 
             offset = 0;
             for ( f = 0; f < numf; f++ )
@@ -214,7 +214,7 @@ bool S2Spice::convertTouchstone(QTextStream *stream)
                     ph = a * sin(b * pi / 180);
                     mag = a * cos(b * pi / 180);
                 }
-                (*stream) << QString("+ %1Hz %2 %3\n").arg(freqs[f] * funits).arg(mag).arg(ph + offset);
+                (*stream) << QStringLiteral("+ %1Hz %2 %3\n").arg(freqs[f] * funits).arg(mag).arg(ph + offset);
             }
             (*stream) << "+ ]\n\n";
         }

--- a/qucs/extsimkernels/spicecompat.cpp
+++ b/qucs/extsimkernels/spicecompat.cpp
@@ -241,8 +241,8 @@ void spicecompat::convertNodeNames(QStringList &tokens, QString &sim)
                 auto cnt = it->size();
                 it->chop(cnt-idx);
                 if (suffix.toUpper().startsWith("I"))
-                    *it = QString("V%1#branch").arg(*it);
-                else *it = QString("V(%2)").arg(*it);
+                    *it = QStringLiteral("V%1#branch").arg(*it);
+                else *it = QStringLiteral("V(%2)").arg(*it);
             }
         } else if ((*it=="frequency")||(*it=="acfrequency")) {
             sim = "ac";
@@ -253,7 +253,7 @@ void spicecompat::convertNodeNames(QStringList &tokens, QString &sim)
 }
 
 QString spicecompat::normalize_node_name(QString nod) {
-    return (nod == "gnd") ? QString("0") : nod;
+    return (nod == "gnd") ? QStringLiteral("0") : nod;
 }
 
 /*
@@ -342,8 +342,8 @@ QString spicecompat::getSubcktName(const QString& subfilename)
  */
 QString spicecompat::convert_sweep_type(const QString& sweep)
 {
-    if (sweep=="lin") return QString("lin");
-    if (sweep=="log") return QString("dec");
+    if (sweep=="lin") return QStringLiteral("lin");
+    if (sweep=="log") return QStringLiteral("dec");
     return QString();
 }
 

--- a/qucs/extsimkernels/verilogawriter.cpp
+++ b/qucs/extsimkernels/verilogawriter.cpp
@@ -56,10 +56,10 @@ QString vacompat::normalize_voltage(QString &plus, QString &minus, bool left_sid
 {
     QString s;
     if (plus=="gnd") {
-        if (left_side) s = QString("V(%1)").arg(minus);
-        else s = QString("(-V(%1))").arg(minus);
-    } else if (minus=="gnd") s = QString("V(%1)").arg(plus);
-    else s = QString("V(%1,%2)").arg(plus).arg(minus);
+        if (left_side) s = QStringLiteral("V(%1)").arg(minus);
+        else s = QStringLiteral("(-V(%1))").arg(minus);
+    } else if (minus=="gnd") s = QStringLiteral("V(%1)").arg(plus);
+    else s = QStringLiteral("V(%1,%2)").arg(plus).arg(minus);
     return s;
 }
 
@@ -67,10 +67,10 @@ QString vacompat::normalize_current(QString &plus, QString &minus, bool left_sid
 {
     QString s;
     if (plus=="gnd") {
-        if (left_side) s = QString("I(%1)").arg(minus);
-       else s = QString("(-I(%1))").arg(minus);
-    } else if (minus=="gnd") s = QString("I(%1)").arg(plus);
-    else s = QString("I(%1,%2)").arg(plus).arg(minus);
+        if (left_side) s = QStringLiteral("I(%1)").arg(minus);
+       else s = QStringLiteral("(-I(%1))").arg(minus);
+    } else if (minus=="gnd") s = QStringLiteral("I(%1)").arg(plus);
+    else s = QStringLiteral("I(%1,%2)").arg(plus).arg(minus);
     return s;
 }
 
@@ -179,9 +179,9 @@ bool VerilogAwriter::createVA_module(QTextStream &stream, Schematic *sch)
     base.remove('-').remove(' ');
     nodes.removeAll("gnd"); // Exclude ground node
 
-    stream<<QString("module %1(%2);\n").arg(base).arg(ports.join(", "));
-    stream<<QString("inout %1;\n").arg(ports.join(", "));
-    stream<<QString("electrical %1;\n").arg(nodes.join(", "));
+    stream<<QStringLiteral("module %1(%2);\n").arg(base).arg(ports.join(", "));
+    stream<<QStringLiteral("inout %1;\n").arg(ports.join(", "));
+    stream<<QStringLiteral("electrical %1;\n").arg(nodes.join(", "));
 
     Painting *pi; // Find module parameters
     for(pi = sch->SymbolPaints.first(); pi != 0; pi = sch->SymbolPaints.next())

--- a/qucs/extsimkernels/xyce.cpp
+++ b/qucs/extsimkernels/xyce.cpp
@@ -149,7 +149,7 @@ void Xyce::createNetlist(QTextStream &stream, int , QStringList &simulations,
     nods.clear();
     for (auto& nod :vars) {
         if (!nod.startsWith("I(")) {
-            nods += QString("v(%1) ").arg(nod);
+            nods += QStringLiteral("v(%1) ").arg(nod);
         } else {
             nods += nod + " ";
         }
@@ -157,7 +157,7 @@ void Xyce::createNetlist(QTextStream &stream, int , QStringList &simulations,
 
     if (DC_OP_only) {
         stream<<".OP\n";
-        stream<<QString(".PRINT dc format=noindex file=spice4qucs.cir.dc_op_xyce %1\n").arg(nods);
+        stream<<QStringLiteral(".PRINT dc format=noindex file=spice4qucs.cir.dc_op_xyce %1\n").arg(nods);
         outputs.append("spice4qucs.cir.dc_op_xyce");
         return;
     }
@@ -236,17 +236,17 @@ void Xyce::createNetlist(QTextStream &stream, int , QStringList &simulations,
     }
 
     QString filename;
-    if (hasParSweep) filename = QString("%1.%2._swp.plot").arg(basenam).arg(sim);
-    else filename = QString("%1.%2.plot").arg(basenam).arg(sim);
+    if (hasParSweep) filename = QStringLiteral("%1.%2._swp.plot").arg(basenam).arg(sim);
+    else filename = QStringLiteral("%1.%2.plot").arg(basenam).arg(sim);
     filename.remove(QRegularExpression("\\s")); // XYCE don't support spaces and quotes
     QString write_str;
     if (sim=="hb") {
-        // write_str = QString(".PRINT  %1 file=%2 %3\n").arg(sim).arg(filename).arg(nods);
-        write_str = QString(".PRINT  %1 %2\n").arg(sim).arg(nods);
+        // write_str = QStringLiteral(".PRINT  %1 file=%2 %3\n").arg(sim).arg(filename).arg(nods);
+        write_str = QStringLiteral(".PRINT  %1 %2\n").arg(sim).arg(nods);
         outputs.append("spice4qucs.hb.cir.HB.FD.prn");
     } else if (sim=="noise") {
         filename += "_std";
-        write_str = QString(".PRINT noise file=%1 inoise onoise\n").arg(filename);
+        write_str = QStringLiteral(".PRINT noise file=%1 inoise onoise\n").arg(filename);
         outputs.append(filename);
     } else if (sim=="sens") {
         write_str.clear();
@@ -260,7 +260,7 @@ void Xyce::createNetlist(QTextStream &stream, int , QStringList &simulations,
         if (hasParSweep) {
             for (const auto &v: spar_vars) { // Bug in Xyce; cannot print Z-par if
                  // .STEP is activated; otherwise simulation error
-                if ( !v.startsWith("z(")) write_str += QString("%1 ").arg(v);
+                if ( !v.startsWith("z(")) write_str += QStringLiteral("%1 ").arg(v);
             }
         } else {
             write_str += spar_vars.join(" ");
@@ -268,7 +268,7 @@ void Xyce::createNetlist(QTextStream &stream, int , QStringList &simulations,
         write_str += "\n";
         outputs.append("spice4qucs_sparam.prn");
     } else {
-        write_str = QString(".PRINT  %1 format=raw file=%2 %3\n").arg(sim).arg(filename).arg(nods);
+        write_str = QStringLiteral(".PRINT  %1 format=raw file=%2 %3\n").arg(sim).arg(filename).arg(nods);
         outputs.append(filename);
     }
     stream<<write_str;
@@ -424,7 +424,7 @@ void Xyce::nextSimulation()
         QString file = netlistQueue.takeFirst();
         if (file.endsWith(".noise.cir")) Noisesim = true;
         SimProcess->setWorkingDirectory(workdir);
-        QString cmd = QString("%1 %2 \"%3\"").arg(simulator_cmd,simulator_parameters,file);
+        QString cmd = QStringLiteral("%1 %2 \"%3\"").arg(simulator_cmd,simulator_parameters,file);
         QStringList cmd_args = misc::parseCmdArgs(cmd);
         QString xyce_cmd = cmd_args.at(0);
         cmd_args.removeAt(0);
@@ -445,7 +445,7 @@ void Xyce::setParallel(bool par)
         QString xyce_par = QucsSettings.XyceParExecutable;
         xyce_par.replace("%p",QString::number(QucsSettings.NProcs));
         simulator_cmd = xyce_par;
-        simulator_parameters = simulator_parameters + QString(" -a ");
+        simulator_parameters = simulator_parameters + QStringLiteral(" -a ");
     } else {
         simulator_cmd = "\"" + QucsSettings.XyceExecutable + "\"";
         simulator_parameters = simulator_parameters + " -a ";

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -657,9 +657,9 @@ void createDocData() {
         compData << "Category; "          + category;
 
         // 001_data.csv - CSV file with component data
-        QString ID = QString("%1").arg(num,3,'d',0,'0');
+        QString ID = QStringLiteral("%1").arg(num,3,'d',0,'0');
         QString objDataFile;
-        objDataFile = QString("%1_data.csv").arg( ID  ) ;
+        objDataFile = QStringLiteral("%1_data.csv").arg( ID  ) ;
 
         QFile file(curDir + objDataFile);
         if (!file.open(QFile::WriteOnly | QFile::Text)) return;
@@ -670,9 +670,9 @@ void createDocData() {
 
         QStringList compProps;
         compProps << "# Note: auto-generated file (changes will be lost on update)";
-        compProps << QString("# %1; %2; %3; %4").arg(  "Name", "Value", "Display", "Description");
+        compProps << QStringLiteral("# %1; %2; %3; %4").arg(  "Name", "Value", "Display", "Description");
         for (Property *prop : c->Props) {
-          compProps << QString("%1; \"%2\"; %3; \"%4\"").arg(
+          compProps << QStringLiteral("%1; \"%2\"; %3; \"%4\"").arg(
                          prop->Name,
                          prop->Value,
                          prop->display?"yes":"no",
@@ -680,7 +680,7 @@ void createDocData() {
         }
 
         // 001_props.csv - CSV file with component properties
-        QString objPropFile = QString("%1_prop.csv").arg( ID ) ;
+        QString objPropFile = QStringLiteral("%1_prop.csv").arg( ID ) ;
 
         QFile fileProps(curDir + objPropFile );
         if (!fileProps.open(QFile::WriteOnly | QFile::Text)) return;
@@ -898,7 +898,7 @@ int main(int argc, char *argv[])
       lang = loc.name();
 //    lang = QTextCodec::locale();
   }
-  tor.load( QString("qucs_") + lang, QucsSettings.LangDir);
+  tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir);
   QApplication::installTranslator( &tor );
 
   // This seems to be necessary on a few system to make strtod()

--- a/qucs/misc.cpp
+++ b/qucs/misc.cpp
@@ -41,7 +41,7 @@
 
 QString misc::getWindowTitle()
 {
-    QString title = QString("%1 %2").arg(QUCS_NAME,PACKAGE_VERSION);
+    QString title = QStringLiteral("%1 %2").arg(QUCS_NAME,PACKAGE_VERSION);
     if (title.endsWith(".0")) {
         title.chop(2);
     }
@@ -152,7 +152,7 @@ QString misc::StringNum(double num, char form, int Precision)
 QString misc::StringNiceNum(double num)
 {
   char Format[6] = "%.8e";
-  if(fabs(num) < 1e-250)  return QString("0");  // avoid many problems
+  if(fabs(num) < 1e-250)  return QStringLiteral("0");  // avoid many problems
   if(fabs(log10(fabs(num))) < 3.0)  Format[3] = 'g';
 
   int a = 0;
@@ -745,7 +745,7 @@ bool VersionTriplet::operator<=(const VersionTriplet& v2) {
 }
 
 QString VersionTriplet::toString() {
-  return QString("%1.%2.%3").arg(major).arg(minor).arg(patch);
+  return QStringLiteral("%1.%2.%3").arg(major).arg(minor).arg(patch);
 }
 
 // This function can parse TeX sequences _{…} and ^{…} in given string and

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1091,7 +1091,7 @@ void MouseActions::MPressSelect(Schematic *Doc, QMouseEvent *Event, float fX, fl
     if (focusElement)
         // print define value in hex, see element.h
         qDebug() << "MPressSelect: focusElement->Type"
-                 << QString("0x%1").arg(focusElement->Type, 0, 16);
+                 << QStringLiteral("0x%1").arg(focusElement->Type, 0, 16);
     else
         qDebug() << "MPressSelect";
 
@@ -2268,7 +2268,7 @@ void MouseActions::MPressTune(Schematic *Doc, QMouseEvent *Event, float fX, floa
     if (focusElement)
         // print define value in hex, see element.h
         qDebug() << "MPressTune: focusElement->Type"
-                 << QString("0x%1").arg(focusElement->Type, 0, 16);
+                 << QStringLiteral("0x%1").arg(focusElement->Type, 0, 16);
     else
         qDebug() << "MPressTune";
 

--- a/qucs/paintings/arrow.cpp
+++ b/qucs/paintings/arrow.cpp
@@ -197,7 +197,7 @@ QString Arrow::saveJSON()
 {
   // arrow not allowed in symbols, thus we use line here
   QString s =
-    QString("{\"type\" : \"arrow\", "
+    QStringLiteral("{\"type\" : \"arrow\", "
        "\"x1\" : %1, \"y1\" : %2, \"x2\" : %3, \"y2\" : %4, "
        "\"color\" : \"%5\", \"thick\" : %6, \"style\" : \"%7\"},").
        arg(cx+x1).arg(cy+y1).arg(cx+x2).arg(cy+y2).

--- a/qucs/paintings/ellipse.cpp
+++ b/qucs/paintings/ellipse.cpp
@@ -201,7 +201,7 @@ QString qucs::Ellipse::saveJSON()
     QString ("\"colorfill\" : \"%1\", \"stylefill\" : \"%2\"").
     arg(Brush.color().name()).arg(toBrushString(Brush.style())) : "";
   QString s =
-    QString("{\"type\" : \"ellipse\", "
+    QStringLiteral("{\"type\" : \"ellipse\", "
     "\"x\" : %1, \"y\" : %2, \"w\" : %3, \"h\" : %4,"
     "\"color\" : \"%5\", \"thick\" : %6, \"style\" : \"%7\", %8},").
     arg(cx).arg(cy).arg(x2).arg(y2).

--- a/qucs/paintings/graphictext.cpp
+++ b/qucs/paintings/graphictext.cpp
@@ -180,7 +180,7 @@ QString GraphicText::saveCpp()
     QString t = Text;
     misc::convert2ASCII(t);
 
-    QString s = QString("new Text (%1, %2, \"%3\", QColor (\"%4\"), %5, %6, %7)")
+    QString s = QStringLiteral("new Text (%1, %2, \"%3\", QColor (\"%4\"), %5, %6, %7)")
                     .arg(cx)
                     .arg(cy)
                     .arg(t)
@@ -197,7 +197,7 @@ QString GraphicText::saveJSON()
     QString t = Text;
     misc::convert2ASCII(t);
 
-    QString s = QString("{\"type\" : \"graphictext\", "
+    QString s = QStringLiteral("{\"type\" : \"graphictext\", "
                         "\"x\" : %1, \"y\" : %2, \"s\" : \"%3\", "
                         "\"color\" : \"%4\", \"size\" : %5, \"cos\" : %6, \"sin\" : %7},")
                     .arg(cx)

--- a/qucs/paintings/rectangle.cpp
+++ b/qucs/paintings/rectangle.cpp
@@ -201,7 +201,7 @@ QString qucs::Rectangle::saveJSON()
     arg(Brush.color().name()).arg(toBrushString(Brush.style())) : "";
 
   QString s =
-    QString("{\"type\" : \"rectangle\", "
+    QStringLiteral("{\"type\" : \"rectangle\", "
       "\"x\" : %1, \"y\" : %2, \"w\" : %3, \"h\" : %4, "
       "\"color\" : \"%5\", \"thick\" : %6, \"style\" : \"%7\", %8},").
       arg(cx).arg(cy).arg(x2).arg(y2).

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -131,7 +131,7 @@ QucsApp::QucsApp()
     tr("Verilog Sources") + " (*.v);;" +
     tr("Verilog-A Sources") + " (*.va);;" +
     tr("Octave Scripts") + " (*.m *.oct);;" +
-    tr("Spice Files") + QString(" (") + QucsSettings.spiceExtensions.join(" ") + QString(");;") +
+    tr("Spice Files") + QStringLiteral(" (") + QucsSettings.spiceExtensions.join(" ") + QStringLiteral(");;") +
     tr("Any File")+" (*)";
 
   //updateSchNameHash();
@@ -265,7 +265,7 @@ void QucsApp::initView()
   // set application icon
   // APPLE sets the QApplication icon with Info.plist
 #ifndef __APPLE__
-  setWindowIcon (QPixmap(QString(":/bitmaps/hicolor/scalable/apps/qucs.svg")));
+  setWindowIcon (QPixmap(QStringLiteral(":/bitmaps/hicolor/scalable/apps/qucs.svg")));
 #else
   // setUnifiedTitleAndToolBarOnMac(true);
   setStyleSheet("QToolButton { padding: 0px; }");
@@ -1271,7 +1271,7 @@ void QucsApp::slotCMenuCopy()
 
   if(ok && !s.isEmpty()) {
     if (!s.endsWith(suffix)) {
-      s += QString(".") + suffix;
+      s += QStringLiteral(".") + suffix;
     }
 
     if (QFile::exists(dir.filePath(s))) {  //check New Name exists
@@ -1321,7 +1321,7 @@ void QucsApp::slotCMenuRename()
 
   if(ok && !s.isEmpty()) { 
     if (!s.endsWith(suffix)) {
-      s += QString(".") + suffix;
+      s += QStringLiteral(".") + suffix;
     }
     QDir dir(QucsSettings.QucsWorkDir.path());
     if(!dir.rename(filename, s)) {
@@ -3621,7 +3621,7 @@ void QucsApp::slotBuildVAModule()
             messageDock->builderTabs->setTabText(0,tr("XSPICE"));
             messageDock->builderTabs->setTabIcon(1,QPixmap());
             messageDock->admsOutput->
-                    insertPlainText(QString("Creating XSPICE source file: %1\n").arg(filename));
+                    insertPlainText(QStringLiteral("Creating XSPICE source file: %1\n").arg(filename));
             errs += cmgen->getLog();
             if (errs.isEmpty()) {
                 messageDock->admsOutput->insertPlainText(tr("Success!\n"));

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -1022,7 +1022,7 @@ void QucsApp::slotAddToProject()
 
 
   QStringList List = QFileDialog::getOpenFileNames(this, tr("Select files to copy"),
-    lastDir.isEmpty() ? QString(".") : lastDir, QucsFileFilter);
+    lastDir.isEmpty() ? QStringLiteral(".") : lastDir, QucsFileFilter);
 
   if(List.isEmpty()) {
     statusBar()->showMessage(tr("No files copied."), 2000);
@@ -1360,12 +1360,12 @@ void QucsApp::slotExportGraphAsCsv()
   }
 
   /*QString s = Q3FileDialog::getSaveFileName(
-     lastDir.isEmpty() ? QString(".") : lastDir,
+     lastDir.isEmpty() ? QStringLiteral(".") : lastDir,
      tr("CSV file")+" (*.csv);;" + tr("Any File")+" (*)",
      this, 0, tr("Enter an Output File Name"));
      */
   QString s = QFileDialog::getSaveFileName(this, tr("Enter an Output File Name"),
-    lastDir.isEmpty() ? QString(".") : lastDir, tr("CSV file")+" (*.csv);;" + tr("Any File")+" (*)");
+    lastDir.isEmpty() ? QStringLiteral(".") : lastDir, tr("CSV file")+" (*.csv);;" + tr("Any File")+" (*)");
 
   if(s.isEmpty())
     return;
@@ -1611,16 +1611,16 @@ void QucsApp::slotBuildModule()
     // admsXml emits C++
     QStringList Arguments;
     Arguments << "-f" <<  QDir::toNativeSeparators(include.absoluteFilePath("va2cpp.makefile"))
-              << QString("ADMSXML=%1").arg(admsXml)
-              << QString("PREFIX=%1").arg(QDir::toNativeSeparators(prefix.absolutePath()))
-              << QString("MODEL=%1").arg(vaModule);
+              << QStringLiteral("ADMSXML=%1").arg(admsXml)
+              << QStringLiteral("PREFIX=%1").arg(QDir::toNativeSeparators(prefix.absolutePath()))
+              << QStringLiteral("MODEL=%1").arg(vaModule);
 
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     env.insert("PATH", env.value("PATH") );
     builder->setProcessEnvironment(env);
 
     // prepend command to log
-    QString cmdString = QString("%1 %2\n").arg(make, Arguments.join(" "));
+    QString cmdString = QStringLiteral("%1 %2\n").arg(make, Arguments.join(" "));
     messageDock->admsOutput->appendPlainText(cmdString);
 
     qDebug() << "Command :" << make << Arguments.join(" ");
@@ -1643,12 +1643,12 @@ void QucsApp::slotBuildModule()
     Arguments.clear();
 
     Arguments << "-f" <<  QDir::toNativeSeparators(include.absoluteFilePath("cpp2lib.makefile"))
-              << QString("PREFIX=\"%1\"").arg(QDir::toNativeSeparators(prefix.absolutePath()))
-              << QString("PROJDIR=\"%1\"").arg(QDir::toNativeSeparators(workDir))
-              << QString("MODEL=%1").arg(vaModule);
+              << QStringLiteral("PREFIX=\"%1\"").arg(QDir::toNativeSeparators(prefix.absolutePath()))
+              << QStringLiteral("PROJDIR=\"%1\"").arg(QDir::toNativeSeparators(workDir))
+              << QStringLiteral("MODEL=%1").arg(vaModule);
 
     // prepend command to log
-    cmdString = QString("%1 %2\n").arg(make, Arguments.join(" "));
+    cmdString = QStringLiteral("%1 %2\n").arg(make, Arguments.join(" "));
     messageDock->cppOutput->appendPlainText(cmdString);
 
     builder->start(make, Arguments);
@@ -1702,7 +1702,7 @@ void QucsApp::buildWithOpenVAF()
     builder->setProcessEnvironment(env);
 
     // prepend command to log
-    QString cmdString = QString("%1 %2\n").arg(openVAF, Arguments.join(" "));
+    QString cmdString = QStringLiteral("%1 %2\n").arg(openVAF, Arguments.join(" "));
     messageDock->admsOutput->appendPlainText(cmdString);
 
     qDebug() << "Command :" << openVAF << Arguments.join(" ");

--- a/qucs/qucslib_common.h
+++ b/qucs/qucslib_common.h
@@ -406,11 +406,11 @@ inline int parseSPICEComponentLibrary (QString libPath, ComponentLibrary &librar
             ComponentLibraryItem comp;
             comp.name = lin.section(" ",1,1,QString::SectionSkipEmpty);
             // Form fake component definition
-            comp.modelString = QString("<SpLib X1 1 280 260 -29 -164 0 0 \"%1\" 0 \"%2\" 1 \"auto\" 1 \"%3\" 1>")
+            comp.modelString = QStringLiteral("<SpLib X1 1 280 260 -29 -164 0 0 \"%1\" 0 \"%2\" 1 \"auto\" 1 \"%3\" 1>")
                     .arg(filename).arg(comp.name).arg(pars);
-            comp.definition += QString("<Component %1>\n").arg(comp.name);
+            comp.definition += QStringLiteral("<Component %1>\n").arg(comp.name);
             comp.definition += "<Description>\n";
-            comp.definition += QString("%1 device from %2 library").arg(comp.name).arg(library.name);
+            comp.definition += QStringLiteral("%1 device from %2 library").arg(comp.name).arg(library.name);
             comp.definition += "</Description>\n";
             comp.definition += "<Spice>\n";
             comp.definition += lin + "\n.ends\n";
@@ -448,22 +448,22 @@ inline int parseSPICEComponentLibrary (QString libPath, ComponentLibrary &librar
             ComponentLibraryItem comp;
             comp.name = lin.section(" ",1,1,QString::SectionSkipEmpty);
             // Form fake component definition
-            QString m_str = QString("M_%1_1").arg(comp.name);
-            comp.modelString = QString("<SpiceModel %1 1 250 290 -29 17 0 0").arg(m_str); // .MODEL start
+            QString m_str = QStringLiteral("M_%1_1").arg(comp.name);
+            comp.modelString = QStringLiteral("<SpiceModel %1 1 250 290 -29 17 0 0").arg(m_str); // .MODEL start
             int lin_cnt = 0;
             QString visible = "1";
             for (const auto &p: mod_lines) {
-                if (lin_cnt>3) comp.modelString += QString(" \"Line_%1=%2\" %3")
+                if (lin_cnt>3) comp.modelString += QStringLiteral(" \"Line_%1=%2\" %3")
                         .arg(lin_cnt+1).arg(p).arg(visible);
-                else comp.modelString += QString(" \"%1\" %2").arg(p).arg(visible);
+                else comp.modelString += QStringLiteral(" \"%1\" %2").arg(p).arg(visible);
                 lin_cnt++;
                 visible = "0";
             }
             comp.modelString += ">";
 
-            comp.definition += QString("<Component %1>\n").arg(comp.name);
+            comp.definition += QStringLiteral("<Component %1>\n").arg(comp.name);
             comp.definition += "<Description>\n";
-            comp.definition += QString("%1 model from %2 library\n"
+            comp.definition += QStringLiteral("%1 model from %2 library\n"
                                        "This component is model-only (.MODEL).\n"
                                        "No subcircuit definition!\n"
                                        "Use appropriate device to attach this model.").arg(comp.name).arg(library.name);

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -323,21 +323,21 @@ int Schematic::savePropsJSON()
 
     stream << "{\n";
 
-    stream << QString("  \"description\" : \"%1 verilog device\",\n").arg(module);
+    stream << QStringLiteral("  \"description\" : \"%1 verilog device\",\n").arg(module);
     stream << "  \"property\" : [\n";
     auto name = prop_name.begin();
     auto val = prop_val.begin();
     for(; name != prop_name.end(); name++,val++) {
-      stream << QString("    { \"name\" : \"%1\", \"value\" : \"%2\", \"display\" : \"false\", \"desc\" : \"-\"},\n")
+      stream << QStringLiteral("    { \"name\" : \"%1\", \"value\" : \"%2\", \"display\" : \"false\", \"desc\" : \"-\"},\n")
                     .arg(*name,*val);
     }
     stream << "  ],\n\n";
     stream << "  \"tx\" : 4,\n";
     stream << "  \"ty\" : 4,\n";
-    stream << QString("  \"Model\" : \"%1\",\n").arg(module);
+    stream << QStringLiteral("  \"Model\" : \"%1\",\n").arg(module);
     stream << "  \"NetName\" : \"T\",\n\n\n";
-    stream << QString("  \"SymName\" : \"%1\",\n").arg(module);
-    stream << QString("  \"BitmapFile\" : \"%1\",\n").arg(module);
+    stream << QStringLiteral("  \"SymName\" : \"%1\",\n").arg(module);
+    stream << QStringLiteral("  \"BitmapFile\" : \"%1\",\n").arg(module);
 
     stream << "}";
 
@@ -443,23 +443,23 @@ int Schematic::savePropsJSON()
 
     stream << "{\n";
 
-    stream << QString("  \"description\" : \"%1 verilog device\",\n").arg(module);
+    stream << QStringLiteral("  \"description\" : \"%1 verilog device\",\n").arg(module);
     stream << "  \"property\" : [\n";
     auto name = prop_name.begin();
     auto val = prop_val.begin();
     auto disp = prop_disp.begin();
     auto desc = prop_desc.begin();
     for(; name != prop_name.end(); name++,val++,disp++,desc++) {
-      stream << QString("    { \"name\" : \"%1\", \"value\" : \"%2\", \"display\" : \"%3\", \"desc\" : \"%4\"},\n")
+      stream << QStringLiteral("    { \"name\" : \"%1\", \"value\" : \"%2\", \"display\" : \"%3\", \"desc\" : \"%4\"},\n")
                     .arg(*name,*val,*disp,*desc);
     }
     stream << "  ],\n\n";
     stream << "  \"tx\" : 4,\n";
     stream << "  \"ty\" : 4,\n";
-    stream << QString("  \"Model\" : \"%1\",\n").arg(module);
+    stream << QStringLiteral("  \"Model\" : \"%1\",\n").arg(module);
     stream << "  \"NetName\" : \"T\",\n\n\n";
-    stream << QString("  \"SymName\" : \"%1\",\n").arg(module);
-    stream << QString("  \"BitmapFile\" : \"%1\",\n").arg(module);
+    stream << QStringLiteral("  \"SymName\" : \"%1\",\n").arg(module);
+    stream << QStringLiteral("  \"BitmapFile\" : \"%1\",\n").arg(module);
 
     stream << "}";
 
@@ -711,12 +711,12 @@ int Schematic::saveDocument()
           // how to capture [warning]? need to modify admsXml?
           // TODO put stdout, stderr into a dock window, not messagebox
           if (!builder.waitForFinished()) {
-            QString cmdString = QString("%1 %2\n\n").arg(admsXml, Arguments.join(" "));
+            QString cmdString = QStringLiteral("%1 %2\n\n").arg(admsXml, Arguments.join(" "));
             cmdString = cmdString + builder.errorString();
             QMessageBox::critical(this, tr("Error"), cmdString);
           }
           else {
-            QString cmdString = QString("%1 %2\n\n").arg(admsXml, Arguments.join(" "));
+            QString cmdString = QStringLiteral("%1 %2\n\n").arg(admsXml, Arguments.join(" "));
             cmdString = cmdString + builder.readAll();
             QMessageBox::information(this, tr("Status"), cmdString);
           }
@@ -2053,7 +2053,7 @@ bool Schematic::createSubNetlist(QTextStream *stream, int& countInit,
       AbstractSpiceKernel *kern = new AbstractSpiceKernel(this);
       QStringList err_lst;
       if (!kern->checkSchematic(err_lst)) {
-          QString s = QString("Subcircuit %1 contains SPICE-incompatible components.\n"
+          QString s = QStringLiteral("Subcircuit %1 contains SPICE-incompatible components.\n"
                               "Check these components: %2 \n")
                   .arg(this->DocName).arg(err_lst.join("; "));
           ErrText->insertPlainText(s);

--- a/qucs/spicecomponents/BJT_SPICE.cpp
+++ b/qucs/spicecomponents/BJT_SPICE.cpp
@@ -202,11 +202,11 @@ QString BJT_SPICE::spice_netlist(bool)
     QString Q_Line_4= Props.at(6)->Value;
     QString Q_Line_5= Props.at(7)->Value;
 
-    if(  Q.length()  > 0)          s += QString("%1").arg(Q);
-    if(  Q_Line_2.length() > 0 )   s += QString("\n%1").arg(Q_Line_2);
-    if(  Q_Line_3.length() > 0 )   s += QString("\n%1").arg(Q_Line_3);
-    if(  Q_Line_4.length() > 0 )   s += QString("\n%1").arg(Q_Line_4);
-    if(  Q_Line_5.length() > 0 )   s += QString("\n%1").arg(Q_Line_5);
+    if(  Q.length()  > 0)          s += QStringLiteral("%1").arg(Q);
+    if(  Q_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(Q_Line_2);
+    if(  Q_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(Q_Line_3);
+    if(  Q_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(Q_Line_4);
+    if(  Q_Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(Q_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/C_SPICE.cpp
+++ b/qucs/spicecomponents/C_SPICE.cpp
@@ -125,11 +125,11 @@ QString C_SPICE::spice_netlist(bool)
     QString C_Line_4= Props.at(3)->Value;
     QString C_Line_5= Props.at(4)->Value;
 
-    if(  C.length()  > 0)          s += QString("%1").arg(C);
-    if(  C_Line_2.length() > 0 )   s += QString("\n%1").arg(C_Line_2);
-    if(  C_Line_3.length() > 0 )   s += QString("\n%1").arg(C_Line_3);
-    if(  C_Line_4.length() > 0 )   s += QString("\n%1").arg(C_Line_4);
-    if(  C_Line_5.length() > 0 )   s += QString("\n%1").arg(C_Line_5);
+    if(  C.length()  > 0)          s += QStringLiteral("%1").arg(C);
+    if(  C_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(C_Line_2);
+    if(  C_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(C_Line_3);
+    if(  C_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(C_Line_4);
+    if(  C_Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(C_Line_5);
     s += "\n";
     return s;
 }

--- a/qucs/spicecomponents/DIODE_SPICE.cpp
+++ b/qucs/spicecomponents/DIODE_SPICE.cpp
@@ -130,11 +130,11 @@ QString DIODE_SPICE::spice_netlist(bool)
     QString D_Line_4= Props.at(3)->Value;
     QString D_Line_5= Props.at(4)->Value;
 
-    if(  D.length()  > 0)          s += QString("%1").arg(D);
-    if(  D_Line_2.length() > 0 )   s += QString("\n%1").arg(D_Line_2);
-    if(  D_Line_3.length() > 0 )   s += QString("\n%1").arg(D_Line_3);
-    if(  D_Line_4.length() > 0 )   s += QString("\n%1").arg(D_Line_4);
-    if(  D_Line_5.length() > 0 )   s += QString("\n%1").arg(D_Line_5);
+    if(  D.length()  > 0)          s += QStringLiteral("%1").arg(D);
+    if(  D_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(D_Line_2);
+    if(  D_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(D_Line_3);
+    if(  D_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(D_Line_4);
+    if(  D_Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(D_Line_5);
     s += "\n";
     return s;
 }

--- a/qucs/spicecomponents/Icouple.cpp
+++ b/qucs/spicecomponents/Icouple.cpp
@@ -113,8 +113,8 @@ QString Icouple::spice_netlist(bool)
     
     QString A= Props.at(0)->Value;
     QString A_Line_2= Props.at(1)->Value;
-    if(  A.length()        > 0)    s += QString("%1").arg(A);
-    if(  A_Line_2.length() > 0 )   s += QString("\n%1").arg(A_Line_2);
+    if(  A.length()        > 0)    s += QStringLiteral("%1").arg(A);
+    if(  A_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(A_Line_2);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/K_SPICE.cpp
+++ b/qucs/spicecomponents/K_SPICE.cpp
@@ -87,7 +87,7 @@ QString K_SPICE::spice_netlist(bool)
    QString Ind2 = Props.at(1) ->Value;
    QString K = spicecompat::normalize_value(Props.at(2)->Value);
    
-   s+= QString(" %1 %2 %3 \n").arg(Ind1).arg(Ind2).arg(K);
+   s+= QStringLiteral(" %1 %2 %3 \n").arg(Ind1).arg(Ind2).arg(K);
     
     return s;
 }

--- a/qucs/spicecomponents/LTL_SPICE.cpp
+++ b/qucs/spicecomponents/LTL_SPICE.cpp
@@ -109,17 +109,17 @@ QString LTL_SPICE::spice_netlist(bool)
 
 
    if( Z0.trimmed().length() > 0) {
-       s += QString(" Z0=%1").arg(Z0);
+       s += QStringLiteral(" Z0=%1").arg(Z0);
    }
    if( Td.trimmed().length() > 0 )  {
-       s += QString(" Td=%1").arg(Td);
+       s += QStringLiteral(" Td=%1").arg(Td);
    }
    if( Freq.trimmed().length() > 0 ) {
-       s += QString(" F=%1").arg(Freq);
+       s += QStringLiteral(" F=%1").arg(Freq);
    }
    if( Nl.trimmed().length() > 0 ) {
-       s += QString(" NL=%1").arg(Nl);
+       s += QStringLiteral(" NL=%1").arg(Nl);
    }
-   s += QString(" IC=%5, %6, %7, %8 \n").arg(V1).arg(I1).arg(V2).arg(I2);
+   s += QStringLiteral(" IC=%5, %6, %7, %8 \n").arg(V1).arg(I1).arg(V2).arg(I2);
     return s;
 }

--- a/qucs/spicecomponents/LTRA_SPICE.cpp
+++ b/qucs/spicecomponents/LTRA_SPICE.cpp
@@ -109,11 +109,11 @@ QString LTRA_SPICE::spice_netlist(bool)
     QString O_Line_4= Props.at(3)->Value;
     QString O_Line_5= Props.at(4)->Value;
 
-    if(  O.length()  > 0)          s += QString("%1").arg(O);
-    if(  O_Line_2.length() > 0 )   s += QString("\n%1").arg(O_Line_2);
-    if(  O_Line_3.length() > 0 )   s += QString("\n%1").arg(O_Line_3);
-    if(  O_Line_4.length() > 0 )   s += QString("\n%1").arg(O_Line_4);
-    if(  O_Line_5.length() >  0 )  s += QString("\n%1").arg(O_Line_5);
+    if(  O.length()  > 0)          s += QStringLiteral("%1").arg(O);
+    if(  O_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(O_Line_2);
+    if(  O_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(O_Line_3);
+    if(  O_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(O_Line_4);
+    if(  O_Line_5.length() >  0 )  s += QStringLiteral("\n%1").arg(O_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/L_SPICE.cpp
+++ b/qucs/spicecomponents/L_SPICE.cpp
@@ -98,11 +98,11 @@ QString L_SPICE::spice_netlist(bool)
     QString L_Line_4= Props.at(3)->Value;
     QString L_Line_5= Props.at(4)->Value;
 
-    if(  L.length()  > 0)          s += QString("%1").arg(L);
-    if(  L_Line_2.length() > 0 )   s += QString("\n%1").arg(L_Line_2);
-    if(  L_Line_3.length() > 0 )   s += QString("\n%1").arg(L_Line_3);
-    if(  L_Line_4.length() > 0 )   s += QString("\n%1").arg(L_Line_4);
-    if( L_Line_5.length() >  0 )   s += QString("\n%1").arg(L_Line_5);
+    if(  L.length()  > 0)          s += QStringLiteral("%1").arg(L);
+    if(  L_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(L_Line_2);
+    if(  L_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(L_Line_3);
+    if(  L_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(L_Line_4);
+    if( L_Line_5.length() >  0 )   s += QStringLiteral("\n%1").arg(L_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/MESFET_SPICE.cpp
+++ b/qucs/spicecomponents/MESFET_SPICE.cpp
@@ -101,11 +101,11 @@ QString MESFET_SPICE::spice_netlist(bool)
     QString Z_Line_4= Props.at(3)->Value;
     QString Z_Line_5= Props.at(4)->Value;
 
-    if(  Z.length()  > 0)          s += QString("%1").arg(Z);
-    if(  Z_Line_2.length() > 0 )   s += QString("\n%1").arg(Z_Line_2);
-    if(  Z_Line_3.length() > 0 )   s += QString("\n%1").arg(Z_Line_3);
-    if(  Z_Line_4.length() > 0 )   s += QString("\n%1").arg(Z_Line_4);
-    if(  Z_Line_5.length() >  0 )  s += QString("\n%1").arg(Z_Line_5);
+    if(  Z.length()  > 0)          s += QStringLiteral("%1").arg(Z);
+    if(  Z_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(Z_Line_2);
+    if(  Z_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(Z_Line_3);
+    if(  Z_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(Z_Line_4);
+    if(  Z_Line_5.length() >  0 )  s += QStringLiteral("\n%1").arg(Z_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/MOS_SPICE.cpp
+++ b/qucs/spicecomponents/MOS_SPICE.cpp
@@ -240,11 +240,11 @@ QString MOS_SPICE::spice_netlist(bool)
     QString M_Line_4= Props.at(6)->Value;
     QString M_Line_5= Props.at(7)->Value;
 
-    if(  M.length()  > 0)          s += QString("%1").arg(M);
-    if(  M_Line_2.length() > 0 )   s += QString("\n%1").arg(M_Line_2);
-    if(  M_Line_3.length() > 0 )   s += QString("\n%1").arg(M_Line_3);
-    if(  M_Line_4.length() > 0 )   s += QString("\n%1").arg(M_Line_4);
-    if(  M_Line_5.length() > 0 )   s += QString("\n%1").arg(M_Line_5);
+    if(  M.length()  > 0)          s += QStringLiteral("%1").arg(M);
+    if(  M_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(M_Line_2);
+    if(  M_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(M_Line_3);
+    if(  M_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(M_Line_4);
+    if(  M_Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(M_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/NJF_SPICE.cpp
+++ b/qucs/spicecomponents/NJF_SPICE.cpp
@@ -108,11 +108,11 @@ QString NJF_SPICE::spice_netlist(bool)
     QString J_Line_4= Props.at(3)->Value;
     QString J_Line_5= Props.at(4)->Value;
 
-    if(  J.length()  > 0)          s += QString("%1").arg(J);
-    if(  J_Line_2.length() > 0 )   s += QString("\n%1").arg(J_Line_2);
-    if(  J_Line_3.length() > 0 )   s += QString("\n%1").arg(J_Line_3);
-    if(  J_Line_4.length() > 0 )   s += QString("\n%1").arg(J_Line_4);
-    if(  J_Line_5.length() > 0 )   s += QString("\n%1").arg(J_Line_5);
+    if(  J.length()  > 0)          s += QStringLiteral("%1").arg(J);
+    if(  J_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(J_Line_2);
+    if(  J_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(J_Line_3);
+    if(  J_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(J_Line_4);
+    if(  J_Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(J_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/NMOS_SPICE.cpp
+++ b/qucs/spicecomponents/NMOS_SPICE.cpp
@@ -117,11 +117,11 @@ QString NMOS_SPICE::spice_netlist(bool)
     QString M_Line_4= Props.at(3)->Value;
     QString M_Line_5= Props.at(4)->Value;
 
-    if(  M.length()  > 0)          s += QString("%1").arg(M);
-    if(  M_Line_2.length() > 0 )   s += QString("\n%1").arg(M_Line_2);
-    if(  M_Line_3.length() > 0 )   s += QString("\n%1").arg(M_Line_3);
-    if(  M_Line_4.length() > 0 )   s += QString("\n%1").arg(M_Line_4);
-    if(  M_Line_5.length() > 0 )   s += QString("\n%1").arg(M_Line_5);
+    if(  M.length()  > 0)          s += QStringLiteral("%1").arg(M);
+    if(  M_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(M_Line_2);
+    if(  M_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(M_Line_3);
+    if(  M_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(M_Line_4);
+    if(  M_Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(M_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/NPN_SPICE.cpp
+++ b/qucs/spicecomponents/NPN_SPICE.cpp
@@ -109,11 +109,11 @@ QString NPN_SPICE::spice_netlist(bool)
     QString Q_Line_4= Props.at(3)->Value;
     QString Q_Line_5= Props.at(4)->Value;
 
-    if(  Q.length()  > 0)          s += QString("%1").arg(Q);
-    if(  Q_Line_2.length() > 0 )   s += QString("\n%1").arg(Q_Line_2);
-    if(  Q_Line_3.length() > 0 )   s += QString("\n%1").arg(Q_Line_3);
-    if(  Q_Line_4.length() > 0 )   s += QString("\n%1").arg(Q_Line_4);
-    if(  Q_Line_5.length() > 0 )   s += QString("\n%1").arg(Q_Line_5);
+    if(  Q.length()  > 0)          s += QStringLiteral("%1").arg(Q);
+    if(  Q_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(Q_Line_2);
+    if(  Q_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(Q_Line_3);
+    if(  Q_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(Q_Line_4);
+    if(  Q_Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(Q_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/PJF_SPICE.cpp
+++ b/qucs/spicecomponents/PJF_SPICE.cpp
@@ -108,11 +108,11 @@ QString PJF_SPICE::spice_netlist(bool)
     QString J_Line_4= Props.at(3)->Value;
     QString J_Line_5= Props.at(4)->Value;
 
-    if(  J.length()  > 0)          s += QString("%1").arg(J);
-    if(  J_Line_2.length() > 0 )   s += QString("\n%1").arg(J_Line_2);
-    if(  J_Line_3.length() > 0 )   s += QString("\n%1").arg(J_Line_3);
-    if(  J_Line_4.length() > 0 )   s += QString("\n%1").arg(J_Line_4);
-    if(  J_Line_5.length() > 0 )   s += QString("\n%1").arg(J_Line_5);
+    if(  J.length()  > 0)          s += QStringLiteral("%1").arg(J);
+    if(  J_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(J_Line_2);
+    if(  J_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(J_Line_3);
+    if(  J_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(J_Line_4);
+    if(  J_Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(J_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/PMF_MESFET_SPICE.cpp
+++ b/qucs/spicecomponents/PMF_MESFET_SPICE.cpp
@@ -101,11 +101,11 @@ QString PMF_MESFET_SPICE::spice_netlist(bool)
     QString Z_Line_4= Props.at(3)->Value;
     QString Z_Line_5= Props.at(4)->Value;
 
-    if(  Z.length()  > 0)          s += QString("%1").arg(Z);
-    if(  Z_Line_2.length() > 0 )   s += QString("\n%1").arg(Z_Line_2);
-    if(  Z_Line_3.length() > 0 )   s += QString("\n%1").arg(Z_Line_3);
-    if(  Z_Line_4.length() > 0 )   s += QString("\n%1").arg(Z_Line_4);
-    if(  Z_Line_5.length() >  0 )  s += QString("\n%1").arg(Z_Line_5);
+    if(  Z.length()  > 0)          s += QStringLiteral("%1").arg(Z);
+    if(  Z_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(Z_Line_2);
+    if(  Z_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(Z_Line_3);
+    if(  Z_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(Z_Line_4);
+    if(  Z_Line_5.length() >  0 )  s += QStringLiteral("\n%1").arg(Z_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/PMOS_SPICE.cpp
+++ b/qucs/spicecomponents/PMOS_SPICE.cpp
@@ -117,11 +117,11 @@ QString PMOS_SPICE::spice_netlist(bool)
     QString M_Line_4= Props.at(3)->Value;
     QString M_Line_5= Props.at(4)->Value;
 
-    if(  M.length()  > 0)          s += QString("%1").arg(M);
-    if(  M_Line_2.length() > 0 )   s += QString("\n%1").arg(M_Line_2);
-    if(  M_Line_3.length() > 0 )   s += QString("\n%1").arg(M_Line_3);
-    if(  M_Line_4.length() > 0 )   s += QString("\n%1").arg(M_Line_4);
-    if(  M_Line_5.length() > 0 )   s += QString("\n%1").arg(M_Line_5);
+    if(  M.length()  > 0)          s += QStringLiteral("%1").arg(M);
+    if(  M_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(M_Line_2);
+    if(  M_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(M_Line_3);
+    if(  M_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(M_Line_4);
+    if(  M_Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(M_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/PNP_SPICE.cpp
+++ b/qucs/spicecomponents/PNP_SPICE.cpp
@@ -110,11 +110,11 @@ QString PNP_SPICE::spice_netlist(bool)
     QString Q_Line_4= Props.at(3)->Value;
     QString Q_Line_5= Props.at(4)->Value;
 
-    if(  Q.length()  > 0)          s += QString("%1").arg(Q);
-    if(  Q_Line_2.length() > 0 )   s += QString("\n%1").arg(Q_Line_2);
-    if(  Q_Line_3.length() > 0 )   s += QString("\n%1").arg(Q_Line_3);
-    if(  Q_Line_4.length() > 0 )   s += QString("\n%1").arg(Q_Line_4);
-    if(  Q_Line_5.length() > 0 )   s += QString("\n%1").arg(Q_Line_5);
+    if(  Q.length()  > 0)          s += QStringLiteral("%1").arg(Q);
+    if(  Q_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(Q_Line_2);
+    if(  Q_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(Q_Line_3);
+    if(  Q_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(Q_Line_4);
+    if(  Q_Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(Q_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/R_SPICE.cpp
+++ b/qucs/spicecomponents/R_SPICE.cpp
@@ -129,11 +129,11 @@ QString R_SPICE::spice_netlist(bool)
     QString R_Line_4= Props.at(3)->Value;
     QString R_Line_5= Props.at(4)->Value;
 
-    if(  R.length()  > 0)          s += QString("%1").arg(R);
-    if(  R_Line_2.length() > 0 )   s += QString("\n%1").arg(R_Line_2);
-    if(  R_Line_3.length() > 0 )   s += QString("\n%1").arg(R_Line_3);
-    if(  R_Line_4.length() > 0 )   s += QString("\n%1").arg(R_Line_4);
-    if(  R_Line_5.length() > 0)    s += QString("\n%1").arg(R_Line_5);
+    if(  R.length()  > 0)          s += QStringLiteral("%1").arg(R);
+    if(  R_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(R_Line_2);
+    if(  R_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(R_Line_3);
+    if(  R_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(R_Line_4);
+    if(  R_Line_5.length() > 0)    s += QStringLiteral("\n%1").arg(R_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/S4Q_I.cpp
+++ b/qucs/spicecomponents/S4Q_I.cpp
@@ -92,11 +92,11 @@ QString S4Q_I::spice_netlist(bool)
     QString l3= Props.at(3)->Value;
     QString l4= Props.at(4)->Value;
 
-    if(l0.length()> 0)   s += QString("%1").arg(l0);
-    if(l1.length()> 0)   s += QString("\n%1").arg(l1);
-    if(l2.length()> 0)   s += QString("\n%1").arg(l2);
-    if(l3.length()> 0)   s += QString("\n%1").arg(l3);
-    if(l4.length()> 0)   s += QString("\n%1").arg(l4);
+    if(l0.length()> 0)   s += QStringLiteral("%1").arg(l0);
+    if(l1.length()> 0)   s += QStringLiteral("\n%1").arg(l1);
+    if(l2.length()> 0)   s += QStringLiteral("\n%1").arg(l2);
+    if(l3.length()> 0)   s += QStringLiteral("\n%1").arg(l3);
+    if(l4.length()> 0)   s += QStringLiteral("\n%1").arg(l4);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/S4Q_Ieqndef.cpp
+++ b/qucs/spicecomponents/S4Q_Ieqndef.cpp
@@ -102,11 +102,11 @@ QString S4Q_Ieqndef::spice_netlist(bool)
     QString Line_4 = Props.at(3)->Value;
     QString Line_5 = Props.at(4)->Value;
 
-    s += QString(" %1 = %2 \n").arg(VI).arg(VI2);
-    if(  Line_2.length() > 0 )   s += QString("%1").arg(Line_2);
-    if(  Line_3.length() > 0 )   s += QString("\n%1").arg(Line_3);
-    if(  Line_4.length() > 0 )   s += QString("\n%1").arg(Line_4);
-    if(  Line_5.length() > 0 )   s += QString("\n%1").arg(Line_5);
+    s += QStringLiteral(" %1 = %2 \n").arg(VI).arg(VI2);
+    if(  Line_2.length() > 0 )   s += QStringLiteral("%1").arg(Line_2);
+    if(  Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_3);
+    if(  Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_4);
+    if(  Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_5);
     s += "\n";
 
     return s;
@@ -121,7 +121,7 @@ QString S4Q_Ieqndef::va_code()
     if (Props.at(0)->Name=="I") Src = vacompat::normalize_current(plus,minus,true);
     else Src = vacompat::normalize_voltage(plus,minus); // Voltage contribution is reserved for future
     // B-source may be polar
-    if (plus=="gnd") s = QString(" %1 <+ -(%2); // %3 source\n").arg(Src).arg(Props.at(0)->Value).arg(Name);
-    else s = QString(" %1 <+ %2; // %3 source\n").arg(Src).arg(Props.at(0)->Value).arg(Name);
+    if (plus=="gnd") s = QStringLiteral(" %1 <+ -(%2); // %3 source\n").arg(Src).arg(Props.at(0)->Value).arg(Name);
+    else s = QStringLiteral(" %1 <+ %2; // %3 source\n").arg(Src).arg(Props.at(0)->Value).arg(Name);
     return s;
 }

--- a/qucs/spicecomponents/S4Q_S.cpp
+++ b/qucs/spicecomponents/S4Q_S.cpp
@@ -108,11 +108,11 @@ QString S4Q_S::spice_netlist(bool)
     QString S_Line_4= Props.at(3)->Value;
     QString S_Line_5= Props.at(4)->Value;
 
-    if(  S.length()  > 0)          s += QString("%1").arg(S);
-    if(  S_Line_2.length() > 0 )   s += QString("\n%1").arg(S_Line_2);
-    if(  S_Line_3.length() > 0 )   s += QString("\n%1").arg(S_Line_3);
-    if(  S_Line_4.length() > 0 )   s += QString("\n%1").arg(S_Line_4);
-    if(  S_Line_5.length() > 0)    s += QString("\n%1").arg(S_Line_5);
+    if(  S.length()  > 0)          s += QStringLiteral("%1").arg(S);
+    if(  S_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(S_Line_2);
+    if(  S_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(S_Line_3);
+    if(  S_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(S_Line_4);
+    if(  S_Line_5.length() > 0)    s += QStringLiteral("\n%1").arg(S_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/S4Q_V.cpp
+++ b/qucs/spicecomponents/S4Q_V.cpp
@@ -92,11 +92,11 @@ QString S4Q_V::spice_netlist(bool)
     QString l3= Props.at(3)->Value;
     QString l4= Props.at(4)->Value;
 
-    if(l0.length()> 0)   s += QString("%1").arg(l0);
-    if(l1.length()> 0)   s += QString("\n%1").arg(l1);
-    if(l2.length()> 0)   s += QString("\n%1").arg(l2);
-    if(l3.length()> 0)   s += QString("\n%1").arg(l3);
-    if(l4.length()> 0)   s += QString("\n%1").arg(l4);
+    if(l0.length()> 0)   s += QStringLiteral("%1").arg(l0);
+    if(l1.length()> 0)   s += QStringLiteral("\n%1").arg(l1);
+    if(l2.length()> 0)   s += QStringLiteral("\n%1").arg(l2);
+    if(l3.length()> 0)   s += QStringLiteral("\n%1").arg(l3);
+    if(l4.length()> 0)   s += QStringLiteral("\n%1").arg(l4);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/S4Q_W.cpp
+++ b/qucs/spicecomponents/S4Q_W.cpp
@@ -96,11 +96,11 @@ QString S4Q_W::spice_netlist(bool)
     QString W_Line_4= Props.at(3)->Value;
     QString W_Line_5= Props.at(4)->Value;
 
-    if(  W.length()  > 0)          s += QString("%1").arg(W);
-    if(  W_Line_2.length() > 0 )   s += QString("\n%1").arg(W_Line_2);
-    if(  W_Line_3.length() > 0 )   s += QString("\n%1").arg(W_Line_3);
-    if(  W_Line_4.length() > 0 )   s += QString("\n%1").arg(W_Line_4);
-    if(  W_Line_5.length() > 0)    s += QString("\n%1").arg(W_Line_5);
+    if(  W.length()  > 0)          s += QStringLiteral("%1").arg(W);
+    if(  W_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(W_Line_2);
+    if(  W_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(W_Line_3);
+    if(  W_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(W_Line_4);
+    if(  W_Line_5.length() > 0)    s += QStringLiteral("\n%1").arg(W_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/SDTF.cpp
+++ b/qucs/spicecomponents/SDTF.cpp
@@ -101,13 +101,13 @@ QString SDTF::spice_netlist(bool)
     QString A_Line_6 = Props.at(5)->Value;
     QString A_Line_7 = Props.at(6)->Value;   
      
-    if(  A.length()        > 0)    s += QString("%1").arg(A);
-    if(  A_Line_2.length() > 0 )   s += QString("\n%1").arg(A_Line_2);
-    if(  A_Line_3.length() > 0 )   s += QString("\n%1").arg(A_Line_3);
-    if(  A_Line_4.length() > 0 )   s += QString("\n%1").arg(A_Line_4);
-    if(  A_Line_5.length() > 0 )   s += QString("\n%1").arg(A_Line_5);
-    if(  A_Line_6.length() > 0 )   s += QString("\n%1").arg(A_Line_6);
-    if(  A_Line_7.length() > 0 )   s += QString("\n%1").arg(A_Line_7);
+    if(  A.length()        > 0)    s += QStringLiteral("%1").arg(A);
+    if(  A_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(A_Line_2);
+    if(  A_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(A_Line_3);
+    if(  A_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(A_Line_4);
+    if(  A_Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(A_Line_5);
+    if(  A_Line_6.length() > 0 )   s += QStringLiteral("\n%1").arg(A_Line_6);
+    if(  A_Line_7.length() > 0 )   s += QStringLiteral("\n%1").arg(A_Line_7);
     s += "\n";
     return s;
 }

--- a/qucs/spicecomponents/UDRCTL_SPICE.cpp
+++ b/qucs/spicecomponents/UDRCTL_SPICE.cpp
@@ -107,11 +107,11 @@ QString UDRCTL_SPICE::spice_netlist(bool)
     QString U_Line_4= Props.at(3)->Value;
     QString U_Line_5= Props.at(4)->Value;
 
-    if(  U.length()  > 0)          s += QString("%1").arg(U);
-    if(  U_Line_2.length() > 0 )   s += QString("\n%1").arg(U_Line_2);
-    if(  U_Line_3.length() > 0 )   s += QString("\n%1").arg(U_Line_3);
-    if(  U_Line_4.length() > 0 )   s += QString("\n%1").arg(U_Line_4);
-    if(  U_Line_5.length() > 0 )   s += QString("\n%1").arg(U_Line_5);
+    if(  U.length()  > 0)          s += QStringLiteral("%1").arg(U);
+    if(  U_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(U_Line_2);
+    if(  U_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(U_Line_3);
+    if(  U_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(U_Line_4);
+    if(  U_Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(U_Line_5);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/XAPWL.cpp
+++ b/qucs/spicecomponents/XAPWL.cpp
@@ -101,13 +101,13 @@ QString XAPWL::spice_netlist(bool)
     QString A_Line_6 = Props.at(5)->Value;
     QString A_Line_7 = Props.at(6)->Value;   
      
-    if(  A.length()        > 0)    s += QString("%1").arg(A);
-    if(  A_Line_2.length() > 0 )   s += QString("\n%1").arg(A_Line_2);
-    if(  A_Line_3.length() > 0 )   s += QString("\n%1").arg(A_Line_3);
-    if(  A_Line_4.length() > 0 )   s += QString("\n%1").arg(A_Line_4);
-    if(  A_Line_5.length() > 0 )   s += QString("\n%1").arg(A_Line_5);
-    if(  A_Line_6.length() > 0 )   s += QString("\n%1").arg(A_Line_6);
-    if(  A_Line_7.length() > 0 )   s += QString("\n%1").arg(A_Line_7);
+    if(  A.length()        > 0)    s += QStringLiteral("%1").arg(A);
+    if(  A_Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(A_Line_2);
+    if(  A_Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(A_Line_3);
+    if(  A_Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(A_Line_4);
+    if(  A_Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(A_Line_5);
+    if(  A_Line_6.length() > 0 )   s += QStringLiteral("\n%1").arg(A_Line_6);
+    if(  A_Line_7.length() > 0 )   s += QStringLiteral("\n%1").arg(A_Line_7);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/core.cpp
+++ b/qucs/spicecomponents/core.cpp
@@ -107,13 +107,13 @@ QString core::spice_netlist(bool)
     QString A_Line_5= Props.at(4)->Value; 
     QString A_Line_6= Props.at(5)->Value;
     QString A_Line_7= Props.at(6)->Value; 
-    if(  A.length()        > 0)    s += QString("%1\n").arg(A);
-    if(  A_Line_2.length() > 0 )   s += QString("%1\n").arg(A_Line_2);
-    if(  A_Line_3.length() > 0 )   s += QString("%1\n").arg(A_Line_3);
-    if(  A_Line_4.length() > 0 )   s += QString("%1\n").arg(A_Line_4);
-    if(  A_Line_5.length() > 0 )   s += QString("%1\n").arg(A_Line_5);
-    if(  A_Line_6.length() > 0 )   s += QString("%1\n").arg(A_Line_6);
-    if(  A_Line_7.length() > 0 )   s += QString("%1\n").arg(A_Line_7);
+    if(  A.length()        > 0)    s += QStringLiteral("%1\n").arg(A);
+    if(  A_Line_2.length() > 0 )   s += QStringLiteral("%1\n").arg(A_Line_2);
+    if(  A_Line_3.length() > 0 )   s += QStringLiteral("%1\n").arg(A_Line_3);
+    if(  A_Line_4.length() > 0 )   s += QStringLiteral("%1\n").arg(A_Line_4);
+    if(  A_Line_5.length() > 0 )   s += QStringLiteral("%1\n").arg(A_Line_5);
+    if(  A_Line_6.length() > 0 )   s += QStringLiteral("%1\n").arg(A_Line_6);
+    if(  A_Line_7.length() > 0 )   s += QStringLiteral("%1\n").arg(A_Line_7);
  
     return s;
 }

--- a/qucs/spicecomponents/eNL.cpp
+++ b/qucs/spicecomponents/eNL.cpp
@@ -97,11 +97,11 @@ QString eNL::spice_netlist(bool)
     QString Line_5 = Props.at(4)->Value;
 
     
-    if(  E.length()  > 0)        s += QString("%1").arg(E);
-    if(  Line_2.length() > 0 )   s += QString("\n%1").arg(Line_2);
-    if(  Line_3.length() > 0 )   s += QString("\n%1").arg(Line_3);
-    if(  Line_4.length() > 0 )   s += QString("\n%1").arg(Line_4);
-    if(  Line_5.length() > 0 )   s += QString("\n%1").arg(Line_5);
+    if(  E.length()  > 0)        s += QStringLiteral("%1").arg(E);
+    if(  Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_2);
+    if(  Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_3);
+    if(  Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_4);
+    if(  Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_5);
     s += "\n";
     return s;
 }

--- a/qucs/spicecomponents/gNL.cpp
+++ b/qucs/spicecomponents/gNL.cpp
@@ -96,11 +96,11 @@ QString gNL::spice_netlist(bool)
     QString Line_5 = Props.at(4)->Value;
  
     
-    if(  G.length()      > 0 )   s += QString("%1").arg(G);
-    if(  Line_2.length() > 0 )   s += QString("\n%1").arg(Line_2);
-    if(  Line_3.length() > 0 )   s += QString("\n%1").arg(Line_3);
-    if(  Line_4.length() > 0 )   s += QString("\n%1").arg(Line_4);
-    if(  Line_5.length() > 0 )   s += QString("\n%1").arg(Line_5);
+    if(  G.length()      > 0 )   s += QStringLiteral("%1").arg(G);
+    if(  Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_2);
+    if(  Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_3);
+    if(  Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_4);
+    if(  Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_5);
     s += "\n";
 
      return s;

--- a/qucs/spicecomponents/iAmpMod.cpp
+++ b/qucs/spicecomponents/iAmpMod.cpp
@@ -105,6 +105,6 @@ QString iAmpMod::spice_netlist(bool)
    QString Td = spicecompat::normalize_value(Props.at(4)->Value);
 
 
-    s += QString(" DC 0 AM(%1 %2 %3 %4 %5 ) AC 0\n").arg(Va).arg(Vo).arg(Mf).arg(Fc).arg(Td);
+    s += QStringLiteral(" DC 0 AM(%1 %2 %3 %4 %5 ) AC 0\n").arg(Va).arg(Vo).arg(Mf).arg(Fc).arg(Td);
     return s;
 }

--- a/qucs/spicecomponents/iPWL.cpp
+++ b/qucs/spicecomponents/iPWL.cpp
@@ -113,16 +113,16 @@ QString Line_10= Props.at(9)->Value;
 
     s += QString();
  
-    if(  PWL.length()    > 0)    s += QString("%1").arg(PWL);
-    if(  Line_2.length() > 0 )   s += QString("\n%1").arg(Line_2);
-    if(  Line_3.length() > 0 )   s += QString("\n%1").arg(Line_3);
-    if(  Line_4.length() > 0 )   s += QString("\n%1").arg(Line_4);
-    if(  Line_5.length() > 0 )   s += QString("\n%1").arg(Line_5);
-    if(  Line_6.length() > 0 )   s += QString("\n%1").arg(Line_6);
-    if(  Line_7.length() > 0 )   s += QString("\n%1").arg(Line_7);
-    if(  Line_8.length() > 0)    s += QString("\n%1").arg(Line_8);
-    if(  Line_9.length() > 0 )   s += QString("\n%1").arg(Line_9);
-    if(  Line_10.length() > 0 )  s += QString("\n%1").arg(Line_10);
+    if(  PWL.length()    > 0)    s += QStringLiteral("%1").arg(PWL);
+    if(  Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_2);
+    if(  Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_3);
+    if(  Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_4);
+    if(  Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_5);
+    if(  Line_6.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_6);
+    if(  Line_7.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_7);
+    if(  Line_8.length() > 0)    s += QStringLiteral("\n%1").arg(Line_8);
+    if(  Line_9.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_9);
+    if(  Line_10.length() > 0 )  s += QStringLiteral("\n%1").arg(Line_10);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/iTRNOISE.cpp
+++ b/qucs/spicecomponents/iTRNOISE.cpp
@@ -116,7 +116,7 @@ QString iTRNOISE::spice_netlist(bool)
    QString Rtsemt = spicecompat::normalize_value(Props.at(4)->Value);
 
 
-    s += QString(" DC 0 AC 0 TRNOISE(%1 %2 %3 %4 %5  %6 %7) \n").arg(Na).arg(Nt).arg(Nalpha).arg(Namp).
+    s += QStringLiteral(" DC 0 AC 0 TRNOISE(%1 %2 %3 %4 %5  %6 %7) \n").arg(Na).arg(Nt).arg(Nalpha).arg(Namp).
                                 arg(Rtsam).arg(Rtscapt).arg(Rtsemt);
     return s;
 }

--- a/qucs/spicecomponents/isffm.cpp
+++ b/qucs/spicecomponents/isffm.cpp
@@ -105,6 +105,6 @@ QString iSffm::spice_netlist(bool)
    QString Fs  = spicecompat::normalize_value(Props.at(4)->Value);
 
 
-    s += QString(" DC 0 SFFM(%1 %2 %3 %4 %5 ) AC 0\n").arg(I0).arg(Ia).arg(Fc).arg(Mdi).arg(Fs);
+    s += QStringLiteral(" DC 0 SFFM(%1 %2 %3 %4 %5 ) AC 0\n").arg(I0).arg(Ia).arg(Fc).arg(Mdi).arg(Fs);
     return s;
 }

--- a/qucs/spicecomponents/sp_disto.cpp
+++ b/qucs/spicecomponents/sp_disto.cpp
@@ -86,7 +86,7 @@ QString SpiceDisto::spice_netlist(bool isXyce)
             points = Props.at(3)->Value;
         }
 
-        s = QString("disto %1 %2 %3 %4 %5\n").arg(swp).arg(points).arg(fstart).arg(fstop)
+        s = QStringLiteral("disto %1 %2 %3 %4 %5\n").arg(swp).arg(points).arg(fstart).arg(fstop)
                                              .arg(Props.at(4)->Value.simplified());
     } else {
         s.clear();

--- a/qucs/spicecomponents/sp_fourier.cpp
+++ b/qucs/spicecomponents/sp_fourier.cpp
@@ -60,10 +60,10 @@ QString SpiceFourier::spice_netlist(bool isXyce)
     QString f0 = spicecompat::normalize_value(Props.at(2)->Value);
     QString out = "spice4qucs." + Name.toLower() + ".four";
     if (!isXyce) {
-        s = QString("set nfreqs=%1\n").arg(Props.at(1)->Value);
-        s += QString("fourier %1 %2 > %3\n").arg(f0).arg(Props.at(3)->Value).arg(out);
+        s = QStringLiteral("set nfreqs=%1\n").arg(Props.at(1)->Value);
+        s += QStringLiteral("fourier %1 %2 > %3\n").arg(f0).arg(Props.at(3)->Value).arg(out);
     } else {
-        s = QString(".FOUR %1 %2\n").arg(f0).arg(Props.at(3)->Value);
+        s = QStringLiteral(".FOUR %1 %2\n").arg(f0).arg(Props.at(3)->Value);
     }
 
     return s;

--- a/qucs/spicecomponents/sp_func.cpp
+++ b/qucs/spicecomponents/sp_func.cpp
@@ -78,8 +78,8 @@ QString SpiceFunc::getExpression(bool)
     s.clear();
     for (Property *pp : Props) {
         if (QucsSettings.DefaultSimulator==spicecompat::simXyce)
-            s += QString(".FUNC %1 %2\n").arg(pp->Name).arg(pp->Value);
-        else s += QString(".FUNC %1 = %2\n").arg(pp->Name).arg(pp->Value);
+            s += QStringLiteral(".FUNC %1 %2\n").arg(pp->Name).arg(pp->Value);
+        else s += QStringLiteral(".FUNC %1 = %2\n").arg(pp->Name).arg(pp->Value);
     }
     return s;
 }

--- a/qucs/spicecomponents/sp_globalpar.cpp
+++ b/qucs/spicecomponents/sp_globalpar.cpp
@@ -77,7 +77,7 @@ QString SpiceGlobalParam::getExpression(bool)
     QString s;
     s.clear();
     for (Property *pp : Props) {
-        s += QString(".GLOBAL_PARAM %1 = %2\n").arg(pp->Name).arg(pp->Value);
+        s += QStringLiteral(".GLOBAL_PARAM %1 = %2\n").arg(pp->Name).arg(pp->Value);
     }
     return s;
 }

--- a/qucs/spicecomponents/sp_ic.cpp
+++ b/qucs/spicecomponents/sp_ic.cpp
@@ -76,7 +76,7 @@ QString SpiceIC::getExpression(bool)
     QString s;
     s.clear();
     for (Property *pp : Props) {
-        s += QString(".IC %1 = %2\n").arg(pp->Name).arg(pp->Value);
+        s += QStringLiteral(".IC %1 = %2\n").arg(pp->Name).arg(pp->Value);
     }
     return s;
 }

--- a/qucs/spicecomponents/sp_include.cpp
+++ b/qucs/spicecomponents/sp_include.cpp
@@ -87,10 +87,10 @@ QString S4Q_Include::getSpiceLibrary()
             val = misc::properAbsFileName(val, containingSchematic);
             switch (QucsSettings.DefaultSimulator) {
             case spicecompat::simSpiceOpus: // Spice Opus doesn't support quotes
-                s += QString("%1 %2\n").arg(SpiceModel).arg(val);
+                s += QStringLiteral("%1 %2\n").arg(SpiceModel).arg(val);
                 break;
             default:
-                s += QString("%1 \"%2\"\n").arg(SpiceModel).arg(val);
+                s += QStringLiteral("%1 \"%2\"\n").arg(SpiceModel).arg(val);
                 break;
             }
         }

--- a/qucs/spicecomponents/sp_lib.cpp
+++ b/qucs/spicecomponents/sp_lib.cpp
@@ -81,7 +81,7 @@ QString S4Q_Lib::getSpiceLibrary()
   if ( !file.isEmpty() ){
     file = misc::properAbsFileName(file, containingSchematic);
     QString sec = getProperty("Section")->Value;
-    s += QString("%1 \"%2\" %3\n").arg(SpiceModel).arg(file).arg(sec);
+    s += QStringLiteral("%1 \"%2\" %3\n").arg(SpiceModel).arg(file).arg(sec);
   }
 
   return s;

--- a/qucs/spicecomponents/sp_nodeset.cpp
+++ b/qucs/spicecomponents/sp_nodeset.cpp
@@ -76,7 +76,7 @@ QString SpiceNodeset::getExpression(bool)
     QString s;
     s.clear();
     for (Property *pp : Props) {
-        s += QString(".NODESET %1 = %2\n").arg(pp->Name).arg(pp->Value);
+        s += QStringLiteral(".NODESET %1 = %2\n").arg(pp->Name).arg(pp->Value);
     }
     return s;
 }

--- a/qucs/spicecomponents/sp_noise.cpp
+++ b/qucs/spicecomponents/sp_noise.cpp
@@ -88,11 +88,11 @@ QString SpiceNoise::spice_netlist(bool isXyce)
         points = Props.at(3)->Value;
     }
 
-    s = QString("noise %1 %2 %3 %4 %5 %6\n").arg(Props.at(4)->Value).arg(Props.at(5)->Value)
+    s = QStringLiteral("noise %1 %2 %3 %4 %5 %6\n").arg(Props.at(4)->Value).arg(Props.at(5)->Value)
             .arg(swp).arg(points).arg(fstart).arg(fstop);
     QString out = "spice4qucs." + Name.toLower() + ".cir.noise";
     if (!isXyce) {
-        s += QString("print inoise_total onoise_total >> %1\n").arg(out);
+        s += QStringLiteral("print inoise_total onoise_total >> %1\n").arg(out);
     } else {
         s.insert(0,'.');
     }

--- a/qucs/spicecomponents/sp_nutmeg.cpp
+++ b/qucs/spicecomponents/sp_nutmeg.cpp
@@ -88,7 +88,7 @@ QString NutmegEquation::getEquations(QString sim, QStringList &dep_vars)
         auto pp = Props.begin();
         pp++;
         for ( ; pp != Props.end() ; ++pp) {
-            s += QString("let %1 = %2\n").arg((*pp)->Name).arg((*pp)->Value);
+            s += QStringLiteral("let %1 = %2\n").arg((*pp)->Name).arg((*pp)->Value);
           dep_vars.append((*pp)->Name);
         }
     }

--- a/qucs/spicecomponents/sp_options.cpp
+++ b/qucs/spicecomponents/sp_options.cpp
@@ -78,14 +78,14 @@ QString SpiceOptions::getExpression(bool isXyce)
     QString s;
     s.clear();
     if (isXyce) {
-        s += QString(".OPTIONS %1 ").arg(Props.at(0)->Value);
+        s += QStringLiteral(".OPTIONS %1 ").arg(Props.at(0)->Value);
         for (int i=1;i<Props.count();i++) {
-            s += QString(" %1 = %2 ").arg(Props.at(i)->Name).arg(Props.at(i)->Value);
+            s += QStringLiteral(" %1 = %2 ").arg(Props.at(i)->Name).arg(Props.at(i)->Value);
         }
         s += "\n";
     } else {
         for (int i=1;i<Props.count();i++) {
-            s += QString(".OPTION %1 = %2\n").arg(Props.at(i)->Name).arg(Props.at(i)->Value);
+            s += QStringLiteral(".OPTION %1 = %2\n").arg(Props.at(i)->Name).arg(Props.at(i)->Value);
         }
     }
     return s;

--- a/qucs/spicecomponents/sp_parameter.cpp
+++ b/qucs/spicecomponents/sp_parameter.cpp
@@ -76,7 +76,7 @@ QString SpiceParam::getExpression(bool)
     QString s;
     s.clear();
     for (Property *pp : Props) {
-        s += QString(".PARAM %1 = %2\n").arg(pp->Name).arg(pp->Value);
+        s += QStringLiteral(".PARAM %1 = %2\n").arg(pp->Name).arg(pp->Value);
     }
     return s;
 }

--- a/qucs/spicecomponents/sp_pz.cpp
+++ b/qucs/spicecomponents/sp_pz.cpp
@@ -63,11 +63,11 @@ QString SpicePZ::spice_netlist(bool isXyce)
     QString s;
     QString out = "spice4qucs." + Name.toLower() + ".cir.pz";
     if (!isXyce) {
-        s = QString("pz %1 %2 %3 %4\n").arg(Props.at(0)->Value).arg(Props.at(1)->Value)
+        s = QStringLiteral("pz %1 %2 %3 %4\n").arg(Props.at(0)->Value).arg(Props.at(1)->Value)
                 .arg(Props.at(2)->Value).arg(Props.at(3)->Value);
-        s += QString("echo \"PZ analysis\" >> %1\n").arg(out);
+        s += QStringLiteral("echo \"PZ analysis\" >> %1\n").arg(out);
         s += "let dummy_var = 0.0\n"; // To overcome featurebug of Ngspice when printing single variable
-        s += QString("print all >> %1\n").arg(out);
+        s += QStringLiteral("print all >> %1\n").arg(out);
     } else {
         s.clear();
     }

--- a/qucs/spicecomponents/sp_sens.cpp
+++ b/qucs/spicecomponents/sp_sens.cpp
@@ -71,21 +71,21 @@ QString SpiceSENS::spice_netlist(bool isXyce)
         QString stop = spicecompat::normalize_value(Props.at(3)->Value);
         QString step = spicecompat::normalize_value(Props.at(4)->Value);
         QString output = "spice4qucs." + Name.toLower() + ".ngspice.sens.dc.prn";
-        s += QString("echo \"Start\">%1\n").arg(output);
-        s += QString("let %1_start=%2\n").arg(sweepvar).arg(start);
-        s += QString("let %1_sweep=%1_start\n").arg(sweepvar);
-        s += QString("let %1_step=%2\n").arg(sweepvar).arg(step);
-        s += QString("let %1_stop=%2\n").arg(sweepvar).arg(stop);
-        s += QString("while %1_sweep le %1_stop\n").arg(sweepvar);
+        s += QStringLiteral("echo \"Start\">%1\n").arg(output);
+        s += QStringLiteral("let %1_start=%2\n").arg(sweepvar).arg(start);
+        s += QStringLiteral("let %1_sweep=%1_start\n").arg(sweepvar);
+        s += QStringLiteral("let %1_step=%2\n").arg(sweepvar).arg(step);
+        s += QStringLiteral("let %1_stop=%2\n").arg(sweepvar).arg(stop);
+        s += QStringLiteral("while %1_sweep le %1_stop\n").arg(sweepvar);
         if (sweepvar.compare("temp",Qt::CaseInsensitive)) {
-            s += QString("alter %1 = %2_sweep\n").arg(par).arg(sweepvar);
+            s += QStringLiteral("alter %1 = %2_sweep\n").arg(par).arg(sweepvar);
         } else {
-            s += QString("set %1 = $&%2_sweep\n").arg(par).arg(sweepvar);
+            s += QStringLiteral("set %1 = $&%2_sweep\n").arg(par).arg(sweepvar);
         }
-        s += QString("sens %1\n").arg(Props.at(0)->Value);
-        s += QString("echo \"Sens analysis\">>%1\n").arg(output);
-        s += QString("print %1_sweep>>%2\nprint all>>%2\n").arg(sweepvar).arg(output);
-        s += QString("let %1_sweep = %1_sweep + %1_step\nend\n").arg(sweepvar);
+        s += QStringLiteral("sens %1\n").arg(Props.at(0)->Value);
+        s += QStringLiteral("echo \"Sens analysis\">>%1\n").arg(output);
+        s += QStringLiteral("print %1_sweep>>%2\nprint all>>%2\n").arg(sweepvar).arg(output);
+        s += QStringLiteral("let %1_sweep = %1_sweep + %1_step\nend\n").arg(sweepvar);
 
     }
 

--- a/qucs/spicecomponents/sp_sens_ac.cpp
+++ b/qucs/spicecomponents/sp_sens_ac.cpp
@@ -67,10 +67,10 @@ QString SpiceSENS_AC::spice_netlist(bool isXyce)
         QString fstart = spicecompat::normalize_value(Props.at(2)->Value); // Start freq.
         QString fstop = spicecompat::normalize_value(Props.at(3)->Value); // Stop freq.
         QString out = "spice4qucs." + Name.toLower() + ".sens.prn";
-        s = QString("sens %1 ac %2 %3 %4 %5\n")
+        s = QStringLiteral("sens %1 ac %2 %3 %4 %5\n")
                 .arg(Props.at(0)->Value).arg(Props.at(1)->Value).arg(Props.at(4)->Value)
                 .arg(fstart).arg(fstop);
-        s += QString("write %1 all\n").arg(out);
+        s += QStringLiteral("write %1 all\n").arg(out);
     }
 
     return s;

--- a/qucs/spicecomponents/sp_sens_tr_xyce.cpp
+++ b/qucs/spicecomponents/sp_sens_tr_xyce.cpp
@@ -70,17 +70,17 @@ QString SpiceSENS_TR_Xyce::spice_netlist(bool isXyce)
         QString start = spicecompat::normalize_value(Props.at(3)->Value);
         QString stop = spicecompat::normalize_value(Props.at(4)->Value);
         QString step = spicecompat::normalize_value(Props.at(5)->Value);
-        s = QString(".tran %1 %2 %3").arg(start).arg(stop).arg(step);
+        s = QStringLiteral(".tran %1 %2 %3").arg(start).arg(stop).arg(step);
         if (Props.at(6)->Value=="yes") s +="\n";
         else s += " uic\n";
         if (Props.at(2)->Value=="direct") s += ".options sensitivity direct=1 adjoint=0\n";
         else s += ".options sensitivity direct=0 adjoint=1\n";
-        s += QString(".sens objfunc={%1} param=%2\n")
+        s += QStringLiteral(".sens objfunc={%1} param=%2\n")
                 .arg(Props.at(0)->Value).arg(Props.at(1)->Value);
         if (Props.at(2)->Value=="direct") {
             s += ".print sens\n";
         } else {
-            s += QString(".print tran %1\n.print tranadjoint\n").arg(Props.at(0)->Value);
+            s += QStringLiteral(".print tran %1\n.print tranadjoint\n").arg(Props.at(0)->Value);
         }
     }
 

--- a/qucs/spicecomponents/sp_sens_xyce.cpp
+++ b/qucs/spicecomponents/sp_sens_xyce.cpp
@@ -68,7 +68,7 @@ QString SpiceSENS_Xyce::spice_netlist(bool isXyce)
         QString start = spicecompat::normalize_value(Props.at(3)->Value);
         QString stop = spicecompat::normalize_value(Props.at(4)->Value);
         QString step = spicecompat::normalize_value(Props.at(5)->Value);
-        s = QString(".dc %3 %4 %5 %6\n"
+        s = QStringLiteral(".dc %3 %4 %5 %6\n"
                     ".sens objfunc={%1} param=%2\n"
                     ".print sens\n").arg(Props.at(0)->Value).arg(Props.at(1)->Value)
                 .arg(Props.at(2)->Value).arg(start).arg(stop).arg(step);

--- a/qucs/spicecomponents/sp_spectrum.cpp
+++ b/qucs/spicecomponents/sp_spectrum.cpp
@@ -73,10 +73,10 @@ QString SpiceFFT::spice_netlist(bool isXyce)
     double tstop = 1.0/df + tstart;
     double tstep = 1.0/(2*bw);
     QString win = getProperty("Window")->Value;
-    s =  QString("tran %1 %2 %3\n").arg(tstep).arg(tstop).arg(tstart);
-    s += QString("set specwindow=%1\n").arg(win);
+    s =  QStringLiteral("tran %1 %2 %3\n").arg(tstep).arg(tstop).arg(tstart);
+    s += QStringLiteral("set specwindow=%1\n").arg(win);
     if (win == "gaussian") {
-        s += QString("set specwindoworder=%1\n")
+        s += QStringLiteral("set specwindoworder=%1\n")
                 .arg(getProperty("Order")->Value);
     }
 

--- a/qucs/spicecomponents/spicelibcomp.cpp
+++ b/qucs/spicecomponents/spicelibcomp.cpp
@@ -90,7 +90,7 @@ void SpiceLibComp::createSymbol()
     FileName = symname;
   } else {
     FileName  = QucsSettings.BinDir;
-    FileName += QString("/../share/" QUCS_NAME "/symbols/%1.sym").arg(Props.at(2)->Value);
+    FileName += QStringLiteral("/../share/" QUCS_NAME "/symbols/%1.sym").arg(Props.at(2)->Value);
   }
 
   // Default symbol: LM358 in opamps.lib ---> opamps/LM358.sym
@@ -220,7 +220,7 @@ int SpiceLibComp::loadSymbol(const QString& DocName)
 
 QString SpiceLibComp::spice_netlist(bool)
 {
-  QString s = QString("X%1 ").arg(Name);
+  QString s = QStringLiteral("X%1 ").arg(Name);
   QString pins = getProperty("PinAssign")->Value;
   QString sym = getProperty("SymPattern")->Value;
   if (sym == "auto" || pins.isEmpty()) {
@@ -235,7 +235,7 @@ QString SpiceLibComp::spice_netlist(bool)
       s += " " + spicecompat::normalize_node_name(pp->Connection->Name);
     }
   }
-  s += QString(" %1 %2\n").arg(Props.at(1)->Value).arg(Props.at(3)->Value);
+  s += QStringLiteral(" %1 %2\n").arg(Props.at(1)->Value).arg(Props.at(3)->Value);
   return s;
 }
 
@@ -243,6 +243,6 @@ QString SpiceLibComp::getSpiceLibrary()
 {
     if (isActive != COMP_IS_ACTIVE) return QString();
     QString f = misc::properAbsFileName(Props.at(0)->Value, containingSchematic);
-    QString s = QString(".INCLUDE \"%1\"\n").arg(f);
+    QString s = QStringLiteral(".INCLUDE \"%1\"\n").arg(f);
     return s;
 }

--- a/qucs/spicecomponents/src_eqndef.cpp
+++ b/qucs/spicecomponents/src_eqndef.cpp
@@ -83,11 +83,11 @@ QString Src_eqndef::spice_netlist(bool)
     QString Line_4 = Props.at(3)->Value;
     QString Line_5 = Props.at(4)->Value;
 
-    s += QString(" %1 = %2 ").arg(VI).arg(VI2);
-    if(  Line_2.length() > 0 )   s += QString("\n%1").arg(Line_2);
-    if(  Line_3.length() > 0 )   s += QString("\n%1").arg(Line_3);
-    if(  Line_4.length() > 0 )   s += QString("\n%1").arg(Line_4);
-    if(  Line_5.length() > 0 )   s += QString("\n%1").arg(Line_5);
+    s += QStringLiteral(" %1 = %2 ").arg(VI).arg(VI2);
+    if(  Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_2);
+    if(  Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_3);
+    if(  Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_4);
+    if(  Line_5.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_5);
     s += "\n";
 
     return s;
@@ -102,7 +102,7 @@ QString Src_eqndef::va_code()
     if (Props.at(0)->Name=="I") Src = vacompat::normalize_current(plus,minus,true);
     else Src = vacompat::normalize_voltage(plus,minus); // Voltage contribution is reserved for future
     // B-source may be polar
-    if (plus=="gnd") s = QString(" %1 <+ -(%2); // %3 source\n").arg(Src).arg(Props.at(0)->Value).arg(Name);
-    else s = QString(" %1 <+ %2; // %3 source\n").arg(Src).arg(Props.at(0)->Value).arg(Name);
+    if (plus=="gnd") s = QStringLiteral(" %1 <+ -(%2); // %3 source\n").arg(Src).arg(Props.at(0)->Value).arg(Name);
+    else s = QStringLiteral(" %1 <+ %2; // %3 source\n").arg(Src).arg(Props.at(0)->Value).arg(Name);
     return s;
 }

--- a/qucs/spicecomponents/vAmpMod.cpp
+++ b/qucs/spicecomponents/vAmpMod.cpp
@@ -107,6 +107,6 @@ QString vAmpMod::spice_netlist(bool)
    QString Td = spicecompat::normalize_value(Props.at(4)->Value);
 
 
-    s += QString(" DC 0 AM(%1 %2 %3 %4 %5 ) AC 0\n").arg(Va).arg(Vo).arg(Mf).arg(Fc).arg(Td);
+    s += QStringLiteral(" DC 0 AM(%1 %2 %3 %4 %5 ) AC 0\n").arg(Va).arg(Vo).arg(Mf).arg(Fc).arg(Td);
     return s;
 }

--- a/qucs/spicecomponents/vPWL.cpp
+++ b/qucs/spicecomponents/vPWL.cpp
@@ -112,16 +112,16 @@ QString Line_10= Props.at(9)->Value;
 
     s += QString();
   
-    if(  PWL.length()  > 0)        s += QString("%1").arg(PWL);
-    if(  Line_2.length() > 0 )     s += QString("\n%1").arg(Line_2);
-    if(  Line_3.length() > 0 )     s += QString("\n%1").arg(Line_3);
-    if(  Line_4.length() > 0 )     s += QString("\n%1").arg(Line_4);
-    if(  Line_5.length() > 0 )     s += QString("\n%1").arg(Line_5);
-    if(  Line_6.length() > 0 )     s += QString("\n%1").arg(Line_6);
-    if(  Line_7.length() > 0 )     s += QString("\n%1").arg(Line_7);
-    if(  Line_8.length() > 0)      s += QString("\n%1").arg(Line_8);
-    if(  Line_9.length() > 0 )     s += QString("\n%1").arg(Line_9);
-    if(  Line_10.length() > 0 )    s += QString("\n%1").arg(Line_10);
+    if(  PWL.length()  > 0)        s += QStringLiteral("%1").arg(PWL);
+    if(  Line_2.length() > 0 )     s += QStringLiteral("\n%1").arg(Line_2);
+    if(  Line_3.length() > 0 )     s += QStringLiteral("\n%1").arg(Line_3);
+    if(  Line_4.length() > 0 )     s += QStringLiteral("\n%1").arg(Line_4);
+    if(  Line_5.length() > 0 )     s += QStringLiteral("\n%1").arg(Line_5);
+    if(  Line_6.length() > 0 )     s += QStringLiteral("\n%1").arg(Line_6);
+    if(  Line_7.length() > 0 )     s += QStringLiteral("\n%1").arg(Line_7);
+    if(  Line_8.length() > 0)      s += QStringLiteral("\n%1").arg(Line_8);
+    if(  Line_9.length() > 0 )     s += QStringLiteral("\n%1").arg(Line_9);
+    if(  Line_10.length() > 0 )    s += QStringLiteral("\n%1").arg(Line_10);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/vTRNOISE.cpp
+++ b/qucs/spicecomponents/vTRNOISE.cpp
@@ -112,7 +112,7 @@ QString vTRNOISE::spice_netlist(bool)
    QString Rtsemt = spicecompat::normalize_value(Props.at(6)->Value);
 
 
-    s += QString(" DC 0 AC 0 TRNOISE(%1 %2 %3 %4 %5  %6 %7) \n").arg(Na).arg(Nt).arg(Nalpha).arg(Namp).
+    s += QStringLiteral(" DC 0 AC 0 TRNOISE(%1 %2 %3 %4 %5  %6 %7) \n").arg(Na).arg(Nt).arg(Nalpha).arg(Namp).
                                 arg(Rtsam).arg(Rtscapt).arg(Rtsemt);
     return s;
 }

--- a/qucs/spicecomponents/vTRRANDOM.cpp
+++ b/qucs/spicecomponents/vTRRANDOM.cpp
@@ -111,6 +111,6 @@ QString vTRRANDOM::spice_netlist(bool)
    QString Param1 = spicecompat::normalize_value(Props.at(3)->Value);
    QString Param2 = spicecompat::normalize_value(Props.at(4)->Value);
 
-    s += QString(" DC 0 AC 0 TRRANDOM(%1 %2 %3 %4 %5 ) \n").arg(Type).arg(Ts).arg(Td).arg(Param1).arg(Param2);
+    s += QStringLiteral(" DC 0 AC 0 TRRANDOM(%1 %2 %3 %4 %5 ) \n").arg(Type).arg(Ts).arg(Td).arg(Param1).arg(Param2);
     return s;
 }

--- a/qucs/spicecomponents/volt_ac_SPICE.cpp
+++ b/qucs/spicecomponents/volt_ac_SPICE.cpp
@@ -87,11 +87,11 @@ QString Vac_SPICE::spice_netlist(bool)
     QString l3= Props.at(3)->Value;
     QString l4= Props.at(4)->Value;
 
-    if(l0.length()> 0)   s += QString("%1").arg(l0);
-    if(l1.length()> 0)   s += QString("\n%1").arg(l1);
-    if(l2.length()> 0)   s += QString("\n%1").arg(l2);
-    if(l3.length()> 0)   s += QString("\n%1").arg(l3);
-    if(l4.length()> 0)   s += QString("\n%1").arg(l4);
+    if(l0.length()> 0)   s += QStringLiteral("%1").arg(l0);
+    if(l1.length()> 0)   s += QStringLiteral("\n%1").arg(l1);
+    if(l2.length()> 0)   s += QStringLiteral("\n%1").arg(l2);
+    if(l3.length()> 0)   s += QStringLiteral("\n%1").arg(l3);
+    if(l4.length()> 0)   s += QStringLiteral("\n%1").arg(l4);
     s += "\n";
 
     return s;

--- a/qucs/spicecomponents/vsffm.cpp
+++ b/qucs/spicecomponents/vsffm.cpp
@@ -105,6 +105,6 @@ QString vSffm::spice_netlist(bool)
    QString Fs = spicecompat::normalize_value(Props.at(4)->Value);
 
 
-    s += QString(" DC 0 SFFM(%1 %2 %3 %4 %5 ) AC 0\n").arg(Vo).arg(Va).arg(Fc).arg(Mdi).arg(Fs);
+    s += QStringLiteral(" DC 0 SFFM(%1 %2 %3 %4 %5 ) AC 0\n").arg(Vo).arg(Va).arg(Fc).arg(Mdi).arg(Fs);
     return s;
 }

--- a/qucs/spicecomponents/xspicegeneric.cpp
+++ b/qucs/spicecomponents/xspicegeneric.cpp
@@ -166,9 +166,9 @@ QString XspiceGeneric::spice_netlist(bool)
             (t_port!="d")) {
             i++;
             QString nod1 =  spicecompat::normalize_node_name(Ports.at(i)->Connection->Name);
-            s += QString(" %%1(%2 %3) ").arg(t_port).arg(nod).arg(nod1);
+            s += QStringLiteral(" %%1(%2 %3) ").arg(t_port).arg(nod).arg(nod1);
         } else {
-            s += QString(" %%1(%2) ").arg(t_port).arg(nod);
+            s += QStringLiteral(" %%1(%2) ").arg(t_port).arg(nod);
         }
         if (closing_bracket) s += ']';
         i++;


### PR DESCRIPTION
- Qt provides a macro `QStringLiteral()`, which makes constructing QString objects from string literals more efficient.