### PR TITLE
Add grid color setting option

### DIFF
--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -600,7 +600,7 @@ void QucsSettingsDialog::slotApply()
         for (int tab = 0; tab < App->DocumentTab->count(); tab++) {
             QWidget* widget = App->DocumentTab->widget(tab);
             if (!QucsApp::isTextDocument(widget)) {
-                static_cast<Schematic*>(widget)->GridColor = _settings::Get().item<QColor>("GridColor");
+                static_cast<Schematic*>(widget)->setGridColor(_settings::Get().item<QColor>("GridColor"));
             }
         }
 

--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -597,6 +597,17 @@ void QucsSettingsDialog::slotApply()
     if (_settings::Get().item<QColor>("GridColor") != GridColorButton->palette().color(GridColorButton->backgroundRole()))
     {
         _settings::Get().setItem<QColor>("GridColor", GridColorButton->palette().color(GridColorButton->backgroundRole()));
+
+        for (int tab = 0; tab < App->DocumentTab->count(); tab++)
+        {
+            QWidget* widget = App->DocumentTab->widget(tab);
+            if (!QucsApp::isTextDocument(widget))
+            {
+                static_cast<Schematic*>(widget)->setChanged(true);
+                static_cast<Schematic*>(widget)->repaint();
+            }
+        }
+
         changed = true;
     }
 

--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -594,17 +594,13 @@ void QucsSettingsDialog::slotApply()
     }
 
     // Update all open schematics with the new grid color.
-    if (_settings::Get().item<QColor>("GridColor") != GridColorButton->palette().color(GridColorButton->backgroundRole()))
-    {
+    if (_settings::Get().item<QColor>("GridColor") != GridColorButton->palette().color(GridColorButton->backgroundRole())) {
         _settings::Get().setItem<QColor>("GridColor", GridColorButton->palette().color(GridColorButton->backgroundRole()));
 
-        for (int tab = 0; tab < App->DocumentTab->count(); tab++)
-        {
+        for (int tab = 0; tab < App->DocumentTab->count(); tab++) {
             QWidget* widget = App->DocumentTab->widget(tab);
-            if (!QucsApp::isTextDocument(widget))
-            {
-                static_cast<Schematic*>(widget)->setChanged(true);
-                static_cast<Schematic*>(widget)->repaint();
+            if (!QucsApp::isTextDocument(widget)) {
+                static_cast<Schematic*>(widget)->GridColor = _settings::Get().item<QColor>("GridColor");
             }
         }
 

--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -75,33 +75,7 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     QWidget *appSettingsTab = new QWidget(t);
     QGridLayout *appSettingsGrid = new QGridLayout(appSettingsTab);
 
-    appSettingsGrid->addWidget(new QLabel(tr("Schematic font (set after reload):"), appSettingsTab), 0,0);
-    FontButton = new QPushButton(appSettingsTab);
-    connect(FontButton, SIGNAL(clicked()), SLOT(slotFontDialog()));
-    appSettingsGrid->addWidget(FontButton,0,1);
-
-    appSettingsGrid->addWidget(new QLabel(tr("Application font (set after reload):"), appSettingsTab), 1,0);
-    AppFontButton = new QPushButton(appSettingsTab);
-    connect(AppFontButton, SIGNAL(clicked()), SLOT(slotAppFontDialog()));
-    appSettingsGrid->addWidget(AppFontButton,1,1);
-
-    appSettingsGrid->addWidget(new QLabel(tr("Text document font (set after reload):"), appSettingsTab), 2,0);
-    TextFontButton = new QPushButton(appSettingsTab);
-    connect(TextFontButton, SIGNAL(clicked()), SLOT(slotTextFontDialog()));
-    appSettingsGrid->addWidget(TextFontButton,2,1);
-
-    val50 = new QIntValidator(1, 50, this);
-    appSettingsGrid->addWidget(new QLabel(tr("Large font size:"), appSettingsTab), 3,0);
-    LargeFontSizeEdit = new QLineEdit(appSettingsTab);
-    LargeFontSizeEdit->setValidator(val50);
-    appSettingsGrid->addWidget(LargeFontSizeEdit,3,1);
-
-    appSettingsGrid->addWidget(new QLabel(tr("Document Background Color:"), appSettingsTab) ,4,0);
-    BGColorButton = new QPushButton("      ", appSettingsTab);
-    connect(BGColorButton, SIGNAL(clicked()), SLOT(slotBGColorDialog()));
-    appSettingsGrid->addWidget(BGColorButton,4,1);
-
-    appSettingsGrid->addWidget(new QLabel(tr("Language (set after reload):"), appSettingsTab) ,5,0);
+    appSettingsGrid->addWidget(new QLabel(tr("Language (set after reload):"), appSettingsTab) ,1, 0);
     LanguageCombo = new QComboBox(appSettingsTab);
     LanguageCombo->insertItem(-1, tr("Ukrainian")+" (uk)");
     LanguageCombo->insertItem(-1, tr("Turkish")+" (tr)");
@@ -125,48 +99,86 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     LanguageCombo->insertItem(-1, tr("Arabic")+" (ar)");
     LanguageCombo->insertItem(-1, tr("English")+" (en)");
     LanguageCombo->insertItem(-1, tr("system language"));
-    appSettingsGrid->addWidget(LanguageCombo,5,1);
+    appSettingsGrid->addWidget(LanguageCombo, 1, 1);
 
     val200 = new QIntValidator(0, 200, this);
-    appSettingsGrid->addWidget(new QLabel(tr("Maximum undo operations:"), appSettingsTab) ,6,0);
+    appSettingsGrid->addWidget(new QLabel(tr("Maximum undo operations:"), appSettingsTab) ,2, 0);
     undoNumEdit = new QLineEdit(appSettingsTab);
     undoNumEdit->setValidator(val200);
-    appSettingsGrid->addWidget(undoNumEdit,6,1);
+    appSettingsGrid->addWidget(undoNumEdit, 2, 1);
 
-    appSettingsGrid->addWidget(new QLabel(tr("Text editor:"), appSettingsTab) ,7,0);
+    appSettingsGrid->addWidget(new QLabel(tr("Text editor:"), appSettingsTab), 3, 0);
     editorEdit = new QLineEdit(appSettingsTab);
     editorEdit->setToolTip(tr("Set to qucs, qucsedit or the path to your favorite text editor."));
-    appSettingsGrid->addWidget(editorEdit,7,1);
+    appSettingsGrid->addWidget(editorEdit, 3, 1);
 
-    appSettingsGrid->addWidget(new QLabel(tr("Start wiring when clicking open node:"), appSettingsTab) ,8,0);
+    appSettingsGrid->addWidget(new QLabel(tr("Start wiring when clicking open node:"), appSettingsTab), 4, 0);
     checkWiring = new QCheckBox(appSettingsTab);
-    appSettingsGrid->addWidget(checkWiring,8,1);
+    appSettingsGrid->addWidget(checkWiring, 4, 1);
 
-    appSettingsGrid->addWidget(new QLabel(tr("Load documents from future versions:")));
+    appSettingsGrid->addWidget(new QLabel(tr("Load documents from future versions:")), 5, 0);
     checkLoadFromFutureVersions = new QCheckBox(appSettingsTab);
     checkLoadFromFutureVersions->setToolTip(tr("Try to load also documents created with newer versions of Qucs."));
-    appSettingsGrid->addWidget(checkLoadFromFutureVersions,9,1);
+    appSettingsGrid->addWidget(checkLoadFromFutureVersions, 5, 1);
     checkLoadFromFutureVersions->setChecked(QucsSettings.IgnoreFutureVersion);
 
-    appSettingsGrid->addWidget(new QLabel(tr("Draw diagrams with anti-aliasing feature:")));
-    checkAntiAliasing = new QCheckBox(appSettingsTab);
-    checkAntiAliasing->setToolTip(tr("Use anti-aliasing for graphs for a smoother appearance."));
-    appSettingsGrid->addWidget(checkAntiAliasing,10,1);
-    checkAntiAliasing->setChecked(QucsSettings.GraphAntiAliasing);
-
-    appSettingsGrid->addWidget(new QLabel(tr("Draw text with anti-aliasing feature:")));
-    checkTextAntiAliasing = new QCheckBox(appSettingsTab);
-    checkTextAntiAliasing->setToolTip(tr("Use anti-aliasing for text for a smoother appearance."));
-    appSettingsGrid->addWidget(checkTextAntiAliasing,11,1);
-    checkTextAntiAliasing->setChecked(QucsSettings.TextAntiAliasing);
-
-    appSettingsGrid->addWidget(new QLabel(tr("Show trace name prefix on diagrams:")));
+    appSettingsGrid->addWidget(new QLabel(tr("Show trace name prefix on diagrams:")), 6, 0);
     checkFullTraceNames = new QCheckBox(appSettingsTab);
     checkFullTraceNames->setToolTip(tr("Show prefixes for trace names on diagrams like \"ngspice/\""));
-    appSettingsGrid->addWidget(checkFullTraceNames,12,1);
+    appSettingsGrid->addWidget(checkFullTraceNames, 6, 1);
     checkFullTraceNames->setChecked(QucsSettings.fullTraceName);
 
     t->addTab(appSettingsTab, tr("Settings"));
+
+    // ...........................................................
+    // The appearance settings tab
+    QWidget *appAppearanceTab = new QWidget(t);
+    QGridLayout *appAppearanceGrid = new QGridLayout(appAppearanceTab);
+
+    appAppearanceGrid->addWidget(new QLabel(tr("Schematic font (set after reload):"), appSettingsTab), 0, 0);
+    FontButton = new QPushButton(appSettingsTab);
+    connect(FontButton, SIGNAL(clicked()), SLOT(slotFontDialog()));
+    appAppearanceGrid->addWidget(FontButton, 0, 1);
+
+    appAppearanceGrid->addWidget(new QLabel(tr("Application font (set after reload):"), appSettingsTab), 1, 0);
+    AppFontButton = new QPushButton(appSettingsTab);
+    connect(AppFontButton, SIGNAL(clicked()), SLOT(slotAppFontDialog()));
+    appAppearanceGrid->addWidget(AppFontButton, 1, 1);
+
+    appAppearanceGrid->addWidget(new QLabel(tr("Text document font (set after reload):"), appSettingsTab), 2, 0);
+    TextFontButton = new QPushButton(appSettingsTab);
+    connect(TextFontButton, SIGNAL(clicked()), SLOT(slotTextFontDialog()));
+    appAppearanceGrid->addWidget(TextFontButton, 2, 1);
+
+    val50 = new QIntValidator(1, 50, this);
+    appAppearanceGrid->addWidget(new QLabel(tr("Large font size:"), appSettingsTab), 3, 0);
+    LargeFontSizeEdit = new QLineEdit(appSettingsTab);
+    LargeFontSizeEdit->setValidator(val50);
+    appAppearanceGrid->addWidget(LargeFontSizeEdit, 3, 1);
+
+    appAppearanceGrid->addWidget(new QLabel(tr("Document Background Color:"), appSettingsTab) ,4, 0);
+    BGColorButton = new QPushButton("      ", appSettingsTab);
+    connect(BGColorButton, SIGNAL(clicked()), SLOT(slotBGColorDialog()));
+    appAppearanceGrid->addWidget(BGColorButton, 4, 1);
+
+    appAppearanceGrid->addWidget(new QLabel(tr("Grid Color (set after reload):"), appSettingsTab) ,5, 0);
+    GridColorButton = new QPushButton("      ", appSettingsTab);
+    connect(GridColorButton, SIGNAL(clicked()), SLOT(slotGridColorDialog()));
+    appAppearanceGrid->addWidget(GridColorButton, 5, 1);
+
+    appAppearanceGrid->addWidget(new QLabel(tr("Draw diagrams with anti-aliasing feature:")), 6, 0);
+    checkAntiAliasing = new QCheckBox(appSettingsTab);
+    checkAntiAliasing->setToolTip(tr("Use anti-aliasing for graphs for a smoother appearance."));
+    appAppearanceGrid->addWidget(checkAntiAliasing, 6, 1);
+    checkAntiAliasing->setChecked(QucsSettings.GraphAntiAliasing);
+
+    appAppearanceGrid->addWidget(new QLabel(tr("Draw text with anti-aliasing feature:")), 7, 0);
+    checkTextAntiAliasing = new QCheckBox(appSettingsTab);
+    checkTextAntiAliasing->setToolTip(tr("Use anti-aliasing for text for a smoother appearance."));
+    appAppearanceGrid->addWidget(checkTextAntiAliasing, 7, 1);
+    checkTextAntiAliasing->setChecked(QucsSettings.TextAntiAliasing);    
+
+    t->addTab(appAppearanceTab, tr("Appearance"));
 
     // ...........................................................
     // The source code editor settings tab
@@ -449,6 +461,10 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     p.setColor(BGColorButton->backgroundRole(), QucsSettings.BGColor);
     BGColorButton->setPalette(p);
 
+    p = GridColorButton->palette();
+    p.setColor(GridColorButton->backgroundRole(), _settings::Get().item<QColor>("GridColor"));
+    GridColorButton->setPalette(p);
+
     undoNumEdit->setText(QString::number(QucsSettings.maxUndo));
     editorEdit->setText(QucsSettings.Editor);
     checkWiring->setChecked(QucsSettings.NodeWiring);
@@ -574,6 +590,13 @@ void QucsSettingsDialog::slotApply()
           p.setColor(vp->backgroundRole(), QucsSettings.BGColor);
           vp->setPalette(p);
         }
+        changed = true;
+    }
+
+    // Update all open schematics with the new grid color.
+    if (_settings::Get().item<QColor>("GridColor") != GridColorButton->palette().color(GridColorButton->backgroundRole()))
+    {
+        _settings::Get().setItem<QColor>("GridColor", GridColorButton->palette().color(GridColorButton->backgroundRole()));
         changed = true;
     }
 
@@ -763,6 +786,19 @@ void QucsSettingsDialog::slotBGColorDialog()
         QPalette p = BGColorButton->palette();
         p.setColor(BGColorButton->backgroundRole(), c);
         BGColorButton->setPalette(p);
+    }
+}
+
+// -----------------------------------------------------------
+void QucsSettingsDialog::slotGridColorDialog()
+{
+    QColor c = QColorDialog::getColor(
+                   GridColorButton->palette().color(GridColorButton->foregroundRole()),
+                   this);
+    if(c.isValid()) {
+        QPalette p = GridColorButton->palette();
+        p.setColor(GridColorButton->backgroundRole(), c);
+        GridColorButton->setPalette(p);
     }
 }
 

--- a/qucs/dialogs/qucssettingsdialog.h
+++ b/qucs/dialogs/qucssettingsdialog.h
@@ -51,6 +51,7 @@ private slots:
     void slotAppFontDialog();
     void slotTextFontDialog();
     void slotBGColorDialog();
+    void slotGridColorDialog();
     void slotDefaultValues();
     void slotAddFileType();
     void slotRemoveFileType();
@@ -88,7 +89,7 @@ public:
               *checkAntiAliasing, *checkTextAntiAliasing,
               *checkFullTraceNames;
     QComboBox *LanguageCombo;
-    QPushButton *FontButton, *AppFontButton, *TextFontButton, *BGColorButton;
+    QPushButton *FontButton, *AppFontButton, *TextFontButton, *BGColorButton, *GridColorButton;
     QLineEdit *LargeFontSizeEdit, *undoNumEdit, *editorEdit, *Input_Suffix,
               *Input_Program, *homeEdit, *admsXmlEdit, *ascoEdit, *octaveEdit,
               *OpenVAFEdit, *RFLayoutEdit;

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -55,6 +55,7 @@
 #include "paintings/paintings.h"
 #include "qucs.h"
 #include "schematic.h"
+#include "settings.h"
 #include "textdoc.h"
 
 #include "misc.h"
@@ -87,6 +88,8 @@ Schematic::Schematic(QucsApp *App_, const QString &Name_)
     setFont(QucsSettings.font);
     // ...........................................................
     GridX = GridY = 10;
+    GridColor = _settings::Get().item<QString>("GridColor");
+   
     ViewX1 = ViewY1 = 0;
     ViewX2 = ViewY2 = 1;
     UsedX1 = UsedY1 = INT_MAX;
@@ -1078,7 +1081,7 @@ void Schematic::drawGrid(QPainter* painter) {
     // A grid drawn with pen of 1.0 width reportedly looks good both
     // on standard and HiDPI displays.
     // See here for details https://github.com/ra3xdh/qucs_s/pull/524
-    painter->setPen(QPen{ Qt::black, 1.0 });
+    painter->setPen(QPen{ GridColor, 1.0 });
 
     {
         // Draw small cross at origin of coordinates

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1098,7 +1098,7 @@ void Schematic::drawGrid(QPainter* painter) {
     // A grid drawn with pen of 1.0 width reportedly looks good both
     // on standard and HiDPI displays.
     // See here for details https://github.com/ra3xdh/qucs_s/pull/524
-    painter->setPen(QPen{ GridColor, 1.0 });
+    painter->setPen(QPen{ a_GridColor, 1.0 });
 
     {
         // Draw small cross at origin of coordinates

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -205,8 +205,9 @@ public:
   bool symbolMode;  // true if in symbol painting mode
   bool isSymbolOnly;
 
-  // Horizontal and vertical grid step
+  // Horizontal and vertical grid step, grid color.
   int GridX, GridY;
+  QColor GridColor;
 
   // Variables View* are the coordinates of top-level and bottom-right corners
   // of a rectangle representing the schematic "model". This

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -213,6 +213,8 @@ public:
   void setGridX(int value) { a_GridX = value; }
   int getGridY() const { return a_GridY; }
   void setGridY(int value) { a_GridY = value; }
+  void setGridColor(const QColor& color) { a_GridColor = color; }
+  QColor getGridColor() const { return a_GridColor; }
   bool getSymbolMode() const { return a_symbolMode; }
   void setSymbolMode(bool value) { a_symbolMode = value; }
   bool getIsSymbolOnly() const { return a_isSymbolOnly; }

--- a/qucs/settings.cpp
+++ b/qucs/settings.cpp
@@ -49,6 +49,7 @@ void settingsManager::initDefaults()
     m_Defaults["font"] = QApplication::font();
     m_Defaults["appFont"] = QApplication::font();
     m_Defaults["LargeFontSize"] = static_cast<double>(16.0);
+    m_Defaults["GridColor"] = QColor(qRgb(25, 25, 25));
     m_Defaults["maxUndo"] = 20;
     m_Defaults["QucsHomeDir"] = QDir::homePath() + QDir::toNativeSeparators("/QucsWorkspace");
 


### PR DESCRIPTION
This change adds a new 'Appearance' tab to the `QucsSettingsDialog` and moves all settings related to schematic appearance to it.

A new option to change the schematic grid color is added. Currently, it requires the user to close and reopen each schematic for the change to be visible. This is because there doesn't seem to be a dynamic mechanism to update the schematic following a color change