### PR TITLE
Allow document grid visibilty to be toggled via menu and shortcut key

### DIFF
--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -2055,7 +2055,6 @@ void QucsApp::slotHelpReport()
 // Is called when another document is selected via the TabBar.
 void QucsApp::slotChangeView()
 {
-
   QWidget *w = DocumentTab->currentWidget();
   editText->setHidden (true); // disable text edit of component property
   QucsDoc * Doc;
@@ -2086,6 +2085,8 @@ void QucsApp::slotChangeView()
       switchSchematicDoc(true);
       changeSchematicSymbolMode(d);
     }
+
+    showGrid->setChecked(d->getGridOn());
   }
 
   Doc->becomeCurrent(true);
@@ -2133,6 +2134,10 @@ void QucsApp::slotFileSettings ()
   else {
     SettingsDialog * d = new SettingsDialog ((Schematic *) w);
     d->exec ();
+
+    // TODO: It would be better to emit a signal to notify all subscribers
+    // that the diagram settings have changed.
+    showGrid->setChecked(static_cast<Schematic*>(w)->getGridOn());
   }
 }
 

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -349,7 +349,7 @@ public:
 
   QAction *insWire, *insLabel, *insGround, *insPort, *insEquation, *magPlus,
           *editRotate, *editMirror, *editMirrorY, *editPaste, *select,
-          *editActivate, *wire, *editDelete, *setMarker, *setDiagramLimits, *resetDiagramLimits, *onGrid, *moveText,
+          *editActivate, *wire, *editDelete, *setMarker, *setDiagramLimits, *resetDiagramLimits, *showGrid, *onGrid, *moveText,
           *helpIndex, *helpGetStart, *callEditor, *callFilter, *callLine, *callActiveFilter,
           *showMsg, *showNet, *alignTop, *alignBottom, *alignLeft, *alignRight,
           *distrHor, *distrVert, *selectAll, *callMatch, *changeProps,
@@ -381,6 +381,7 @@ public slots:
   void slotSetMarker(bool);
   void slotSetDiagramLimits(bool);
   void slotResetDiagramLimits();
+  void slotShowGrid();        // turn the grid on or off
   void slotOnGrid(bool);      // set selected elements on grid
   void slotMoveText(bool);    // move property text of components
   void slotZoomIn(bool);

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -249,6 +249,19 @@ void QucsApp::slotResetDiagramLimits()
 }
 
 // -----------------------------------------------------------------------
+// Is called, when "show grid" action is triggered.
+void QucsApp::slotShowGrid()
+{
+  qDebug() << "slotShowGrid";
+  Schematic* schematic = static_cast<Schematic*>(DocumentTab->currentWidget());
+  if(!isTextDocument(schematic)) {
+    schematic->setGridOn(!schematic->getGridOn());
+    schematic->setChanged(true);
+    schematic->viewport()->repaint();
+  }
+}
+
+// -----------------------------------------------------------------------
 // Is called, when "move component text" action is triggered.
 void QucsApp::slotMoveText(bool on)
 {

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -597,6 +597,13 @@ void QucsApp::initActions()
   resetDiagramLimits->setWhatsThis(tr("Reset Diagram Limits\n\nResets the limits for all axis to auto."));
   connect(resetDiagramLimits, SIGNAL(triggered()), SLOT(slotResetDiagramLimits()));
 
+  showGrid = new QAction(tr("Show Grid (current document)"), this);
+  showGrid->setCheckable(true);
+  showGrid->setShortcut(tr("Alt+G"));
+  showGrid->setStatusTip(tr("Show or hide the grid for the current document."));
+  showGrid->setWhatsThis(tr("Show / Hide Grid\n\nShow or hide the grid for the current document."));
+  connect(showGrid, SIGNAL(triggered()), SLOT(slotShowGrid()));
+
   showMsg = new QAction(tr("Show Last Messages"), this);
   showMsg->setShortcut(Qt::Key_F5);
   showMsg->setStatusTip(tr("Shows last simulation messages"));
@@ -800,7 +807,9 @@ void QucsApp::initMenuBar()
   viewMenu->addAction(magMinus);
   viewMenu->addAction(setDiagramLimits);
   viewMenu->addSeparator();
-  //viewMenu->setCheckable(true);
+  viewMenu->addAction(showGrid);
+  viewMenu->addSeparator();
+    //viewMenu->setCheckable(true);
   viewMenu->addAction(viewBrowseDock);
   viewMenu->addAction(viewOctaveDock);
 


### PR DESCRIPTION
This change allows a schematic's grid to be shown or hidden via a shortcut key and an entry in the 'View' menu.