### PR TITLE
Allow a default graph line thickness to be set

### DIFF
--- a/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/diagrams/diagramdialog.cpp
@@ -25,6 +25,7 @@
 #include "rect3ddiagram.h"
 #include "main.h"
 #include "misc.h"
+#include "settings.h"
 
 #include <cmath>
 #include <assert.h>
@@ -250,7 +251,7 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
     Property2->setValidator(ValInteger);
     Property2->setMaximumWidth(25);
     Property2->setMaxLength(2);
-    Property2->setText("0");
+    Property2->setText(_settings::Get().item<QString>("DefaultGraphLineWidth"));
 
     if((Diag->Name=="Rect") || (Diag->Name=="PS") || (Diag->Name=="SP") || (Diag->Name=="Curve")) {
       Label4 = new QLabel(tr("y-Axis:"));

--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -176,7 +176,12 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     checkTextAntiAliasing = new QCheckBox(appSettingsTab);
     checkTextAntiAliasing->setToolTip(tr("Use anti-aliasing for text for a smoother appearance."));
     appAppearanceGrid->addWidget(checkTextAntiAliasing, 7, 1);
-    checkTextAntiAliasing->setChecked(QucsSettings.TextAntiAliasing);    
+    checkTextAntiAliasing->setChecked(QucsSettings.TextAntiAliasing);
+
+    appAppearanceGrid->addWidget(new QLabel(tr("Default graph line thickness:"), appSettingsTab), 8, 0);
+    graphLineWidthEdit = new QLineEdit(appSettingsTab);
+    graphLineWidthEdit->setValidator(val50);
+    appAppearanceGrid->addWidget(graphLineWidthEdit, 8, 1);      
 
     t->addTab(appAppearanceTab, tr("Appearance"));
 
@@ -456,6 +461,7 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     TextFontButton->setText(TextFont.toString());
     QString s = QString::number(QucsSettings.largeFontSize, 'f', 1);
     LargeFontSizeEdit->setText(s);
+    graphLineWidthEdit->setText(_settings::Get().item<QString>("DefaultGraphLineWidth"));
 
     p = BGColorButton->palette();
     p.setColor(BGColorButton->backgroundRole(), QucsSettings.BGColor);
@@ -720,6 +726,12 @@ void QucsSettingsDialog::slotApply()
     if (QucsSettings.largeFontSize != LargeFontSizeEdit->text().toDouble(&ok))
     {
         QucsSettings.largeFontSize = LargeFontSizeEdit->text().toDouble(&ok);
+        changed = true;
+    }
+
+    if (_settings::Get().item<QString>("DefaultGraphLineWidth") != graphLineWidthEdit->text())
+    {
+        _settings::Get().setItem<QString>("DefaultGraphLineWidth", graphLineWidthEdit->text());
         changed = true;
     }
 

--- a/qucs/dialogs/qucssettingsdialog.h
+++ b/qucs/dialogs/qucssettingsdialog.h
@@ -92,7 +92,7 @@ public:
     QPushButton *FontButton, *AppFontButton, *TextFontButton, *BGColorButton, *GridColorButton;
     QLineEdit *LargeFontSizeEdit, *undoNumEdit, *editorEdit, *Input_Suffix,
               *Input_Program, *homeEdit, *admsXmlEdit, *ascoEdit, *octaveEdit,
-              *OpenVAFEdit, *RFLayoutEdit;
+              *OpenVAFEdit, *RFLayoutEdit, *graphLineWidthEdit;
     QTableWidget *fileTypesTableWidget, *pathsTableWidget;
     QStandardItemModel *model;
     QPushButton *ColorComment, *ColorString, *ColorInteger,

--- a/qucs/settings.cpp
+++ b/qucs/settings.cpp
@@ -50,6 +50,7 @@ void settingsManager::initDefaults()
     m_Defaults["appFont"] = QApplication::font();
     m_Defaults["LargeFontSize"] = static_cast<double>(16.0);
     m_Defaults["GridColor"] = QColor(qRgb(25, 25, 25));
+    m_Defaults["DefaultGraphLineWidth"] = "1";
     m_Defaults["maxUndo"] = 20;
     m_Defaults["QucsHomeDir"] = QDir::homePath() + QDir::toNativeSeparators("/QucsWorkspace");
 


### PR DESCRIPTION
This change allows the user to set a default graph line thickness via the Application Settings dialog according to their preference.

Individual graphs can still be adjusted via the normal diagram dialog.