### PR TITLE
Fix #1055 and #861

### DIFF
--- a/qucs/extsimkernels/spicecompat.cpp
+++ b/qucs/extsimkernels/spicecompat.cpp
@@ -285,6 +285,10 @@ int spicecompat::getPins(const QString &file, const QString &compname, QStringLi
     QTextStream stream(&content,QIODevice::ReadOnly);
     while (!stream.atEnd()) {
         QString lin = stream.readLine();
+        auto start_comment = lin.indexOf(';');
+        if (start_comment != -1) {
+          lin = lin.left(start_comment);
+        }
 
         if (subckt_header.match(lin).hasMatch()) {
 
@@ -323,7 +327,7 @@ QString spicecompat::getSubcktName(const QString& subfilename)
         const QRegularExpression subckt_header("^\\s*\\.(S|s)(U|u)(B|b)(C|c)(K|k)(T|t)\\s.*");
         const QRegularExpression sep("\\s");
         QStringList lst = QString(sub_file.readAll()).split("\n");
-        for (const QString& str : lst) {            
+        for (const QString& str : lst) {
             if (subckt_header.match(str).hasMatch()) {
                 s = str.section(sep,1,1,QString::SectionSkipEmpty);
                 break;

--- a/qucs/extsimkernels/spicecompat.cpp
+++ b/qucs/extsimkernels/spicecompat.cpp
@@ -283,6 +283,7 @@ int spicecompat::getPins(const QString &file, const QString &compname, QStringLi
     const QRegularExpression sep("\\s");
 
     QTextStream stream(&content,QIODevice::ReadOnly);
+    bool header_start = false;
     while (!stream.atEnd()) {
         QString lin = stream.readLine();
         auto start_comment = lin.indexOf(';');
@@ -290,8 +291,21 @@ int spicecompat::getPins(const QString &file, const QString &compname, QStringLi
           lin = lin.left(start_comment);
         }
 
-        if (subckt_header.match(lin).hasMatch()) {
+        if (header_start) {
+          // line continuation
+          if (lin.startsWith("+")) {
+            lin.remove(0,1);
+            QStringList pins = lin.split(QRegularExpression("[ \\t]"),Qt::SkipEmptyParts);
+            pin_names.append(pins);
+          } else {
+            // end of header
+            header_start = false;
+            break;
+          }
+        }
 
+        if (subckt_header.match(lin).hasMatch()) {
+            header_start = true;
             QStringList lst2 = lin.split(sep,qucs::SkipEmptyParts);
             QString name = lin.section(sep,1,1,QString::SectionSkipEmpty).toLower();
             QString refname = compname.toLower();
@@ -300,13 +314,14 @@ int spicecompat::getPins(const QString &file, const QString &compname, QStringLi
             lst2.removeFirst();
             for (const auto &s1: lst2) {
                 QString pp = s1;
+                if (pp.toLower() == "params:") header_start = false;
                 if (!s1.contains('=') &&
                    (pp.toLower() != "params:")) {
                     pin_names.append(s1);
                 }
             }
             r = pin_names.count();
-            break;
+            //break;
         }
     }
 

--- a/qucs/extsimkernels/spicelibcompdialog.cpp
+++ b/qucs/extsimkernels/spicelibcompdialog.cpp
@@ -277,6 +277,11 @@ int SpiceLibCompDialog::parseLibFile(const QString &filename)
     QString line = ts.readLine();
     line = line.trimmed();
     line = line.toUpper();
+    // semicolon may be comment start
+    auto start_comment = line.indexOf(';');
+    if (start_comment != -1) {
+      line = line.left(start_comment);
+    }
     if (line.startsWith(".SUBCKT")) {
       subcir_start = true;
       subcir_body.clear();

--- a/qucs/extsimkernels/spicelibcompdialog.cpp
+++ b/qucs/extsimkernels/spicelibcompdialog.cpp
@@ -271,6 +271,8 @@ int SpiceLibCompDialog::parseLibFile(const QString &filename)
   QTextStream ts(&f);
 
   bool subcir_start = false;
+  bool header_start = false;
+  QString last_subcir;
   QString subname;
   QString subcir_body;
   while (!ts.atEnd()) {
@@ -282,17 +284,33 @@ int SpiceLibCompDialog::parseLibFile(const QString &filename)
     if (start_comment != -1) {
       line = line.left(start_comment);
     }
+
+    if (header_start) {
+      // line continuation
+      if (line.startsWith("+")) {
+        line.remove(0,1);
+        QStringList pins = line.split(QRegularExpression("[ \\t]"),Qt::SkipEmptyParts);
+        subcirPins[last_subcir].append(pins);
+      } else {
+        // end of header
+        header_start = false;
+      }
+    }
+
     if (line.startsWith(".SUBCKT")) {
       subcir_start = true;
+      header_start = true;
       subcir_body.clear();
       QStringList pin_names;
       QStringList tokens = line.split(QRegularExpression("[ \\t]"),Qt::SkipEmptyParts);
       if (tokens.count() > 3) {
         subname = tokens.at(1);
+        last_subcir = subname;
       } else continue;
       tokens.removeFirst();
       tokens.removeFirst();
       for (const auto &s1: tokens) {
+        if (s1 == "PARAMS:") header_start = false;
         if (!s1.contains('=') && (s1 != "PARAMS:")) {
           pin_names.append(s1);
         }


### PR DESCRIPTION
This PR fixes two issues:

* Parsing of SUBCKT header containing `;` comment #1055 
* Parsing multi-line SUBCKT header with `+` line continuation #861 