### PR TITLE
Fix sweep steps and number of points issues  (see #1077)

### DIFF
--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -568,14 +568,14 @@ void ComponentDialog::updateSweepProperty(const QString& property)
       if (property == "Start" || property == "Stop" || property == "Points" || property == "All")
       {
         double points = str2num(sweepParamWidget["Points"]->value());
-        double step = (points - 1) / log10(fabs((stop < 1 ? 1 : stop) / (start < 1 ? 1 : start)));
+        double step = (points - 1.0) / log10(fabs((stop < 1.0 ? 1.0 : stop) / (start < 1.0 ? 1.0 : start)));
         sweepParamWidget["Step"]->setValue(misc::num2str(step));
       }
       else if (property == "Step")
       {
         double step = str2num(sweepParamWidget["Step"]->value());
-        double points = log10(fabs((stop < 1 ? 1 : stop) / (start < 1 ? 1 : start))) * step;
-        sweepParamWidget["Points"]->setValue(misc::num2str(points));
+        double points = log10(fabs((stop < 1.0 ? 1.0 : stop) / (start < 1.0 ? 1.0 : start))) * step + 1.0;
+        sweepParamWidget["Points"]->setValue(QString::number(round(points), 'g', 16));
       }     
     }
     else
@@ -589,8 +589,8 @@ void ComponentDialog::updateSweepProperty(const QString& property)
       else if (property == "Step")
       {
         double step = str2num(sweepParamWidget["Step"]->value());
-        double points = (stop - start) / step + 1;
-        sweepParamWidget["Points"]->setValue(misc::num2str(points));
+        double points = (stop - start) / step + 1.0;
+        sweepParamWidget["Points"]->setValue(QString::number(round(points), 'g', 16));
       }     
     }
   }


### PR DESCRIPTION
This pull request attempts to correct the issues found in #1077. Primarily, these were caused by converting the numeric representation to a string using misc::str2num. This is now replaced with the built-in QString::number function. 