### PR TITLE
Do not add export statement for certain models

### DIFF
--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -358,7 +358,7 @@ ComponentDialog::ComponentDialog(Component* schematicComponent, Schematic* schem
   // for a given simulation type. Then only create the valid widgets fo
   // sweepParams[".AC"] = QStringList({"Type", "Start", "Stop", "Points"});
 
-  paramsHiddenBySim["Export"] = QStringList{"NutmegEq"};
+  paramsHiddenBySim["Export"] = QStringList{"NutmegEq", "SpicePar", "SpGlobPar"};
   paramsHiddenBySim["Sim"] = QStringList{".AC", ".DISTO", ".SP", ".NOISE", ".TR", "Eqn", "SpicePar", "SpGlobPar"};
   paramsHiddenBySim["Param"] = QStringList{".AC", ".DISTO", ".SP", ".NOISE", ".TR"};
 


### PR DESCRIPTION
See #1105.

The Put result in dataset should only be enabled for Qucs (Qucsator RF) equations. 

The .PARAM is never put in the dataset and Nutmeg equations are always put in the dataset. 

SPICE handles the both automatically and there is no way to control this manually. 