### PR TITLE
AC power source amplitude fix

### DIFF
--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -106,7 +106,7 @@ QString Source_ac::ngspice_netlist()
     double z0 = spicecompat::normalize_value(getProperty("Z")->Value).toDouble();
     double p = spicecompat::normalize_value(getProperty("P")->Value).toDouble();
     double vrms = sqrt(z0/1000.0)*pow(10, p/20.0);
-    double vamp = 2*vrms*sqrt(2.0);
+    double vamp = 2.0*vrms*sqrt(2.0);
     QString f = spicecompat::normalize_value(getProperty("f")->Value);
 
     bool en_tran = true;
@@ -140,7 +140,7 @@ QString Source_ac::xyce_netlist()
     QString s_p = spicecompat::normalize_value(getProperty("P")->Value);
     double p = s_p.toDouble();
     double vrms = sqrt(z0/1000.0)*pow(10, p/20.0);
-    double vamp = 2*vrms*sqrt(2.0);
+    double vamp = 2.0*vrms*sqrt(2.0);
 
     bool en_tran = true;
     if (getProperty("EnableTran")->Value == "true") {

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -64,7 +64,7 @@ Source_ac::Source_ac()
   Props.append(new Property("Z", "50 Ohm", true,
 		QObject::tr("port impedance")));
   Props.append(new Property("P", "0 dBm", false,
-		QObject::tr("(available) ac power in Watts")));
+		QObject::tr("(available) ac power in dBm")));
   Props.append(new Property("f", "1 MHz", false,
 		QObject::tr("frequency in Hertz")));
   Props.append(new Property("Temp", "26.85", false,
@@ -106,7 +106,7 @@ QString Source_ac::ngspice_netlist()
     double z0 = spicecompat::normalize_value(getProperty("Z")->Value).toDouble();
     double p = spicecompat::normalize_value(getProperty("P")->Value).toDouble();
     double vrms = sqrt(z0/1000.0)*pow(10, p/20.0);
-    double vamp = 2.0*vrms*sqrt(2.0);
+    double vamp = vrms*sqrt(2.0);
     QString f = spicecompat::normalize_value(getProperty("f")->Value);
 
     bool en_tran = true;
@@ -140,7 +140,7 @@ QString Source_ac::xyce_netlist()
     QString s_p = spicecompat::normalize_value(getProperty("P")->Value);
     double p = s_p.toDouble();
     double vrms = sqrt(z0/1000.0)*pow(10, p/20.0);
-    double vamp = 2.0*vrms*sqrt(2.0);
+    double vamp = vrms*sqrt(2.0);
 
     bool en_tran = true;
     if (getProperty("EnableTran")->Value == "true") {

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -106,7 +106,7 @@ QString Source_ac::ngspice_netlist()
     double z0 = spicecompat::normalize_value(getProperty("Z")->Value).toDouble();
     double p = spicecompat::normalize_value(getProperty("P")->Value).toDouble();
     double vrms = sqrt(z0/1000.0)*pow(10, p/20.0);
-    double vamp = vrms*sqrt(2.0);
+    double vamp = 2*vrms*sqrt(2.0);
     QString f = spicecompat::normalize_value(getProperty("f")->Value);
 
     bool en_tran = true;
@@ -140,7 +140,7 @@ QString Source_ac::xyce_netlist()
     QString s_p = spicecompat::normalize_value(getProperty("P")->Value);
     double p = s_p.toDouble();
     double vrms = sqrt(z0/1000.0)*pow(10, p/20.0);
-    double vamp = vrms*sqrt(2.0);
+    double vamp = 2*vrms*sqrt(2.0);
 
     bool en_tran = true;
     if (getProperty("EnableTran")->Value == "true") {


### PR DESCRIPTION
This PR fix two issues:
1) Description string in `AC POWER SOURCE` related to the power field. It changes `Watts` to `dBm`

![image](https://github.com/user-attachments/assets/9a51d0cc-0812-4b64-b8c7-d3a87cb46c42)

2) Calculation of the amplitude of the voltage source. In the previous version a peak-to-peak voltage was calculated and streamed to the spice netlist. According to the `ngspice` and `Xyce` specification a voltage amplitude is required. See `ngspice` manual:

![image](https://github.com/user-attachments/assets/929de34c-790a-4247-a646-5a991e6acc9e)


Example from the figure above:
```
VP1 _net0 0 dc 0 ac 0.316228 SIN(0 0.316228 1MEG) portnum 1 z0 50
```

