### PR TITLE
inno setup improvements

### DIFF
--- a/contrib/InnoSetup/qucs.iss
+++ b/contrib/InnoSetup/qucs.iss
@@ -1,5 +1,5 @@
-;
-; qucs.iss - inno Setup script file
+; Qucs-S Inno Setup script file
+; Refactored for improved readability and maintainability
 ;
 ; Copyright (C) 2005-2011 Stefan Jahn <stefan@lkcc.org>
 ; Copyright (C) 2014-2016 Guilherme Brondani Torri <guitorri@gmail.com>
@@ -18,7 +18,7 @@
 ; along with this package; see the file COPYING.  If not, write to
 ; the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
 ; Boston, MA 02110-1301, USA.
-;
+
 #ifndef RELEASE
   #define RELEASE "24.3.0"
 #endif
@@ -31,37 +31,33 @@
 #define TREE "..\..\build\qucs-suite\"
 
 [Setup]
-AppName={# APPNAME}
-AppVersion={# RELEASE}
+AppName={#APPNAME}
+AppVersion={#RELEASE}
 AppPublisher=The Qucs-S Team
-AppPublisherURL={# URL}
-AppSupportURL={# URL}
-AppUpdatesURL={# URL}
+AppPublisherURL={#URL}
+AppSupportURL={#URL}
+AppUpdatesURL={#URL}
 DefaultDirName={pf}\Qucs-S
 DefaultGroupName=Qucs-S
 AllowNoIcons=yes
-LicenseFile={# TREE}\misc\gpl.rtf
-OutputBaseFilename={# APPNAME}-{# RELEASE}-setup
+LicenseFile={#TREE}\misc\gpl.rtf
+OutputBaseFilename={#APPNAME}-{#RELEASE}-setup
 Compression=lzma2/max
 SolidCompression=yes
 ChangesEnvironment=yes
 UsePreviousAppDir=yes
 WizardStyle=modern
-SetupIconFile={# TREE}\misc\qucs.ico
-
-; [Registry]
-; Root: HKLM; Subkey: SYSTEM\CurrentControlSet\Control\Session Manager\Environment; ValueType: string; ValueName: QUCSDIR; ValueData: "{app}"; Flags: deletevalue createvalueifdoesntexist noerror; MinVersion: 0,4.00.1381
+SetupIconFile={#TREE}\misc\qucs.ico
+Uninstallable=yes
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "{# TREE}\bin\*"; DestDir: "{app}\bin"; Flags: ignoreversion recursesubdirs createallsubdirs
-; Source: "{# TREE}\include\*"; DestDir: "{app}\include"; Flags: ignoreversion recursesubdirs createallsubdirs
-; Source: "{# TREE}\lib\*"; DestDir: "{app}\lib"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "{# TREE}\misc\*"; DestDir: "{app}\misc"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "{# TREE}\lib\*"; DestDir: "{app}\lib"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "{# TREE}\share\*"; DestDir: "{app}\share"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#TREE}\bin\*"; DestDir: "{app}\bin"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#TREE}\misc\*"; DestDir: "{app}\misc"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#TREE}\lib\*"; DestDir: "{app}\lib"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#TREE}\share\*"; DestDir: "{app}\share"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
 Name: "{group}\Qucs-S Simulator"; Filename: "{app}\bin\qucs-s.exe"; IconFilename: "{app}\misc\qucs.ico"; WorkingDir: "{app}\bin"
@@ -70,3 +66,16 @@ Name: "{group}\Technical Online Documentation"; Filename: "{app}\misc\docsite.ur
 Name: "{group}\{cm:UninstallProgram,Qucs}"; Filename: "{uninstallexe}"
 Name: "{userdesktop}\Qucs-S"; Filename: "{app}\bin\qucs-s.exe"; IconFilename: "{app}\misc\qucs.ico"; WorkingDir: "{app}\bin"; Tasks: desktopicon
 
+[Code]
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  ResultCode: Integer;
+  Uninstall: String;
+begin
+  if (CurStep = ssInstall) then begin
+    if RegQueryStringValue(HKLM, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{#APPNAME}_is1', 'UninstallString', Uninstall) then begin
+      MsgBox('An existing version of {#APPNAME} was detected. It will now be removed before installing the new version.', mbInformation, MB_OK);
+      Exec(RemoveQuotes(Uninstall), ' /SILENT', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode);
+    end;
+  end;
+end;

--- a/contrib/InnoSetup/qucs.iss
+++ b/contrib/InnoSetup/qucs.iss
@@ -49,6 +49,7 @@ UsePreviousAppDir=yes
 WizardStyle=modern
 SetupIconFile={#TREE}\misc\qucs.ico
 Uninstallable=yes
+ArchitecturesInstallIn64BitMode=x64compatible
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked


### PR DESCRIPTION
Hi, this PR add change windows installer, 
- it uninstalls before installing new version if installed. Newer Qt version changed some DLLs version and installer can't override it. 
- Enable x64compatible mode to install "C:\Program Files" currently install "C:\Program Files (x86)" so all executable is 64bit.