### PR TITLE
S-parameter Viewer: Some improvements

### DIFF
--- a/qucs-s-spar-viewer/CMakeLists.txt
+++ b/qucs-s-spar-viewer/CMakeLists.txt
@@ -58,9 +58,9 @@ ADD_DEFINITIONS(${QT_DEFINITIONS})
 
 #ADD_SUBDIRECTORY( bitmaps ) -> added as resources
 
-SET( spar_viewer_sources main.cpp qucs-s-spar-viewer.cpp)
+SET( spar_viewer_sources main.cpp qucs-s-spar-viewer.cpp codeeditor.cpp)
 
-SET( spar_viewer_moc_headers qucs-s-spar-viewer.h)
+SET( spar_viewer_moc_headers qucs-s-spar-viewer.h codeeditor.h)
 
 SET(RESOURCES qucs-s-spar-viewer.qrc)
 
@@ -93,7 +93,9 @@ ENDIF(APPLE)
 ADD_EXECUTABLE( ${QUCS_NAME}spar-viewer MACOSX_BUNDLE WIN32
   ${spar_viewer_sources}
   ${spar_viewer_moc_sources}
-  ${RESOURCES_SRCS} )
+  ${RESOURCES_SRCS}
+  codeeditor.cpp
+  codeeditor.h )
 
 TARGET_LINK_LIBRARIES( ${QUCS_NAME}spar-viewer Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Gui Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Charts )
 SET_TARGET_PROPERTIES(${QUCS_NAME}spar-viewer PROPERTIES POSITION_INDEPENDENT_CODE TRUE)

--- a/qucs-s-spar-viewer/codeeditor.cpp
+++ b/qucs-s-spar-viewer/codeeditor.cpp
@@ -1,0 +1,187 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the examples of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:BSD$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** BSD License Usage
+** Alternatively, you may use this file under the terms of the BSD license
+** as follows:
+**
+** "Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are
+** met:
+**   * Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**   * Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in
+**     the documentation and/or other materials provided with the
+**     distribution.
+**   * Neither the name of The Qt Company Ltd nor the names of its
+**     contributors may be used to endorse or promote products derived
+**     from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include "codeeditor.h"
+
+#include <QPainter>
+#include <QTextBlock>
+
+//![constructor]
+
+CodeEditor::CodeEditor(QWidget *parent) : QPlainTextEdit(parent)
+{
+  lineNumberArea = new LineNumberArea(this);
+
+  connect(this, &CodeEditor::blockCountChanged, this, &CodeEditor::updateLineNumberAreaWidth);
+  connect(this, &CodeEditor::updateRequest, this, &CodeEditor::updateLineNumberArea);
+  connect(this, &CodeEditor::cursorPositionChanged, this, &CodeEditor::highlightCurrentLine);
+
+  updateLineNumberAreaWidth(0);
+  highlightCurrentLine();
+}
+
+//![constructor]
+
+//![extraAreaWidth]
+
+int CodeEditor::lineNumberAreaWidth()
+{
+  int digits = 1;
+  int max = qMax(1, blockCount());
+  while (max >= 10) {
+    max /= 10;
+    ++digits;
+  }
+
+  int space = 3 + fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits;
+
+  return space;
+}
+
+//![extraAreaWidth]
+
+//![slotUpdateExtraAreaWidth]
+
+void CodeEditor::updateLineNumberAreaWidth(int /* newBlockCount */)
+{
+  setViewportMargins(lineNumberAreaWidth(), 0, 0, 0);
+}
+
+//![slotUpdateExtraAreaWidth]
+
+//![slotUpdateRequest]
+
+void CodeEditor::updateLineNumberArea(const QRect &rect, int dy)
+{
+  if (dy){
+    lineNumberArea->scroll(0, dy);
+  } else
+    lineNumberArea->update(0, rect.y(), lineNumberArea->width(), rect.height());
+
+  if (rect.contains(viewport()->rect())){
+    updateLineNumberAreaWidth(0);
+  }
+}
+
+//![slotUpdateRequest]
+
+//![resizeEvent]
+
+void CodeEditor::resizeEvent(QResizeEvent *e)
+{
+  QPlainTextEdit::resizeEvent(e);
+
+  QRect cr = contentsRect();
+  lineNumberArea->setGeometry(QRect(cr.left(), cr.top(), lineNumberAreaWidth(), cr.height()));
+}
+
+//![resizeEvent]
+
+//![cursorPositionChanged]
+
+void CodeEditor::highlightCurrentLine()
+{
+  QList<QTextEdit::ExtraSelection> extraSelections;
+
+  if (!isReadOnly()) {
+    QTextEdit::ExtraSelection selection;
+
+    QColor lineColor = QColor(Qt::yellow).lighter(160);
+
+    selection.format.setBackground(lineColor);
+    selection.format.setProperty(QTextFormat::FullWidthSelection, true);
+    selection.cursor = textCursor();
+    selection.cursor.clearSelection();
+    extraSelections.append(selection);
+  }
+
+  setExtraSelections(extraSelections);
+}
+
+//![cursorPositionChanged]
+
+//![extraAreaPaintEvent_0]
+
+void CodeEditor::lineNumberAreaPaintEvent(QPaintEvent *event)
+{
+  QPainter painter(lineNumberArea);
+  painter.fillRect(event->rect(), Qt::lightGray);
+
+  //![extraAreaPaintEvent_0]
+
+  //![extraAreaPaintEvent_1]
+  QTextBlock block = firstVisibleBlock();
+  int blockNumber = block.blockNumber();
+  int top = qRound(blockBoundingGeometry(block).translated(contentOffset()).top());
+  int bottom = top + qRound(blockBoundingRect(block).height());
+  //![extraAreaPaintEvent_1]
+
+  //![extraAreaPaintEvent_2]
+  while (block.isValid() && top <= event->rect().bottom()) {
+    if (block.isVisible() && bottom >= event->rect().top()) {
+      QString number = QString::number(blockNumber + 1);
+      painter.setPen(Qt::black);
+      painter.drawText(0, top, lineNumberArea->width(), fontMetrics().height(),
+                       Qt::AlignRight, number);
+    }
+
+    block = block.next();
+    top = bottom;
+    bottom = top + qRound(blockBoundingRect(block).height());
+    ++blockNumber;
+  }
+}
+
+void CodeEditor::loadText(const QString& text)
+{
+  setPlainText(text);
+}
+//![extraAreaPaintEvent_2]
+

--- a/qucs-s-spar-viewer/codeeditor.h
+++ b/qucs-s-spar-viewer/codeeditor.h
@@ -1,0 +1,119 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the examples of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:BSD$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** BSD License Usage
+** Alternatively, you may use this file under the terms of the BSD license
+** as follows:
+**
+** "Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are
+** met:
+**   * Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**   * Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in
+**     the documentation and/or other materials provided with the
+**     distribution.
+**   * Neither the name of The Qt Company Ltd nor the names of its
+**     contributors may be used to endorse or promote products derived
+**     from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef CODEEDITOR_H
+#define CODEEDITOR_H
+
+#include <QPlainTextEdit>
+
+QT_BEGIN_NAMESPACE
+class QPaintEvent;
+class QResizeEvent;
+class QSize;
+class QWidget;
+QT_END_NAMESPACE
+
+class LineNumberArea;
+
+//![codeeditordefinition]
+
+class CodeEditor : public QPlainTextEdit
+{
+  Q_OBJECT
+
+public:
+  CodeEditor(QWidget *parent = nullptr);
+
+  void lineNumberAreaPaintEvent(QPaintEvent *event);
+  int lineNumberAreaWidth();
+  QString getText() const { return toPlainText(); }
+  void loadText(const QString& text);
+
+
+
+protected:
+  void resizeEvent(QResizeEvent *event) override;
+
+private slots:
+  void updateLineNumberAreaWidth(int newBlockCount);
+  void highlightCurrentLine();
+  void updateLineNumberArea(const QRect &rect, int dy);
+
+private:
+  QWidget *lineNumberArea;
+};
+
+//![codeeditordefinition]
+//![extraarea]
+
+class LineNumberArea : public QWidget
+{
+public:
+  LineNumberArea(CodeEditor *editor) : QWidget(editor), codeEditor(editor)
+  {}
+
+  QSize sizeHint() const override
+  {
+    return QSize(codeEditor->lineNumberAreaWidth(), 0);
+  }
+
+protected:
+  void paintEvent(QPaintEvent *event) override
+  {
+    codeEditor->lineNumberAreaPaintEvent(event);
+  }
+
+private:
+  CodeEditor *codeEditor;
+};
+
+//![extraarea]
+
+#endif

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -1285,6 +1285,7 @@ void Qucs_S_SPAR_Viewer::addTrace(QString selected_dataset, QString selected_tra
     // Color settings
     QPen pen;
     pen.setColor(trace_color);
+    pen.setWidth(trace_width);
     series->setPen(pen);// Apply the pen to the series
 
     chart->addSeries(series);

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -1233,6 +1233,28 @@ void Qucs_S_SPAR_Viewer::addTrace(QString selected_dataset, QString selected_tra
     List_Trace_LineStyle.append(new_trace_linestyle);
     this->TracesGrid->addWidget(new_trace_linestyle, n_trace, 2);
 
+    // Capture the pen style to correctly render the trace
+    Qt::PenStyle pen_style;
+    if (!trace_style.compare("Solid")) {
+      pen_style = Qt::SolidLine;
+    } else {
+      if (!trace_style.compare("- - - -")) {
+        pen_style = Qt::DashLine;
+      } else {
+        if (!trace_style.compare("·······")) {
+          pen_style = Qt::DotLine;
+        } else {
+          if (!trace_style.compare("-·-·-·-")) {
+            pen_style = Qt::DashDotLine;
+          } else {
+            if (!trace_style.compare("-··-··-")) {
+              pen_style = Qt::DashDotDotLine;
+            }
+          }
+        }
+      }
+    }
+
     // Line width
     QSpinBox * new_trace_width = new QSpinBox();
     new_trace_width->setObjectName(QString("Trace_Width_") + trace_name);
@@ -1266,6 +1288,7 @@ void Qucs_S_SPAR_Viewer::addTrace(QString selected_dataset, QString selected_tra
     // Color settings
     QPen pen;
     pen.setColor(trace_color);
+    pen.setStyle(pen_style);
     pen.setWidth(trace_width);
     series->setPen(pen);// Apply the pen to the series
 

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.h
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.h
@@ -1,6 +1,8 @@
 #ifndef QUCSSPARVIEWER_H
 #define QUCSSPARVIEWER_H
 
+#include "codeeditor.h"
+
 #include <QMainWindow>
 #include <QLabel>
 #include <QCheckBox>
@@ -205,6 +207,10 @@ protected:
   QString savepath;
   bool save();
   void loadSession(QString);
+
+  // Notes
+  QDockWidget *dockNotes;
+  CodeEditor *Notes_Widget;
 
   // Utilities
   void convert_MA_RI_to_dB(double *, double *, double *, double *, QString);

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.h
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.h
@@ -105,6 +105,8 @@ protected:
 
   void updateGridLayout(QGridLayout*);
 
+  void calculate_Sparameter_trace(QString, QString);
+
  protected:
   void dragEnterEvent(QDragEnterEvent *event) override;
   void dropEvent(QDropEvent *event) override;

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.h
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.h
@@ -212,6 +212,15 @@ protected:
   QDockWidget *dockNotes;
   CodeEditor *Notes_Widget;
 
+  // Recent files
+  std::vector<QString> recentFiles;
+  QMenu* recentFilesMenu;
+  void updateRecentFilesMenu();
+  void loadRecentFiles();
+  void addRecentFile(const QString&);
+  void clearRecentFiles();
+  void saveRecentFiles();
+
   // Utilities
   void convert_MA_RI_to_dB(double *, double *, double *, double *, QString);
   double getFreqScale();


### PR DESCRIPTION
This PR adds the following improvements and fixes to the S-parameter viewer tool:

-  **Note-taking feature**: When comparing S-parameter traces, I've found it useful to add a notepad widget so I can add my observations. The comments are saved in the .spar file and so they can check them later. Notice that I didn't write this tool, I've just simply took the note-taking Qt example [1]

- **Recent files feature**
- **Bug fix**: When loading the .spar session file, the width of the traces was 1 regardless of the previous trace setting. 
- **Data management improvement**: Now the tool saves only S-par data into the .spar files. Before this, all possible traces were saved into the .spar file, even if the user did not display them. This caused a lot of overhead, especially for large s-par data files. Now the tool only saves the raw S-parameter data.

[1] https://doc.qt.io/qt-5/qtwidgets-widgets-codeeditor-example.html