### PR TITLE
Plug diagram memory leak

### DIFF
--- a/qucs/diagrams/diagram.cpp
+++ b/qucs/diagrams/diagram.cpp
@@ -54,6 +54,7 @@
 #include <QDateTime>
 #include <QPainter>
 #include <QDebug>
+#include <QtAlgorithms>
 
 Diagram::Diagram(int _cx, int _cy) {
     cx = _cx;
@@ -93,6 +94,10 @@ Diagram::Diagram(int _cx, int _cy) {
 }
 
 Diagram::~Diagram() {
+    qDeleteAll(Graphs);
+    qDeleteAll(Arcs);
+    qDeleteAll(Lines);
+    qDeleteAll(Texts);
 }
 
 /*!
@@ -846,16 +851,15 @@ int Graph::loadDatFile(const QString &fileName) {
 
     Info.setFile(file);
     if (g->lastLoaded.isValid())
-        if (g->lastLoaded.currentMSecsSinceEpoch() >
-            Info.lastModified().currentMSecsSinceEpoch()) //Millisecond resulution is needed for tuning
+        if (g->lastLoaded.toMSecsSinceEpoch() >=
+            Info.lastModified().toMSecsSinceEpoch()) //Millisecond resulution is needed for tuning
             return 1;    // dataset unchanged -> no update necessary
+    qDebug() << "Loading data from " << Info.canonicalFilePath();
 
+    qDeleteAll(g->mutable_axes());
+    g->mutable_axes().clear();
     g->countY = 0;
-    g->mutable_axes().clear(); // HACK
-    if (g->cPointsY) {
-        delete[] g->cPointsY;
-        g->cPointsY = 0;
-    }
+    delete[] g->cPointsY;
     if (Variable.isEmpty()) return 0;
 
 #if 0 // FIXME encapsulation. implement digital waves later.

--- a/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/diagrams/diagramdialog.cpp
@@ -48,6 +48,7 @@
 #include <QHeaderView>
 #include <QDir>
 #include <QDebug>
+#include <QtAlgorithms>
 
 #define CROSS3D_SIZE   30
 #define WIDGET3D_SIZE  2*CROSS3D_SIZE
@@ -1349,6 +1350,7 @@ void DiagramDialog::slotApply()
 
   }   // of "if(Diag->Name != "Tab")"
 
+  qDeleteAll(Diag->Graphs);
   Diag->Graphs.clear();   // delete the graphs
 
   for (std::unique_ptr<Graph>& graph : Graphs) {

--- a/qucs/diagrams/graph.cpp
+++ b/qucs/diagrams/graph.cpp
@@ -24,6 +24,7 @@
 #include <QPainter>
 #include <QDebug>
 #include <QPainterPath>
+#include <QtAlgorithms>
 
 class Diagram;
 
@@ -47,8 +48,8 @@ Graph::Graph(Diagram const* d, const QString& _Line) :
 
 Graph::~Graph()
 {
-  if(cPointsY != 0)
     delete[] cPointsY;
+    qDeleteAll(cPointsX);
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses a memory leak in the diagram object. With big datasets the leak can be huge.

The attached schematic can be used to reproduce the problem and test the fix. Run the simulation and monitor Qucs-s memory usage. If the diagram is deleted or the schematic tab is closed the memory is not released. If the schematic is opened again or the diagram is deleted and added again the memory consumption increases further.

[Diagram_Memory_Leak.sch.txt](https://github.com/user-attachments/files/18144284/Diagram_Memory_Leak.sch.txt)
