### PR TITLE
Fixed SpiceLibComp dilaog and ID dialog

### DIFF
--- a/qucs/extsimkernels/spicelibcompdialog.cpp
+++ b/qucs/extsimkernels/spicelibcompdialog.cpp
@@ -317,7 +317,7 @@ int SpiceLibCompDialog::parseLibFile(const QString &filename)
       subcir_body.clear();
       QStringList pin_names;
       QStringList tokens = line.split(QRegularExpression("[ \\t]"),Qt::SkipEmptyParts);
-      if (tokens.count() > 3) {
+      if (tokens.count() >= 3) {
         subname = tokens.at(1);
         last_subcir = subname;
       } else continue;

--- a/qucs/paintings/id_dialog.cpp
+++ b/qucs/paintings/id_dialog.cpp
@@ -327,9 +327,4 @@ void ID_Dialog::slotApply()
   item = ParamTable->item(selectedrow, 4);
   item->setText(TypeEdit->text());
 
-  ParamTable->setCurrentCell(selectedrow,0);
-  ParamNameEdit->clear();
-  ValueEdit->clear();
-  DescriptionEdit->clear();
-  TypeEdit->clear();
 }


### PR DESCRIPTION
This PR fixes the following issues:

* Allow processing 1-pin SPICE subcircuits #1142 
* Don't clear input fields when pressing Apply button in ID dialog #1149 