### PR TITLE
Digital libraries

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -9,6 +9,9 @@ Crystal.lib
 Diodes.lib
 DiodesSchottky.lib
 Diodes_Extended.lib
+Digital_CD4000.lib
+Digital_HC.lib
+Digital_LV.lib
 GeDiodes.lib
 Ideal.lib
 JFETs.lib

--- a/library/Digital_CD4000.lib
+++ b/library/Digital_CD4000.lib
@@ -1,0 +1,698 @@
+<Qucs Library 24.4.1 "Digital_CD4000">
+
+<Component CD4011>
+  <Description>
+Quad 2-Input CMOS NAND
+  </Description>
+  <Model>
+.Def:Digital_CD4000_CD4011 _net0 _net2 _net1
+Sub:X1 _net0 _net2 _net1 gnd Type="CD4011_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "CD4011.cir.lst">
+  <Spice>
+* ----------------------- CD4011B -------------------------
+*
+*  Quad 2-Input NAND Gate
+*
+*  The CMOS Logic Data Book, 1991, Motorola Pages 6-5 to 6-14
+*  jds    6/6/94
+*  This part is shown in the data book as MC14011B
+*
+.SUBCKT CD4011B IN1A IN2A OUTA
++  optional: VDD=$G_CD4000_VDD VSS=$G_CD4000_VSS
++  params: MNTYMXDLY=0 IO_LEVEL=0
+*
+Uf0 nand(2) VDD VSS
++   IN1A IN2A OUTA
++   DLY_MOD IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+.model DLY_MOD ugate (TPLHMN=-1 TPLHTY=125ns TPLHMX=250ns
++                     TPHLMN=-1 TPHLTY=125ns TPHLMX=250ns)
+
+.ENDS CD4011B
+*
+
+.SUBCKT Digital_CD4000_CD4011  gnd _net0 _net2 _net1 
+X1 _net0 _net2 _net1 CD4011B
+.ENDS
+  </Spice>
+  <Symbol>
+    <EArc -30 -20 40 40 4320 2880 #000080 2 1>
+    <Line -10 20 0 -40 #000080 2 1>
+    <Ellipse 10 -4 8 8 #000080 1 1 #000080 1 1>
+    <Line 10 0 20 0 #000080 2 1>
+    <Line -30 -10 20 0 #000080 2 1>
+    <Line -30 10 20 0 #000080 2 1>
+    <.PortSym -30 -10 1 0 P1>
+    <.PortSym -30 10 2 0 P2>
+    <.PortSym 30 0 3 180 P3>
+    <.ID 10 14 Y>
+  </Symbol>
+</Component>
+
+<Component CD4013>
+  <Description>
+Two D-type CMOS Flip-flops
+  </Description>
+  <Model>
+.Def:Digital_CD4000_CD4013 _net0 _net1 _net2 _net3 _net4 _net5
+Sub:X1 _net0 _net1 _net2 _net3 _net4 _net5 gnd Type="CD4013_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "CD4013.cir.lst">
+  <Spice>
+* ----------------------------- CD4013B ------------------------
+*
+*  Dual Type D Flip-Flop
+*
+*  The CMOS Logic Data Book, 1991, Motorola Pages 6-33 to 6-36
+*  jds    6/6/94
+*  This part is shown in the data book as MC14013B
+*
+.SUBCKT CD4013B SA RA CA DA QA QABAR
++  optional: VDD=$G_CD4000_VDD VSS=$G_CD4000_VSS
++  params: MNTYMXDLY=0 IO_LEVEL=0
+*
+Uf0 inva(2) VDD VSS
++   SA RA prebar clrbar
++   D0_GATE IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+Uf1 dff(1) VDD VSS
++   prebar clrbar CA DA Q_A Q_ABAR
++   DFF4013B IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+.MODEL DFF4013B UEFF(TWPCLMN=250NS TWPCLTY=125NS TWPCLMX=-1
++                    TWCLKLMN=250NS TWCLKLTY=125NS TWCLKLMX=-1
++                    TWCLKHMN=250NS TWCLKHTY=125NS TWCLKHMX=-1
++                    TSUDCLKMN=-1NS TSUDCLKTY=250NS TSUDCLKMX=-1
++                    THDCLKMN=40NS THDCLKTY=20NS THDCLKMX=-1)
+
+U3 PINDLY(2,0,3) VDD VSS
++ Q_A Q_ABAR
++ CA SA RA
++ QA QABAR
++ IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
++ BOOLEAN:
++          EDGE = {CHANGED_LH(CA,0)}
++          SET = {CHANGED_LH(SA,0)}
++          CLEAR = {CHANGED_LH(RA,0)}
++ PINDLY:
++          QA QABAR = {
++            CASE(
++               SET, DELAY(-1,175NS,350NS),
++               CLEAR, DELAY(-1,225NS,450NS),
++               EDGE & (TRN_LH | TRN_HL), DELAY(-1,175NS,350NS),
++               DELAY(-1,226NS,451NS))}
+  
+U4 CONSTRAINT(3) VDD VSS
++ CA SA RA
++ IO_4000B IO_LEVEL={IO_LEVEL}
++ FREQ:
++        NODE = CA
++        MAXFREQ = 2MEG
++ SETUP_HOLD:
++             CLOCK LH = CA
++             DATA(2) = SA RA
++             SETUPTIME_LO = 80NS
++             HOLDTIME_LO = 50NS
+
+.ENDS CD4013B
+*
+
+.SUBCKT Digital_CD4000_CD4013  gnd _net0 _net1 _net2 _net3 _net4 _net5 
+X1 _net0 _net1 _net2 _net3 _net4 _net5 CD4013B
+.ENDS
+  </Spice>
+  <Symbol>
+    <Rectangle -30 -40 60 80 #000080 2 1 #c0c0c0 1 0>
+    <Line -50 20 20 0 #000080 2 1>
+    <Line -50 -20 20 0 #000080 2 1>
+    <Line 30 -20 20 0 #000080 2 1>
+    <Line 0 -40 0 -20 #000080 2 1>
+    <Line 30 20 20 0 #000080 2 1>
+    <Line 14 11 12 0 #000080 2 1>
+    <Line -15 20 -15 -10 #000080 2 1>
+    <Line -30 30 15 -10 #000080 2 1>
+    <.PortSym -50 20 3 0 CA>
+    <.PortSym -50 -20 4 0 DA>
+    <.PortSym 50 -20 5 180 QA>
+    <.PortSym 50 20 6 180 QAB>
+    <.PortSym 0 -60 2 0 RA>
+    <.PortSym 0 60 1 0 SA>
+    <Line 0 61 0 -20 #000080 2 1>
+    <.ID 20 44 Y>
+    <Text -4 -40 12 #000080 0 "R">
+    <Text -4 18 12 #000080 0 "S">
+    <Text -27 -30 12 #000080 0 "D">
+    <Text 14 -30 12 #000080 0 "Q">
+    <Text 14 10 12 #000080 0 "Q">
+  </Symbol>
+</Component>
+
+<Component CD4017>
+  <Description>
+Decade counter with 10 decoded outputs
+  </Description>
+  <Model>
+.Def:Digital_CD4000_CD4017 _net13 _net0 _net1 _net2 _net3 _net4 _net5 _net6 _net7 _net8 _net9 _net10 _net11 _net12
+Sub:X1 _net13 _net0 _net1 _net2 _net3 _net4 _net5 _net6 _net7 _net8 _net9 _net10 _net11 _net12 gnd Type="CD4017_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "CD4017.cir.lst">
+  <Spice>
+* ------------------- CD4017B----------------
+*
+*  Decade Counter
+*
+*  The CMOS Logic Data Book, 1991, Motorola Pages 6-54 to 6-58
+*  jds    6/6/94
+*  This part is shown in the data book as MC14017B
+*  Note that the NAND gate feeding into the 3rd flip-flops D input should
+*  be an AND gate for the circuit to operate as in the timing diagram.
+*
+.SUBCKT CD4017B CLK CLKENBAR RESET COUT Q0 Q1 Q2 Q3 Q4 Q5 Q6 Q7 Q8 Q9
++  optional: VDD=$G_CD4000_VDD VSS=$G_CD4000_VSS
++  params: MNTYMXDLY=0 IO_LEVEL=0
+
+U14017B LOGICEXP(13,14) VDD VSS
++      CLK CLKENBAR RESET q1ff q2ff q3ff q4ff q5ff
++      q1ffbar q2ffbar q3ffbar q4ffbar q5ffbar
++      clock clear i1
++      COUT_O Q0_O Q1_O Q2_O Q3_O Q4_O Q5_O Q6_O Q7_O Q8_O Q9_O
++      D0_GATE IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
++
++    LOGIC:
++      clock = {( CLK & ~CLKENBAR )}
++      clear = { (~RESET) }
++      i1 = { (q2ff & (q1ff | q3ff)) }
++      Q0_O = { (q1ffbar & q5ffbar) }
++      Q1_O = { (q1ff & q2ffbar) }
++      Q2_O = { (q2ff & q3ffbar) }
++      Q3_O = { (q3ff & q4ffbar) }
++      Q4_O = { (q4ff & q5ffbar) }
++      Q5_O = { (q1ff & q5ff) }
++      Q6_O = { (q1ffbar & q2ff) }
++      Q7_O = { (q2ffbar & q3ff) }
++      Q8_O = { (q3ffbar & q4ff) }
++      Q9_O = { (q5ff & q4ffbar) }
++      COUT_O = { q5ffbar }
+
+Uf0 dff(5) VDD VSS
++   $D_HI clear clock q5ffbar q1ff i1 q3ff q4ff
++   q1ff q2ff q3ff q4ff q5ff q1ffbar q2ffbar q3ffbar q4ffbar q5ffbar
++   DLY_DFF IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+.MODEL DLY_DFF UEFF(TWCLKLMN=-1 TWCLKLTY=125NS TWCLKLMX=250NS
++                   TWCLKHMN=-1 TWCLKHTY=125NS TWCLKHMX=250NS)
+
+Udly PINDLY (11,0,2) VDD VSS
++    COUT_O Q0_O Q1_O Q2_O Q3_O Q4_O Q5_O Q6_O Q7_O Q8_O Q9_O
++    CLK RESET
++    COUT Q0 Q1 Q2 Q3 Q4 Q5 Q6 Q7 Q8 Q9
++    IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
++
++    BOOLEAN:
++     CP = {CHANGED_LH(CLK,0)}
++     CLR = { CHANGED_LH(RESET,0) }
++
++    PINDLY:
++       Q0 Q1 Q2 Q3 Q4 Q5 Q6 Q7 Q8 Q9 = {
++            CASE(
++                 CLR, DELAY(-1,500ns,1us),
++                 CP, DELAY(-1,500ns,1us),
++                 DELAY(-1,501ns,1.001us)
++                )
++            }
++       COUT = {
++            CASE(
++                 CLR, DELAY(-1,400ns,800ns),
++                 CP, DELAY(-1,400ns,800ns),
++                 DELAY(-1,401ns,801ns)
++                )
++            }
+
+Ucnstr CONSTRAINT(3) VDD VSS
++          CLKENBAR CLK RESET
++          IO_4000B
++
++      FREQ:
++         NODE = CLK
++         MAXFREQ = 5MEG
++      WIDTH:
++         NODE = RESET
++         MIN_HI = 250ns
++      SETUP_HOLD:
++        CLOCK LH = CLK
++        DATA(1) = CLKENBAR
++        SETUPTIME_HI = 175ns
++        SETUPTIME_LO = 260ns
++        WHEN = { RESET != '1 }
++      SETUP_HOLD:
++        CLOCK LH = CLK
++        DATA(1) = RESET
++        SETUPTIME_LO = 375ns
+
+.ENDS CD4017B
+*
+
+.SUBCKT Digital_CD4000_CD4017  gnd _net13 _net0 _net1 _net2 _net3 _net4 _net5 _net6 _net7 _net8 _net9 _net10 _net11 _net12 
+X1 _net13 _net0 _net1 _net2 _net3 _net4 _net5 _net6 _net7 _net8 _net9 _net10 _net11 _net12 CD4017B
+.ENDS
+  </Spice>
+  <Symbol>
+    <Line 30 20 20 0 #000080 2 1>
+    <Text 4 -11 12 #000080 0 "Q0">
+    <Text 4 29 12 #000080 0 "Q2">
+    <Text 4 49 12 #000080 0 "Q3">
+    <Text 4 69 12 #000080 0 "Q4">
+    <Rectangle -30 -20 60 250 #000080 2 1 #c0c0c0 1 0>
+    <Line 30 0 20 0 #000080 2 1>
+    <Text 4 109 12 #000080 0 "Q6">
+    <Text 4 129 12 #000080 0 "Q7">
+    <Line 30 60 20 0 #000080 2 1>
+    <Line 30 40 20 0 #000080 2 1>
+    <Line 30 100 20 0 #000080 2 1>
+    <Line 30 80 20 0 #000080 2 1>
+    <Line 30 140 20 0 #000080 2 1>
+    <Line 30 120 20 0 #000080 2 1>
+    <Line 30 160 20 0 #000080 2 1>
+    <Line 30 180 20 0 #000080 2 1>
+    <Text 4 169 12 #000080 0 "Q9">
+    <Line -50 0 20 0 #000080 2 1>
+    <Line -15 0 -15 -10 #000080 2 1>
+    <Line -30 10 15 -10 #000080 2 1>
+    <.PortSym -50 0 1 0 CLK>
+    <Line -50 60 20 0 #000080 2 1>
+    <Text -28 50 12 #000080 0 "RST">
+    <.PortSym 50 0 5 180 Q0>
+    <.PortSym 50 20 6 180 Q1>
+    <.PortSym 50 40 7 180 Q2>
+    <.PortSym 50 60 8 180 Q3>
+    <.PortSym 50 80 9 180 Q4>
+    <.PortSym 50 100 10 180 Q5>
+    <.PortSym 50 120 11 180 Q6>
+    <.PortSym 50 140 12 180 Q7>
+    <.PortSym 50 160 13 180 Q8>
+    <.PortSym 50 180 14 180 Q9>
+    <Text 4 9 12 #000080 0 "Q1">
+    <Text 4 89 12 #000080 0 "Q5">
+    <Text 4 149 12 #000080 0 "Q8">
+    <.ID -10 234 Y>
+    <.PortSym -50 60 3 0 RST>
+    <Text -28 10 12 #000080 0 "ENB">
+    <.PortSym -50 20 2 0 CLKENB>
+    <Line 30 210 20 0 #000080 2 1>
+    <Text -16 199 12 #000080 0 "COUT">
+    <.PortSym 50 210 4 180 COUT>
+    <Line -50 20 20 0 #000080 2 1>
+    <Ellipse -31 16 -8 8 #000080 1 1 #000080 1 1>
+  </Symbol>
+</Component>
+
+<Component CD4022>
+  <Description>
+Octal counter with 8 decoded outputs
+  </Description>
+  <Model>
+.Def:Digital_CD4000_CD4022 _net11 _net0 _net1 _net2 _net3 _net4 _net5 _net6 _net7 _net8 _net9 _net10
+Sub:X1 _net11 _net0 _net1 _net2 _net3 _net4 _net5 _net6 _net7 _net8 _net9 _net10 gnd Type="CD4022_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "CD4022.cir.lst">
+  <Spice>
+*---------------------------CD4022B----------------------------------
+*
+* Divide by 8 Counter/Divider with 8 Decoded Outputs
+* National Semiconductor, CMOS Logic Databook, 1988, pages 5-57 to 5-62
+* jat 8/18/95
+* Note that there should only be a single inversion in front of COUT, not
+* a double inversion as shown in the logic diagram.
+
+.SUBCKT CD4022B
++ CLK CLKENBAR RESET COUT Q0 Q1 Q2 Q3 Q4 Q5 Q6 Q7
++ OPTIONAL: VDD=$G_CD4000_VDD VSS=$G_CD4000_VSS
++ PARAMS: MNTYMXDLY=0 IO_LEVEL=0
+
+U1 LOGICEXP(11,12) VDD VSS
++ CLK CLKENBAR RESET Q1FF Q2FF Q3FF Q4FF Q1FFBAR Q2FFBAR Q3FFBAR Q4FFBAR
++ CLOCK CLEAR D3 COUT_O Q0_O Q1_O Q2_O Q3_O Q4_O Q5_O Q6_O Q7_O
++ D0_GATE IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
++    LOGIC:
++      CLOCK = {(CLK & (~CLKENBAR))}
++      CLEAR = {(~RESET)}
++      D3 = {~(Q2FFBAR | (~(Q1FF | Q2FFBAR | Q3FF)))}
++      Q0_O = {(Q1FFBAR & Q4FFBAR) }
++      Q1_O = {(Q1FF & Q2FFBAR)}
++      Q2_O = {(Q2FF & Q3FFBAR)}
++      Q3_O = {(Q3FF & Q4FFBAR)}
++      Q4_O = {(Q1FF & Q4FF)}
++      Q5_O = {(Q1FFBAR & Q2FF)}
++      Q6_O = {(Q2FFBAR & Q3FF)}
++      Q7_O = {(Q3FFBAR & Q4FF)}
++      COUT_O = {~Q4FF}
+
+U2 DFF(4) VDD VSS
++ $D_HI CLEAR CLOCK
++ Q4FFBAR Q1FF D3 Q3FF  
++ Q1FF Q2FF Q3FF Q4FF Q1FFBAR Q2FFBAR Q3FFBAR Q4FFBAR
++ DLY_DFF IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+.MODEL DLY_DFF UEFF(TWCLKLMN=-1 TWCLKLTY=125NS TWCLKLMX=250NS
++                   TWCLKHMN=-1 TWCLKHTY=125NS TWCLKHMX=250NS)
+
+U3 PINDLY(9,0,2) VDD VSS
++ COUT_O Q0_O Q1_O Q2_O Q3_O Q4_O Q5_O Q6_O Q7_O
++ CLK RESET
++ COUT Q0 Q1 Q2 Q3 Q4 Q5 Q6 Q7
++ IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
++ BOOLEAN:
++          EDGE = {CHANGED_LH(CLK,0)}
++          CLR = {CHANGED_LH(RESET,0)}
++ PINDLY:
++          Q0 Q1 Q2 Q3 Q4 Q5 Q6 Q7 = {
++            CASE(
++                 EDGE & (TRN_LH | TRN_HL), DELAY(-1,500NS,1000NS),
++                 CLR & (TRN_LH | TRN_HL), DELAY(-1,500NS,1000NS),
++                 DELAY(-1,501NS,1001NS))}
++          COUT = {
++            CASE(
++                 EDGE & (TRN_LH | TRN_HL), DELAY(-1,415NS,800NS),
++                 CLR & (TRN_LH | TRN_HL), DELAY(-1,415NS,800NS),
++                 DELAY(-1,416NS,801NS))}
+
+U4 CONSTRAINT(3) VDD VSS
++ CLKENBAR CLK RESET
++ IO_4000B IO_LEVEL={IO_LEVEL}
++ FREQ:
++       NODE = CLK
++       MAXFREQ = 2MEG
++ WIDTH:
++       NODE = RESET
++       MIN_HI = 200NS 
++ SETUP_HOLD:
++             CLOCK LH = CLK
++             DATA(1) = CLKENBAR
++             SETUPTIME_HI = 120NS
++             WHEN = { RESET != '1 }
++ SETUP_HOLD:
++             CLOCK LH = CLK
++             DATA(1) = RESET
++             SETUPTIME_LO = 75NS
+
+.ENDS CD4022B
+
+.SUBCKT Digital_CD4000_CD4022  gnd _net11 _net0 _net1 _net2 _net3 _net4 _net5 _net6 _net7 _net8 _net9 _net10 
+X1 _net11 _net0 _net1 _net2 _net3 _net4 _net5 _net6 _net7 _net8 _net9 _net10 CD4022B
+.ENDS
+  </Spice>
+  <Symbol>
+    <Line 30 20 20 0 #000080 2 1>
+    <Text 4 -11 12 #000080 0 "Q0">
+    <Text 4 29 12 #000080 0 "Q2">
+    <Text 4 49 12 #000080 0 "Q3">
+    <Text 4 69 12 #000080 0 "Q4">
+    <Rectangle -30 -20 60 220 #000080 2 1 #c0c0c0 1 0>
+    <Line 30 0 20 0 #000080 2 1>
+    <Text 4 109 12 #000080 0 "Q6">
+    <Text 4 129 12 #000080 0 "Q7">
+    <Line 30 60 20 0 #000080 2 1>
+    <Line 30 40 20 0 #000080 2 1>
+    <Line 30 100 20 0 #000080 2 1>
+    <Line 30 80 20 0 #000080 2 1>
+    <Line 30 140 20 0 #000080 2 1>
+    <Line 30 120 20 0 #000080 2 1>
+    <Line 30 180 20 0 #000080 2 1>
+    <Line -50 0 20 0 #000080 2 1>
+    <Line -15 0 -15 -10 #000080 2 1>
+    <Line -30 10 15 -10 #000080 2 1>
+    <.PortSym -50 0 1 0 CLK>
+    <Line -50 60 20 0 #000080 2 1>
+    <Text -28 50 12 #000080 0 "RST">
+    <.PortSym 50 0 5 180 Q0>
+    <.PortSym 50 20 6 180 Q1>
+    <.PortSym 50 40 7 180 Q2>
+    <.PortSym 50 60 8 180 Q3>
+    <.PortSym 50 80 9 180 Q4>
+    <.PortSym 50 100 10 180 Q5>
+    <.PortSym 50 120 11 180 Q6>
+    <.PortSym 50 140 12 180 Q7>
+    <Text 4 9 12 #000080 0 "Q1">
+    <Text 4 89 12 #000080 0 "Q5">
+    <.PortSym -50 60 3 0 RST>
+    <Text -28 10 12 #000080 0 "ENB">
+    <.PortSym -50 20 2 0 CLKENB>
+    <Line -50 20 20 0 #000080 2 1>
+    <Ellipse -31 16 -8 8 #000080 1 1 #000080 1 1>
+    <Text -16 169 12 #000080 0 "COUT">
+    <.PortSym 50 180 4 180 COUT>
+    <.ID -10 204 Y>
+  </Symbol>
+</Component>
+
+<Component CD4040>
+  <Description>
+
+  </Description>
+  <Model>
+.Def:Digital_CD4000_CD4040 _net12 _net13 _net0 _net1 _net2 _net3 _net4 _net5 _net6 _net7 _net8 _net9 _net10 _net11
+Sub:X1 _net12 _net13 _net0 _net1 _net2 _net3 _net4 _net5 _net6 _net7 _net8 _net9 _net10 _net11 gnd Type="CD4040_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "CD4040.cir.lst">
+  <Spice>
+* ----------------------- CD4040B -----------------------
+*
+*  12-Stage Binary Counter
+*
+*  The CMOS Logic Data Book, 1991, Motorola Pages 6-108 to 6-111
+*  jds    6/8/94
+*  This part is shown in the data book as MC14040B
+*
+.SUBCKT CD4040B CLK RESET Q1 Q2 Q3 Q4 Q5 Q6 Q7 Q8 Q9 Q10 Q11 Q12
++  optional: VDD=$G_CD4000_VDD VSS=$G_CD4000_VSS
++  params: MNTYMXDLY=0 IO_LEVEL=0
+
+USTBUF BUF VDD VSS
++ CLK CLKST
++ D0_GATE IO_4000B_ST MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+uf0 inv VDD VSS
++   RESET clr
++   D0_GATE IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+Uf1 jkff(1) VDD VSS
++   $D_HI clr CLKST $D_HI $D_HI Q1_O Q1BAR_O
++   D0_EFF IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+Uf2 jkff(1) VDD VSS
++   $D_HI clr Q1_O $D_HI $D_HI Q2_O Q2BAR_O
++   D0_EFF IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+Uf3 jkff(1) VDD VSS
++   $D_HI clr Q2_O $D_HI $D_HI Q3_O Q3BAR_O
++   D0_EFF IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+Uf4 jkff(1) VDD VSS
++   $D_HI clr Q3_O $D_HI $D_HI Q4_O Q4BAR_O
++   D0_EFF IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+Uf5 jkff(1) VDD VSS
++   $D_HI clr Q4_O $D_HI $D_HI Q5_O Q5BAR_O
++   D0_EFF IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+Uf6 jkff(1) VDD VSS
++   $D_HI clr Q5_O $D_HI $D_HI Q6_O Q6BAR_O
++   D0_EFF IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+Uf7 jkff(1) VDD VSS
++   $D_HI clr Q6_O $D_HI $D_HI Q7_O Q7BAR_O
++   D0_EFF IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+Uf8 jkff(1) VDD VSS
++   $D_HI clr Q7_O $D_HI $D_HI Q8_O Q8BAR_O
++   D0_EFF IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+Uf9 jkff(1) VDD VSS
++   $D_HI clr Q8_O $D_HI $D_HI Q9_O Q9BAR_O
++   D0_EFF IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+Uf10 jkff(1) VDD VSS
++   $D_HI clr Q9_O $D_HI $D_HI Q10_O Q10BAR_O
++   D0_EFF IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+Uf11 jkff(1) VDD VSS
++   $D_HI clr Q10_O $D_HI $D_HI Q11_O Q11BAR_O
++   D0_EFF IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+Uf12 jkff(1) VDD VSS
++   $D_HI clr Q11_O $D_HI $D_HI Q12_O Q12BAR_O
++   D0_EFF IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+Udly PINDLY (12,0,13) VDD VSS
++    Q1_O Q2_O Q3_O Q4_O Q5_O Q6_O Q7_O Q8_O Q9_O Q10_O Q11_O Q12_O
++    CLK RESET Q1BAR Q2BAR Q3BAR Q4BAR Q5BAR Q6BAR Q7BAR
++    Q8BAR Q9BAR Q10BAR Q11BAR
++    Q1 Q2 Q3 Q4 Q5 Q6 Q7 Q8 Q9 Q10 Q11 Q12
++    IO_4000B MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
++
++    PINDLY:
++       Q1  = {
++            CASE(
++                 CHANGED(RESET,0) & TRN_HL, DELAY(-1,370ns,740ns),
++                 CHANGED_HL(CLK,0), DELAY(-1,260ns,520ns),
++                 DELAY(-1,261ns,521ns)
++                )
++            }
++       Q2  = {
++            CASE(
++                 CHANGED(RESET,0) & TRN_HL, DELAY(-1,370ns,740ns),
++                 CHANGED_HL(Q1_O,0), DELAY(-1,384.1ns,768.2ns),
++                 DELAY(-1,385.1ns,769.2ns)
++                )
++            }
++       Q3  = {
++            CASE(
++                 CHANGED(RESET,0) & TRN_HL, DELAY(-1,370ns,740ns),
++                 CHANGED_HL(Q2_O,0), DELAY(-1,508.2ns,1016.4ns),
++                 DELAY(-1,509.2ns,1017.4ns)
++                )
++            }
++       Q4  = {
++            CASE(
++                 CHANGED(RESET,0) & TRN_HL, DELAY(-1,370ns,740ns),
++                 CHANGED_HL(Q3_O,0), DELAY(-1,632.3ns,1264.6ns),
++                 DELAY(-1,633.3ns,1265.6ns)
++                )
++            }
++       Q5  = {
++            CASE(
++                 CHANGED(RESET,0) & TRN_HL, DELAY(-1,370ns,740ns),
++                 CHANGED_HL(Q4_O,0), DELAY(-1,756.4ns,1512.8ns),
++                 DELAY(-1,757.4ns,1513.8ns)
++                )
++            }
++       Q6  = {
++            CASE(
++                 CHANGED(RESET,0) & TRN_HL, DELAY(-1,370ns,740ns),
++                 CHANGED_HL(Q5_O,0), DELAY(-1,880.5ns,1761ns),
++                 DELAY(-1,881.5ns,1762ns)
++                )
++            }
++       Q7  = {
++            CASE(
++                 CHANGED(RESET,0) & TRN_HL, DELAY(-1,370ns,740ns),
++                 CHANGED_HL(Q6_O,0), DELAY(-1,1004.6ns,2009.2ns),
++                 DELAY(-1,1005.6ns,2010.2ns)
++                )
++            }
++       Q8  = {
++            CASE(
++                 CHANGED(RESET,0) & TRN_HL, DELAY(-1,370ns,740ns),
++                 CHANGED_HL(Q7_O,0), DELAY(-1,1128.7ns,2257.4ns),
++                 DELAY(-1,1129.7ns,2258.4ns)
++                )
++            }
++       Q9  = {
++            CASE(
++                 CHANGED(RESET,0) & TRN_HL, DELAY(-1,370ns,740ns),
++                 CHANGED_HL(Q8_O,0), DELAY(-1,1252.8ns,2505.6ns),
++                 DELAY(-1,1253.8ns,2506.6ns)
++                )
++            }
++       Q10  = {
++            CASE(
++                 CHANGED(RESET,0) & TRN_HL, DELAY(-1,370ns,740ns),
++                 CHANGED_HL(Q9_O,0), DELAY(-1,1376.9ns,2753.8ns),
++                 DELAY(-1,1377.9ns,2754.8ns)
++                )
++            }
++       Q11  = {
++            CASE(
++                 CHANGED(RESET,0) & TRN_HL, DELAY(-1,370ns,740ns),
++                 CHANGED_HL(Q10_O,0), DELAY(-1,1501ns,3002ns),
++                 DELAY(-1,1502ns,3003ns)
++                )
++            }
++       Q12  = {
++            CASE(
++                 CHANGED(RESET,0) & TRN_HL, DELAY(-1,370ns,740ns),
++                 CHANGED_HL(Q11_O,0), DELAY(-1,1625ns,3250ns),
++                 DELAY(-1,1626ns,3251ns)
++                )
++            }
+
+Ucnstr CONSTRAINT(2) VDD VSS
++          CLK RESET
++          IO_4000B
++
++      FREQ:
++         NODE = CLK
++         MAXFREQ = 2.1MEG
++      WIDTH:
++         NODE = CLK
++         MIN_HI = 140ns
++      WIDTH:
++         NODE = RESET
++         MIN_HI = 320ns
++      SETUP_HOLD:
++        CLOCK HL = CLK
++        DATA(1) = RESET
++        SETUPTIME_LO = 65ns
+
+.ENDS CD4040B
+*
+
+.SUBCKT Digital_CD4000_CD4040  gnd _net12 _net13 _net0 _net1 _net2 _net3 _net4 _net5 _net6 _net7 _net8 _net9 _net10 _net11 
+X1 _net12 _net13 _net0 _net1 _net2 _net3 _net4 _net5 _net6 _net7 _net8 _net9 _net10 _net11 CD4040B
+.ENDS
+  </Spice>
+  <Symbol>
+    <Line 30 20 20 0 #000080 2 1>
+    <Text 4 9 12 #000080 0 "QB">
+    <Text 4 -11 12 #000080 0 "QA">
+    <Text 4 29 12 #000080 0 "QC">
+    <Text 4 49 12 #000080 0 "QD">
+    <Text 4 69 12 #000080 0 "QE">
+    <Rectangle -30 -20 60 260 #000080 2 1 #c0c0c0 1 0>
+    <Line 30 0 20 0 #000080 2 1>
+    <Text 4 89 12 #000080 0 "QF">
+    <Text 4 109 12 #000080 0 "QG">
+    <Text 4 129 12 #000080 0 "QH">
+    <Line 30 60 20 0 #000080 2 1>
+    <Line 30 40 20 0 #000080 2 1>
+    <Line 30 100 20 0 #000080 2 1>
+    <Line 30 80 20 0 #000080 2 1>
+    <Line 30 140 20 0 #000080 2 1>
+    <Line 30 120 20 0 #000080 2 1>
+    <Line 30 160 20 0 #000080 2 1>
+    <Line 30 180 20 0 #000080 2 1>
+    <Line 30 200 20 0 #000080 2 1>
+    <Line 30 220 20 0 #000080 2 1>
+    <.PortSym 50 0 3 180 QA>
+    <.PortSym 50 20 4 180 QB>
+    <.PortSym 50 40 5 180 QC>
+    <.PortSym 50 60 6 180 QD>
+    <.PortSym 50 80 7 180 QE>
+    <.PortSym 50 100 8 180 QF>
+    <.PortSym 50 120 9 180 QG>
+    <.PortSym 50 140 10 180 QH>
+    <.PortSym 50 160 11 180 QI>
+    <.PortSym 50 180 12 180 QJ>
+    <Text 4 149 12 #000080 0 "QI">
+    <Text 4 169 12 #000080 0 "QJ">
+    <Text 4 189 12 #000080 0 "QK">
+    <Text 4 209 12 #000080 0 "QL">
+    <.ID -10 244 Y>
+    <.PortSym 50 200 13 180 QK>
+    <.PortSym 50 220 14 180 QL>
+    <Line -50 0 20 0 #000080 2 1>
+    <Line -15 0 -15 -10 #000080 2 1>
+    <Line -30 10 15 -10 #000080 2 1>
+    <Line -50 60 20 0 #000080 2 1>
+    <Text -28 50 12 #000080 0 "CLR">
+    <.PortSym -50 60 2 0 RES>
+    <.PortSym -50 0 1 0 CLK>
+  </Symbol>
+</Component>
+

--- a/library/Digital_HC.lib
+++ b/library/Digital_HC.lib
@@ -1,0 +1,432 @@
+<Qucs Library 24.3.0 "Digital_HC">
+
+<Component 74HC00>
+  <Description>
+2-Input Nand Gate
+
+Requirements:
+.spiceinit: set ngbehavior=psa
+.PARAM: vcc=5
+  </Description>
+  <Model>
+.Def:Digital_HC_74HC00 _net0 _net1 _net2
+Sub:X1 _net0 _net1 _net2 gnd Type="n74HC00_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "74HC00.cir.lst">
+  <Spice>
+* ----------------------------------------------------------- 74HC00 ------
+*  Quad 2-Input Nand Gates
+*
+*  The High-Speed CMOS Logic Data Book, 1989, TI Pages 2-3 to 2-5
+*  bss    2/3/94
+*
+.SUBCKT 74HC00  1A 1B 1Y
++     optional: DPWR=$G_DPWR DGND=$G_DGND
++     params: MNTYMXDLY=0 IO_LEVEL=0
+
+U1 nand(2) DPWR DGND
++     1A 1B 1Y
++     DLY_HC00 IO_HC MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+.model DLY_HC00 ugate (tplhTY=9ns tplhMX=18ns tphlTY=9ns tphlMX=18ns)
+
+.ENDS  74HC00
+
+.SUBCKT Digital_HC_74HC00  gnd _net0 _net1 _net2 
+X1 _net0 _net1 _net2 74HC00
+.ENDS
+  </Spice>
+  <Symbol>
+    <EArc -30 -20 40 40 4320 2880 #000080 2 1>
+    <Line -10 20 0 -40 #000000 2 1>
+    <Ellipse 10 -4 8 8 #000080 1 1 #000080 1 1>
+    <Line 10 0 20 0 #000080 2 1>
+    <Line -30 -10 20 0 #000080 2 1>
+    <Line -30 10 20 0 #000080 2 1>
+    <.PortSym -30 -10 1 0 P1>
+    <.PortSym -30 10 2 0 P2>
+    <.PortSym 30 0 3 180 P3>
+    <.ID 10 14 Y>
+  </Symbol>
+</Component>
+
+<Component 74HC02>
+  <Description>
+2-Input Nor Gate
+
+Requirements:
+.spiceinit: set ngbehavior=psa
+.PARAM: vcc=5
+  </Description>
+  <Model>
+.Def:Digital_HC_74HC02 _net0 _net2 _net1
+Sub:X1 _net0 _net2 _net1 gnd Type="n74HC02_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "74HC02.cir.lst">
+  <Spice>
+* ----------------------------------------------------------- 74HC02 ------
+*  Quad 2-Input Nor Gates
+*
+*  The High-Speed CMOS Logic Data Book, 1989, TI Pages 2-13 to 2-15
+*  bss    2/3/94
+*
+.SUBCKT 74HC02  1A 1B 1Y
++     optional: DPWR=$G_DPWR DGND=$G_DGND
++     params: MNTYMXDLY=0 IO_LEVEL=0
+
+U1 nor(2) DPWR DGND
++     1A 1B 1Y
++     DLY_HC02 IO_HC MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+.model DLY_HC02 ugate (tplhTY=9ns tplhMX=18ns tphlTY=9ns tphlMX=18ns)
+
+.ENDS  74HC02
+
+.SUBCKT Digital_HC_74HC02  gnd _net0 _net2 _net1 
+X1 _net0 _net2 _net1 74HC02
+.ENDS
+  </Spice>
+  <Symbol>
+    <.PortSym -30 -10 1 0 P1>
+    <.PortSym -30 10 2 0 P2>
+    <.PortSym 30 0 3 180 P3>
+    <.ID 10 14 Y>
+    <EArc -30 -20 40 40 4320 2880 #000080 2 1>
+    <Ellipse 10 -4 8 8 #000080 1 1 #000080 1 1>
+    <Line 10 0 20 0 #000080 2 1>
+    <Line -30 -10 20 0 #000080 2 1>
+    <Line -30 10 20 0 #000080 2 1>
+    <EArc -20 -20 10 40 4320 2880 #000080 2 1>
+    <Line -10 20 -5 0 #000000 2 1>
+    <Line -10 -20 -5 0 #000000 2 1>
+  </Symbol>
+</Component>
+
+<Component 74HC04>
+  <Description>
+Inverter
+
+Requirements:
+.spiceinit: set ngbehavior=psa
+.PARAM: vcc=5
+  </Description>
+  <Model>
+.Def:Digital_HC_74HC04 _net0 _net1
+Sub:X1 _net0 _net1 gnd Type="n74HC04_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "74HC04.cir.lst">
+  <Spice>
+* ----------------------------------------------------------- 74HC04 ------
+*  Hex Inverters
+*
+*  The High-Speed CMOS Logic Data Book, 1989, TI Pages 2-23 to 2-25
+*  bss    2/3/94
+*
+.SUBCKT 74HC04  1A  1Y
++     optional: DPWR=$G_DPWR DGND=$G_DGND
++     params: MNTYMXDLY=0 IO_LEVEL=0
+
+U1 inv DPWR DGND
++     1A 1Y
++     DLY_HC04 IO_HC MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+.model DLY_HC04 ugate (tplhTY=9ns tplhMX=19ns tphlTY=9ns tphlMX=19ns)
+
+.ENDS  74HC04
+
+.SUBCKT Digital_HC_74HC04  gnd _net0 _net1 
+X1 _net0 _net1 74HC04
+.ENDS
+  </Spice>
+  <Symbol>
+    <EArc -30 -20 40 40 4320 2880 #000080 2 1>
+    <Line -10 20 0 -40 #000000 2 1>
+    <Ellipse 10 -4 8 8 #000080 1 1 #000080 1 1>
+    <Line 10 0 20 0 #000080 2 1>
+    <.ID 10 14 Y>
+    <.PortSym 30 0 2 180 P2>
+    <Line -30 0 20 0 #000080 2 1>
+    <.PortSym -30 0 1 0 P1>
+  </Symbol>
+</Component>
+
+<Component 74HC08>
+  <Description>
+2-Input And Gate
+
+Requirements:
+.spiceinit: set ngbehavior=psa
+.PARAM: vcc=5
+  </Description>
+  <Model>
+.Def:Digital_HC_74HC08 _net0 _net2 _net1
+Sub:X1 _net0 _net2 _net1 gnd Type="n74HC08_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "74HC08.cir.lst">
+  <Spice>
+* ----------------------------------------------------------- 74HC08 ------
+*  Quad 2-Input And Gates   
+*
+*  The High-Speed CMOS Logic Data Book, 1989, TI Pages 2-37 to 2-39
+*  bss    2/3/94
+*
+.SUBCKT 74HC08  1A 1B  1Y
++     optional: DPWR=$G_DPWR DGND=$G_DGND
++     params: MNTYMXDLY=0 IO_LEVEL=0
+
+U1 and(2) DPWR DGND
++     1A 1B 1Y
++     DLY_HC08 IO_HC MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+.model DLY_HC08 ugate (tplhTY=10ns tplhMX=20ns tphlTY=10ns tphlMX=20ns)
+
+.ENDS  74HC08
+
+.SUBCKT Digital_HC_74HC08  gnd _net0 _net2 _net1 
+X1 _net0 _net2 _net1 74HC08
+.ENDS
+  </Spice>
+  <Symbol>
+    <.PortSym -30 -10 1 0 P1>
+    <.PortSym -30 10 2 0 P2>
+    <.PortSym 30 0 3 180 P3>
+    <.ID 10 14 Y>
+    <EArc -30 -20 40 40 4320 2880 #000080 2 1>
+    <Line -10 20 0 -40 #000000 2 1>
+    <Line 10 0 20 0 #000080 2 1>
+    <Line -30 -10 20 0 #000080 2 1>
+    <Line -30 10 20 0 #000080 2 1>
+  </Symbol>
+</Component>
+
+<Component 74HC32>
+  <Description>
+2-Input Or Gate
+
+Requirements:
+.spiceinit: set ngbehavior=psa
+.PARAM: vcc=5
+  </Description>
+  <Model>
+.Def:Digital_HC_74HC32 _net0 _net2 _net1
+Sub:X1 _net0 _net2 _net1 gnd Type="n74HC32_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "74HC32.cir.lst">
+  <Spice>
+* ----------------------------------------------------------- 74HC32 ------
+*  Quad 2-Input Or Gates
+*
+*  The High-Speed CMOS Logic Data Book, 1989, TI Pages 2-77 to 2-79
+*  bss    2/9/94
+*
+.SUBCKT 74HC32  1A 1B 1Y
++     optional: DPWR=$G_DPWR DGND=$G_DGND
++     params: MNTYMXDLY=0 IO_LEVEL=0
+
+U1 or(2) DPWR DGND
++     1A 1B 1Y
++     DLY_HC32 IO_HC MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+.model DLY_HC32 ugate (tplhTY=10ns tplhMX=20ns tphlTY=10ns tphlMX=20ns)
+
+.ENDS  74HC32
+
+.SUBCKT Digital_HC_74HC32  gnd _net0 _net2 _net1 
+X1 _net0 _net2 _net1 74HC32
+.ENDS
+  </Spice>
+  <Symbol>
+    <.PortSym -30 -10 1 0 P1>
+    <.PortSym -30 10 2 0 P2>
+    <.PortSym 30 0 3 180 P3>
+    <.ID 10 14 Y>
+    <EArc -30 -20 40 40 4320 2880 #000080 2 1>
+    <Line 10 0 20 0 #000080 2 1>
+    <Line -30 -10 20 0 #000080 2 1>
+    <Line -30 10 20 0 #000080 2 1>
+    <EArc -20 -20 10 40 4320 2880 #000080 2 1>
+    <Line -10 20 -5 0 #000000 2 1>
+    <Line -10 -20 -5 0 #000000 2 1>
+  </Symbol>
+</Component>
+
+<Component 74HC74>
+  <Description>
+D-Type Positive Edge Triggered Flip-Flop With Preset And Clear
+
+Requirements:
+.spiceinit: set ngbehavior=psa
+.PARAM: vcc=5
+  </Description>
+  <Model>
+.Def:Digital_HC_74HC74 _net0 _net1 _net2 _net3 _net4 _net5
+Sub:X1 _net0 _net1 _net2 _net3 _net4 _net5 gnd Type="n74HC74_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "74HC74.cir.lst">
+  <Spice>
+* ----------------------------------------------------------- 74HC74 ------
+*  Dual D-Type Positive Edge Triggered Flip-Flops With  Preset And Clear
+*
+*  The High-Speed CMOS Logic Data Book, 1989, TI Pages 2-101 to 2-103
+*  bss    2/23/94
+*
+.SUBCKT 74HC74 1PREBAR 1CLRBAR 1CLK 1D 1Q 1QBAR
++     optional:  DPWR=$G_DPWR DGND=$G_DGND
++     params:  MNTYMXDLY=0 IO_LEVEL=0
+
+U1 DFF(1) DPWR DGND
++     1PREBAR 1CLRBAR 1CLK 1D 1Q 1QBAR
++     DLY_HC74 IO_HC MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+.model DLY_HC74 ueff(tppcqlhTY=20ns tppcqlhMX=46ns tppcqhlTY=20ns
++                 tppcqhlMX=46ns twpclMN=25ns
++                 tpclkqlhTY=20ns tpclkqlhMX=35ns tpclkqhlTY=20ns
++                 tpclkqhlMX=35ns twclkhMN=20ns twclklMN=20ns
++                 tsudclkMN=25ns tsupcclkhMN=6ns)
+
+.ENDS 74HC74
+
+.SUBCKT Digital_HC_74HC74  gnd _net0 _net1 _net2 _net3 _net4 _net5 
+X1 _net0 _net1 _net2 _net3 _net4 _net5 74HC74
+.ENDS
+  </Spice>
+  <Symbol>
+    <Rectangle -30 -40 60 80 #000080 2 1 #c0c0c0 1 0>
+    <Line -50 20 20 0 #000080 2 1>
+    <Line -50 -20 20 0 #000080 2 1>
+    <Line 30 -20 20 0 #000080 2 1>
+    <Line 0 -40 0 -20 #000080 2 1>
+    <Ellipse -4 40 8 8 #000080 1 1 #000080 1 1>
+    <Line 30 20 20 0 #000080 2 1>
+    <Ellipse -4 -48 8 8 #000080 1 1 #000080 1 1>
+    <Line 14 11 12 0 #000080 2 1>
+    <Text 14 -31 12 #000080 0 "Q">
+    <Text 14 9 12 #000080 0 "Q">
+    <Text -28 -30 12 #000080 0 "D">
+    <Line -15 20 -15 -10 #000080 2 1>
+    <Line -30 30 15 -10 #000080 2 1>
+    <.PortSym -50 20 3 0 P3>
+    <.PortSym -50 -20 4 0 P4>
+    <.PortSym 50 -20 5 180 P5>
+    <.PortSym 50 20 6 180 P6>
+    <.PortSym 0 -60 2 0 P2>
+    <.PortSym 0 60 1 0 P1>
+    <Line 0 61 0 -20 #000080 2 1>
+    <Text -6 -41 12 #000080 0 "C">
+    <.ID 20 44 Y>
+    <Text -3 19 12 #000080 0 "P">
+  </Symbol>
+</Component>
+
+<Component 74HC86>
+  <Description>
+2-Input Exclusive-Or Gate
+
+Requirements:
+.spiceinit: set ngbehavior=psa
+.PARAM: vcc=5
+  </Description>
+  <Model>
+.Def:Digital_HC_74HC86 _net0 _net2 _net1
+Sub:X1 _net0 _net2 _net1 gnd Type="n74HC86_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "74HC86.cir.lst">
+  <Spice>
+* ----------------------------------------------------------- 74HC86 ------
+*  Quad 2-Input Exclusive-Or Gates
+*
+*  The High-Speed CMOS Logic Data Book, 1989, TI Pages 2-129 to 2-131
+*  bss    2/25/94
+*
+.SUBCKT 74HC86 1A 1B 1Y
++     optional:  DPWR=$G_DPWR DGND=$G_DGND
++     params:  MNTYMXDLY=0 IO_LEVEL=0
+
+U1 xor DPWR DGND
++     1A 1B 1Y
++     DLY_HC86 IO_HC MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+.model DLY_HC86 ugate (tplhTY=12ns tplhMX=20ns tphlTY=12ns tphlMX=20ns)
+
+.ENDS 74HC86
+
+.SUBCKT Digital_HC_74HC86  gnd _net0 _net2 _net1 
+X1 _net0 _net2 _net1 74HC86
+.ENDS
+  </Spice>
+  <Symbol>
+    <.PortSym -30 -10 1 0 P1>
+    <.PortSym -30 10 2 0 P2>
+    <.PortSym 30 0 3 180 P3>
+    <.ID 10 14 Y>
+    <EArc -30 -20 40 40 4320 2880 #000080 2 1>
+    <Line 10 0 20 0 #000080 2 1>
+    <Line -30 -10 20 0 #000080 2 1>
+    <Line -30 10 20 0 #000080 2 1>
+    <EArc -20 -20 10 40 4320 2880 #000080 2 1>
+    <EArc -15 -20 10 40 4320 2880 #000080 2 1>
+  </Symbol>
+</Component>
+
+<Component 74HC132>
+  <Description>
+2-Input Nand Gate
+
+Requirements:
+.spiceinit: set ngbehavior=psa
+.PARAM: vcc=5
+  </Description>
+  <Model>
+.Def:Digital_HC_74HC132 _net0 _net2 _net1
+Sub:X1 _net0 _net2 _net1 gnd Type="n74HC132_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "74HC132.cir.lst">
+  <Spice>
+* ----------------------------------------------------------- 74HC132 ------
+*  Quad 2-Input Nand Schmitt Triggers
+*
+*  The High-Speed CMOS Logic Data Book, 1989, TI Pages 2-159 to 2-161
+*  bss    3/15/94
+*
+.SUBCKT 74HC132 1A 1B 1Y
++  optional:  DPWR=$G_DPWR DGND=$G_DGND
++  params:  MNTYMXDLY=0 IO_LEVEL=0
+
+U1 nand(2) DPWR DGND
++  1A 1B 1Y
++  DLY_HC132 IO_HC_ST MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+.model DLY_HC132 ugate (tplhTY=18ns tplhMX=25ns tphlTY=18ns tphlMX=25ns)
+
+.ENDS 74HC132
+
+.SUBCKT Digital_HC_74HC132  gnd _net0 _net2 _net1 
+X1 _net0 _net2 _net1 74HC132
+.ENDS
+  </Spice>
+  <Symbol>
+    <.PortSym -30 10 2 0 P2>
+    <.PortSym 30 0 3 180 P3>
+    <EArc -30 -20 40 40 4320 2880 #000080 2 1>
+    <Line -10 20 0 -40 #000000 2 1>
+    <Ellipse 10 -4 8 8 #000080 1 1 #000080 1 1>
+    <Line 10 0 20 0 #000080 2 1>
+    <Line -30 -10 20 0 #000080 2 1>
+    <Line -30 10 20 0 #000080 2 1>
+    <Line -6 7 7 0 #000080 2 1>
+    <Line -3 -7 7 0 #000080 2 1>
+    <Line 1 7 0 -14 #000080 2 1>
+    <Line -3 7 0 -14 #000080 2 1>
+    <.PortSym -30 -10 1 0 P1>
+    <.ID 10 14 Y>
+  </Symbol>
+</Component>
+

--- a/library/Digital_LV.lib
+++ b/library/Digital_LV.lib
@@ -1,0 +1,129 @@
+<Qucs Library 24.3.99 "Digital_LV">
+
+<Component 74LV00>
+  <Description>
+2-Input Nand Gate
+
+Requirements:
+.spiceinit: set ngbehavior=psa
+.PARAM: vcc=5
+  </Description>
+  <Model>
+.Def:Digital_LV_74LV00 _net0 _net1 _net2
+Sub:X1 _net0 _net1 _net2 gnd Type="n74LV00_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "74LV00.cir.lst">
+  <Spice>
+* The timing parameters for all of these models were taken from the specifications for a 
+* 3.3V power supply and a 50pF capacitive load.
+
+* ----------------------------------------------------------- 74LV00A ------
+*  Quad 2-Input Positive-Nand Gates
+*
+*  TI PDF File
+*  bss    2/18/03
+*
+.SUBCKT 74LV00A  1A 1B 1Y
++     optional: DPWR_3V=$G_DPWR_3V DGND_3V=$G_DGND_3V
++     params: MNTYMXDLY=0 IO_LEVEL=0
+
+U1 nand(2) DPWR_3V DGND_3V
++     1A 1B 1Y
++     DLY_LV00 IO_LV-A MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+.model DLY_LV00 ugate (tplhTY=6.9ns tplhMX=11.4ns tphlTY=6.9ns tphlMX=11.4ns)
+
+.ENDS  74LV00A
+*
+
+.SUBCKT Digital_LV_74LV00  gnd _net0 _net1 _net2 
+X1 _net0 _net1 _net2 74LV00A
+.ENDS
+  </Spice>
+  <Symbol>
+    <EArc -30 -20 40 40 4320 2880 #000080 2 1>
+    <Line -10 20 0 -40 #000000 2 1>
+    <Ellipse 10 -4 8 8 #000080 1 1 #000080 1 1>
+    <Line 10 0 20 0 #000080 2 1>
+    <Line -30 -10 20 0 #000080 2 1>
+    <Line -30 10 20 0 #000080 2 1>
+    <.PortSym -30 -10 1 0 P1>
+    <.PortSym -30 10 2 0 P2>
+    <.PortSym 30 0 3 180 P3>
+    <.ID 10 14 Y>
+  </Symbol>
+</Component>
+
+<Component 74LV74>
+  <Description>
+D-Type Positive Edge Triggered Flip-Flop With Preset And Clear
+
+Requirements:
+.spiceinit: set ngbehavior=psa
+.PARAM: vcc=5
+  </Description>
+  <Model>
+.Def:Digital_LV_74LV74 _net0 _net1 _net2 _net3 _net4 _net5
+Sub:X1 _net0 _net1 _net2 _net3 _net4 _net5 gnd Type="n74LV74_cir"
+.Def:End
+  </Model>
+  <ModelIncludes "74LV74.cir.lst">
+  <Spice>
+* The timing parameters for all of these models were taken from the specifications for a 
+* 3.3V power supply and a 50pF capacitive load.
+*
+* ----------------------------------------------------------- 74LV74A ------
+*  Dual Positive Edge Triggered D-Type Flip-Flop
+*
+*  TI PDF File
+*  bss    2/24/03
+*
+.SUBCKT 74LV74A 1PREBAR 1CLRBAR 1CLK 1D 1Q 1QBAR
++     optional: DPWR_3V=$G_DPWR_3V DGND_3V=$G_DGND_3V
++     params: MNTYMXDLY=0 IO_LEVEL=0
+
+U1 DFF(1) DPWR_3V DGND_3V
++     1PREBAR 1CLRBAR 1CLK 1D 1Q 1QBAR
++     DLY_LV74 IO_LV-A MNTYMXDLY={MNTYMXDLY} IO_LEVEL={IO_LEVEL}
+
+.model DLY_LV74 ueff(tppcqlhty=9.2ns tppcqlhmx=15.8ns tppcqhlty=9.2ns tppcqhlmx=15.8ns
++							tpclkqlhty=10.2ns tpclkqlhmx=15.4ns tpclkqhlty=10.2ns tpclkqhlmx=15.4ns
++							twpclmn=6ns twclklmn=6ns twclkhmn=6ns tsudclkmn=6n tsupcclkhmn=5ns
++							thdclkmn=.5n)
+
+.ENDS 74LV74A
+*
+
+.SUBCKT Digital_LV_74LV74  gnd _net0 _net1 _net2 _net3 _net4 _net5 
+X1 _net0 _net1 _net2 _net3 _net4 _net5 74LV74A
+.ENDS
+  </Spice>
+  <Symbol>
+    <Rectangle -30 -40 60 80 #000080 2 1 #c0c0c0 1 0>
+    <Line -50 20 20 0 #000080 2 1>
+    <Line -50 -20 20 0 #000080 2 1>
+    <Line 30 -20 20 0 #000080 2 1>
+    <Line 0 -40 0 -20 #000080 2 1>
+    <Ellipse -4 40 8 8 #000080 1 1 #000080 1 1>
+    <Line 30 20 20 0 #000080 2 1>
+    <Ellipse -4 -48 8 8 #000080 1 1 #000080 1 1>
+    <Line 14 11 12 0 #000080 2 1>
+    <Text 14 -31 12 #000080 0 "Q">
+    <Text 14 9 12 #000080 0 "Q">
+    <Text -28 -30 12 #000080 0 "D">
+    <Line -15 20 -15 -10 #000080 2 1>
+    <Line -30 30 15 -10 #000080 2 1>
+    <Line 0 61 0 -20 #000080 2 1>
+    <Text -6 -41 12 #000080 0 "C">
+    <Text -3 19 12 #000080 0 "P">
+    <.PortSym 0 60 1 0 P1>
+    <.ID 20 44 Y>
+    <.PortSym 0 -60 2 0 P2>
+    <.PortSym -50 -20 4 0 P4>
+    <.PortSym -50 20 3 0 P3>
+    <.PortSym 50 -20 5 180 P5>
+    <.PortSym 50 20 6 180 P6>
+  </Symbol>
+</Component>
+

--- a/library/qucs.blacklist
+++ b/library/qucs.blacklist
@@ -1,5 +1,8 @@
 SpiceOpamp.lib
 Cores.lib
+Digital_CD4000.lib
+Digital_HC.lib
+Digital_LV.lib
 Transformers.lib
 Xanalogue.lib
 BF998.lib

--- a/library/xyce.blacklist
+++ b/library/xyce.blacklist
@@ -1,4 +1,6 @@
 Substrates.lib
 Xanalogue.lib
 PWM_Controller.lib
-
+Digital_CD4000.lib
+Digital_HC.lib
+Digital_LV.lib


### PR DESCRIPTION
This PR uploads three new digital ICs libraries:

* CD4000
* 74HC
* 74LV

The libraries contain only a reduced set of ICs that are most frequently used in analog circuits. The libraries works only with Ngspice. 