### PR TITLE
Fix 'Set Diagram Limits' not updating the diagram

### DIFF
--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1886,10 +1886,7 @@ void MouseActions::MReleaseSetLimits(Schematic *Doc, QMouseEvent *Event)
 
             diagram->setLimitsBySelectionRect(select);
 
-            // TODO: Consider refactoring loadGraphData to reload the current dataset if an empty string is passed.
-            QFileInfo Info(Doc->getDocName());
-            QString defaultDataSet = Info.absolutePath() + QDir::separator() + Doc->getDataSet();
-            diagram->loadGraphData(defaultDataSet);
+            diagram->updateGraphData();
 
             Doc->setChanged(true, true);
 

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -228,17 +228,14 @@ void QucsApp::slotResetDiagramLimits()
 {
   if (view->focusElement && view->focusElement->Type == isDiagram)
   {
-    Diagram* diagram = (Diagram*)(view->focusElement);
+    Diagram* diagram = dynamic_cast<Diagram*>(view->focusElement);
+    Schematic* Doc = dynamic_cast<Schematic*>(DocumentTab->currentWidget());
 
     diagram->xAxis.autoScale = true;
     diagram->yAxis.autoScale = true;
     diagram->zAxis.autoScale = true;
 
-    // Now read in the data.
-    auto* Doc = (Schematic*)DocumentTab->currentWidget();
-    QFileInfo Info(Doc->getDocName());
-    QString defaultDataSet = Info.absolutePath() + QDir::separator() + Doc->getDataSet();
-    diagram->loadGraphData(defaultDataSet);
+    diagram->updateGraphData();
 
     Doc->setChanged(true, true);
     Doc->viewport()->update();


### PR DESCRIPTION
This PR fixes the 'Set Diagram Limits' button not redrawing the diagram with the new limits.