### PR TITLE
Set CLI parameters for each simulator individually

### DIFF
--- a/qucs/components/subcirport.cpp
+++ b/qucs/components/subcirport.cpp
@@ -30,9 +30,6 @@ SubCirPort::SubCirPort()
   Props.append(new Property("Type", "analog", false,
 		QObject::tr("type of the port (for digital simulation only)")
 		+" [analog, in, out, inout]"));
-  Props.append(new Property("XSPICE_Type","v",false,"Allowed XSPICE types: [v,i,vd,id,h,g,hd,gd]"));
-  Props.append(new Property("Bounded","",false,
-        QObject::tr("Conjugated port for XSPICE differential ports")));
 
   createSymbol();
   tx = x1+4;

--- a/qucs/extsimkernels/externsimdialog.cpp
+++ b/qucs/extsimkernels/externsimdialog.cpp
@@ -19,6 +19,7 @@
 # include <config.h>
 #endif
 
+#include "settings.h"
 #include "externsimdialog.h"
 #include "simsettingsdialog.h"
 #include "main.h"
@@ -119,7 +120,7 @@ void ExternSimDialog::slotSetSimulator()
         } else {
             a_ngspice->setSimulatorCmd(QucsSettings.NgspiceExecutable); //rely on $PATH
         }
-        a_ngspice->setSimulatorParameters(QucsSettings.SimParameters);
+        a_ngspice->setSimulatorParameters(_settings::Get().item<QString>("NgspiceParams"));
     }
         break;
     case spicecompat::simXyce: {
@@ -127,7 +128,7 @@ void ExternSimDialog::slotSetSimulator()
         connect(a_xyce,SIGNAL(started()),this,SLOT(slotNgspiceStarted()));
         connect(a_xyce,SIGNAL(finished()),this,SLOT(slotProcessOutput()));
         connect(a_xyce,SIGNAL(errors(QProcess::ProcessError)),this,SLOT(slotNgspiceStartError(QProcess::ProcessError)));
-        a_xyce->setSimulatorParameters(QucsSettings.SimParameters);
+        a_xyce->setSimulatorParameters(_settings::Get().item<QString>("XyceParams"));
     }
         break;
 //    case spicecompat::simXycePar: {
@@ -149,7 +150,7 @@ void ExternSimDialog::slotSetSimulator()
         connect(a_ngspice,SIGNAL(finished()),this,SLOT(slotProcessOutput()),Qt::UniqueConnection);
         connect(a_ngspice,SIGNAL(errors(QProcess::ProcessError)),this,SLOT(slotNgspiceStartError(QProcess::ProcessError)),Qt::UniqueConnection);
         a_ngspice->setSimulatorCmd(QucsSettings.SpiceOpusExecutable);
-        a_ngspice->setSimulatorParameters(QucsSettings.SimParameters);
+        a_ngspice->setSimulatorParameters(_settings::Get().item<QString>("NgspiceParams"));
     }
         break;
     default: break;

--- a/qucs/extsimkernels/simsettingsdialog.cpp
+++ b/qucs/extsimkernels/simsettingsdialog.cpp
@@ -29,22 +29,16 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     a_lblXyce(new QLabel(tr("Xyce executable location"))),
     a_lblNgspice(new QLabel(tr("Ngspice executable location"))),
     a_lblSpiceOpus(new QLabel(tr("SpiceOpus executable location"))),
-    //a_lblXycePar(new QLabel(tr("Xyce Parallel executable location (openMPI installed required)"))),
-    //a_lblNprocs(new QLabel(tr("Number of processors in a system:"))),
     a_lblQucsator(new QLabel(tr("Qucsator executable location"))),
-    //a_lblSimulator(new QLabel(tr("Default simulator"))),
     a_lblNgspiceSimParam(new QLabel(tr("Ngspice CLI parameters"))),
     a_lblXyceSimParam(new QLabel(tr("Xyce CLI parameters"))),
     a_lblSpopusSimParam(new QLabel(tr("SpiceOpus CLI parameters"))),
     a_lblCompatMode(new QLabel(tr("Ngspice compatibility mode"))),
     a_cbxCompatMode(new QComboBox),
-    //a_cbxSimulator(new QComboBox(this)),
     a_edtNgspice(new QLineEdit(QucsSettings.NgspiceExecutable)),
     a_edtSpiceOpus(new QLineEdit(QucsSettings.SpiceOpusExecutable)),
     a_edtXyce(new QLineEdit(QucsSettings.XyceExecutable)),
-    //a_edtXycePar(new QLineEdit(QucsSettings.XyceParExecutable),
     a_edtQucsator(new QLineEdit(QucsSettings.Qucsator)),
-    //a_spbNprocs(new QSpinBox(this)),
     a_edtNgspiceSimParam(new QLineEdit()),
     a_edtXyceSimParam(new QLineEdit()),
     a_edtSpopusSimParam(new QLineEdit()),
@@ -53,25 +47,9 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     a_btnSetNgspice(new QPushButton(tr("Select ..."))),
     a_btnSetSpOpus(new QPushButton(tr("Select ..."))),
     a_btnSetXyce(new QPushButton(tr("Select ..."))),
-    //a_btnSetXycePar(new QPushButton(tr("Select ..."))),
     a_btnSetQucsator(new QPushButton(tr("Select ...")))
 {
-//    a_cbxSimulator->addItem("Ngspice", 1);
-//    a_cbxSimulator->addItem("Xyce", 2);
-//    a_cbxSimulator->addItem("SpiceOpus", 4);
-//    a_cbxSimulator->addItem("Qucsator", 8);
-    //QStringList items;
-    //items<<"Ngspice"<<"Xyce (Serial)"<<"Xyce (Parallel)"<<"SpiceOpus"<<"Qucsator";
-    //a_cbxSimulator->addItems(items);
     qDebug()<<QucsSettings.DefaultSimulator;
-//    a_cbxSimulator->setCurrentIndex(QucsSettings.DefaultSimulator);
-//    if (QucsSettings.DefaultSimulator==spicecompat::simNotSpecified)
-//        a_cbxSimulator->setCurrentIndex(spicecompat::simNgspice);
-
-//    a_spbNprocs->setMinimum(1);
-//    a_spbNprocs->setMaximum(256);
-//    a_spbNprocs->setValue(1);
-//    a_spbNprocs->setValue(QucsSettings.NProcs);
 
     a_edtNgspiceSimParam->setText(_settings::Get().item<QString>("NgspiceParams"));
     a_edtXyceSimParam->setText(_settings::Get().item<QString>("XyceParams"));
@@ -83,7 +61,6 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
 
     connect(a_btnSetNgspice,SIGNAL(clicked()),this,SLOT(slotSetNgspice()));
     connect(a_btnSetXyce,SIGNAL(clicked()),this,SLOT(slotSetXyce()));
-    //connect(a_btnSetXycePar,SIGNAL(clicked()),this,SLOT(slotSetXycePar()));
     connect(a_btnSetSpOpus,SIGNAL(clicked()),this,SLOT(slotSetSpiceOpus()));
     connect(a_btnSetQucsator,SIGNAL(clicked()),this,SLOT(slotSetQucsator()));
 
@@ -94,11 +71,6 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     a_cbxCompatMode->setCurrentIndex(compat_mode);
 
     QVBoxLayout *top = new QVBoxLayout;
-
-//    QHBoxLayout *h8 = new QHBoxLayout;
-//    h8->addWidget(a_lblSimulator,1);
-//    h8->addWidget(a_cbxSimulator,3);
-//    top->addLayout(h8);
 
     QGroupBox *gbp1 = new QGroupBox(this);
     gbp1->setTitle(tr("SPICE settings"));
@@ -123,17 +95,6 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     top2->addLayout(h2);
     top2->addWidget(a_lblXyceSimParam);
     top2->addWidget(a_edtXyceSimParam);
-
-//    top2->addWidget(a_lblXycePar);
-//    QHBoxLayout *h4 = new QHBoxLayout;
-//    h4->addWidget(a_edtXycePar,3);
-//    h4->addWidget(a_btnSetXycePar,1);
-//    top2->addLayout(h4);
-//
-//    QHBoxLayout *h5 = new QHBoxLayout;
-//    h5->addWidget(a_lblNprocs);
-//    h5->addWidget(a_spbNprocs);
-//    top2->addLayout(h5);
 
     top2->addWidget(a_lblSpiceOpus);
     QHBoxLayout *h7 = new QHBoxLayout;
@@ -168,14 +129,6 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     this->setFixedWidth(500);
     this->setWindowTitle(tr("Setup simulators executable location"));
 
-#ifndef Q_OS_UNIX
-    // Only Unix supports Xyce-parallel
-//    a_edtXycePar->setDisabled(true);
-//    a_lblXycePar->setDisabled(true);
-//    a_lblNprocs->setDisabled(true);
-//    a_spbNprocs->setDisabled(true);
-#endif
-
 }
 
 
@@ -183,16 +136,8 @@ void SimSettingsDialog::slotApply()
 {
     QucsSettings.NgspiceExecutable = a_edtNgspice->text();
     QucsSettings.XyceExecutable = a_edtXyce->text();
-    //QucsSettings.XyceParExecutable = a_edtXycePar->text();
     QucsSettings.SpiceOpusExecutable = a_edtSpiceOpus->text();
     QucsSettings.Qucsator = a_edtQucsator->text();
-    //QucsSettings.NProcs = a_spbNprocs->value();
-//    if ((QucsSettings.DefaultSimulator != a_cbxSimulator->currentIndex())&&
-//        (QucsSettings.DefaultSimulator != spicecompat::simNotSpecified)) {
-//        QMessageBox::warning(this,tr("Simulator settings"),tr("Default simulator engine was changed!\n"
-//                                                              "Please restart Qucs to affect changes!"));
-//    }
-//    QucsSettings.DefaultSimulator = a_cbxSimulator->currentIndex();
     settingsManager& qs = _settings::Get();
     qs.setItem<int>("NgspiceCompatMode", a_cbxCompatMode->currentIndex());
     qs.setItem<QString>("NgspiceParams", a_edtNgspiceSimParam->text());
@@ -204,8 +149,6 @@ void SimSettingsDialog::slotApply()
 
 void SimSettingsDialog::slotCancel()
 {
-    //if (QucsSettings.DefaultSimulator == spicecompat::simNotSpecified)
-    //QucsSettings.DefaultSimulator = spicecompat::simQucsator;
     reject();
 }
 
@@ -227,11 +170,7 @@ void SimSettingsDialog::slotSetXyce()
 
 void SimSettingsDialog::slotSetXycePar() // TODO ZERGUD
 {
-//    QString s = QFileDialog::getOpenFileName(this,tr("Select Xyce Parallel executable location"),a_edtXycePar->text(),"All files (*)");
-//    if (!s.isEmpty()) {
-//        if (s.endsWith("xmpirun")) s += " -np %p";
-//        a_edtXycePar->setText(s);
-//    }
+
 }
 
 void SimSettingsDialog::slotSetSpiceOpus()

--- a/qucs/extsimkernels/simsettingsdialog.cpp
+++ b/qucs/extsimkernels/simsettingsdialog.cpp
@@ -33,7 +33,9 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     //a_lblNprocs(new QLabel(tr("Number of processors in a system:"))),
     a_lblQucsator(new QLabel(tr("Qucsator executable location"))),
     //a_lblSimulator(new QLabel(tr("Default simulator"))),
-    a_lblSimParam(new QLabel(tr("Extra simulator parameters"))),
+    a_lblNgspiceSimParam(new QLabel(tr("Ngspice CLI parameters"))),
+    a_lblXyceSimParam(new QLabel(tr("Xyce CLI parameters"))),
+    a_lblSpopusSimParam(new QLabel(tr("SpiceOpus CLI parameters"))),
     a_lblCompatMode(new QLabel(tr("Ngspice compatibility mode"))),
     a_cbxCompatMode(new QComboBox),
     //a_cbxSimulator(new QComboBox(this)),
@@ -43,7 +45,9 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     //a_edtXycePar(new QLineEdit(QucsSettings.XyceParExecutable),
     a_edtQucsator(new QLineEdit(QucsSettings.Qucsator)),
     //a_spbNprocs(new QSpinBox(this)),
-    a_edtSimParam(new QLineEdit(QucsSettings.SimParameters)),
+    a_edtNgspiceSimParam(new QLineEdit()),
+    a_edtXyceSimParam(new QLineEdit()),
+    a_edtSpopusSimParam(new QLineEdit()),
     a_btnOK(new QPushButton(tr("Apply changes"))),
     a_btnCancel(new QPushButton(tr("Cancel"))),
     a_btnSetNgspice(new QPushButton(tr("Select ..."))),
@@ -68,6 +72,11 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
 //    a_spbNprocs->setMaximum(256);
 //    a_spbNprocs->setValue(1);
 //    a_spbNprocs->setValue(QucsSettings.NProcs);
+
+    a_edtNgspiceSimParam->setText(_settings::Get().item<QString>("NgspiceParams"));
+    a_edtXyceSimParam->setText(_settings::Get().item<QString>("XyceParams"));
+    a_edtSpopusSimParam->setText(_settings::Get().item<QString>("SpopusParams"));
+
 
     connect(a_btnOK,SIGNAL(clicked()),this,SLOT(slotApply()));
     connect(a_btnCancel,SIGNAL(clicked()),this,SLOT(reject()));
@@ -104,12 +113,16 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     h4->addWidget(a_lblCompatMode);
     h4->addWidget(a_cbxCompatMode);
     top2->addLayout(h4);
+    top2->addWidget(a_lblNgspiceSimParam);
+    top2->addWidget(a_edtNgspiceSimParam);
 
     top2->addWidget(a_lblXyce);
     QHBoxLayout *h2 = new QHBoxLayout;
     h2->addWidget(a_edtXyce,3);
     h2->addWidget(a_btnSetXyce,1);
     top2->addLayout(h2);
+    top2->addWidget(a_lblXyceSimParam);
+    top2->addWidget(a_edtXyceSimParam);
 
 //    top2->addWidget(a_lblXycePar);
 //    QHBoxLayout *h4 = new QHBoxLayout;
@@ -127,12 +140,8 @@ SimSettingsDialog::SimSettingsDialog(QWidget *parent) :
     h7->addWidget(a_edtSpiceOpus,3);
     h7->addWidget(a_btnSetSpOpus,1);
     top2->addLayout(h7);
-
-
-    top2->addWidget(a_lblSimParam);
-    QHBoxLayout *h10 = new QHBoxLayout;
-    h10->addWidget(a_edtSimParam,4);
-    top2->addLayout(h10);
+    top2->addWidget(a_lblSpopusSimParam);
+    top2->addWidget(a_edtSpopusSimParam);
 
     gbp1->setLayout(top2);
     top->addWidget(gbp1);
@@ -178,7 +187,7 @@ void SimSettingsDialog::slotApply()
     QucsSettings.SpiceOpusExecutable = a_edtSpiceOpus->text();
     QucsSettings.Qucsator = a_edtQucsator->text();
     //QucsSettings.NProcs = a_spbNprocs->value();
-    QucsSettings.SimParameters = a_edtSimParam->text();
+    QucsSettings.SimParameters = a_edtNgspiceSimParam->text();
 //    if ((QucsSettings.DefaultSimulator != a_cbxSimulator->currentIndex())&&
 //        (QucsSettings.DefaultSimulator != spicecompat::simNotSpecified)) {
 //        QMessageBox::warning(this,tr("Simulator settings"),tr("Default simulator engine was changed!\n"
@@ -187,6 +196,9 @@ void SimSettingsDialog::slotApply()
 //    QucsSettings.DefaultSimulator = a_cbxSimulator->currentIndex();
     settingsManager& qs = _settings::Get();
     qs.setItem<int>("NgspiceCompatMode", a_cbxCompatMode->currentIndex());
+    qs.setItem<QString>("NgspiceParams", a_edtNgspiceSimParam->text());
+    qs.setItem<QString>("XyceParams", a_edtXyceSimParam->text());
+    qs.setItem<QString>("SpopusParams", a_edtSpopusSimParam->text());
     accept();
     saveApplSettings();
   }

--- a/qucs/extsimkernels/simsettingsdialog.cpp
+++ b/qucs/extsimkernels/simsettingsdialog.cpp
@@ -187,7 +187,6 @@ void SimSettingsDialog::slotApply()
     QucsSettings.SpiceOpusExecutable = a_edtSpiceOpus->text();
     QucsSettings.Qucsator = a_edtQucsator->text();
     //QucsSettings.NProcs = a_spbNprocs->value();
-    QucsSettings.SimParameters = a_edtNgspiceSimParam->text();
 //    if ((QucsSettings.DefaultSimulator != a_cbxSimulator->currentIndex())&&
 //        (QucsSettings.DefaultSimulator != spicecompat::simNotSpecified)) {
 //        QMessageBox::warning(this,tr("Simulator settings"),tr("Default simulator engine was changed!\n"

--- a/qucs/extsimkernels/simsettingsdialog.h
+++ b/qucs/extsimkernels/simsettingsdialog.h
@@ -34,7 +34,9 @@ private:
     //QLabel *a_lblNprocs;
     QLabel *a_lblQucsator;
     //QLabel *a_lblSimulator;
-    QLabel *a_lblSimParam;
+    QLabel *a_lblNgspiceSimParam;
+    QLabel *a_lblXyceSimParam;
+    QLabel *a_lblSpopusSimParam;
     QLabel *a_lblCompatMode;
 
     QComboBox *a_cbxCompatMode;
@@ -46,7 +48,9 @@ private:
     //QLineEdit *a_edtXycePar;
     QLineEdit *a_edtQucsator;
     //QSpinBox  *a_spbNprocs;
-    QLineEdit *a_edtSimParam;
+    QLineEdit *a_edtNgspiceSimParam;
+    QLineEdit *a_edtXyceSimParam;
+    QLineEdit *a_edtSpopusSimParam;
 
     QPushButton *a_btnOK;
     QPushButton *a_btnCancel;

--- a/qucs/extsimkernels/simsettingsdialog.h
+++ b/qucs/extsimkernels/simsettingsdialog.h
@@ -30,24 +30,18 @@ private:
     QLabel *a_lblXyce;
     QLabel *a_lblNgspice;
     QLabel *a_lblSpiceOpus;
-    //QLabel *a_lblXycePar;
-    //QLabel *a_lblNprocs;
     QLabel *a_lblQucsator;
-    //QLabel *a_lblSimulator;
     QLabel *a_lblNgspiceSimParam;
     QLabel *a_lblXyceSimParam;
     QLabel *a_lblSpopusSimParam;
     QLabel *a_lblCompatMode;
 
     QComboBox *a_cbxCompatMode;
-    //QComboBox *a_cbxSimulator;
 
     QLineEdit *a_edtNgspice;
     QLineEdit *a_edtSpiceOpus;
     QLineEdit *a_edtXyce;
-    //QLineEdit *a_edtXycePar;
     QLineEdit *a_edtQucsator;
-    //QSpinBox  *a_spbNprocs;
     QLineEdit *a_edtNgspiceSimParam;
     QLineEdit *a_edtXyceSimParam;
     QLineEdit *a_edtSpopusSimParam;
@@ -58,7 +52,6 @@ private:
     QPushButton *a_btnSetNgspice;
     QPushButton *a_btnSetSpOpus;
     QPushButton *a_btnSetXyce;
-    //QPushButton *a_btnSetXycePar;
     QPushButton *a_btnSetQucsator;
 
 public:

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -129,7 +129,6 @@ bool loadSettings()
     if (QucsSettings.S4Qworkdir == "")
       QucsSettings.S4Qworkdir = QDir::toNativeSeparators(QucsSettings.QucsWorkDir.absolutePath()+"/spice4qucs");
 
-    QucsSettings.SimParameters = _settings::Get().item<QString>("SimParameters");
     QucsSettings.OctaveExecutable = _settings::Get().item<QString>("OctaveExecutable");
     QucsSettings.OpenVAFExecutable = _settings::Get().item<QString>("OpenVAFExecutable");
 
@@ -209,7 +208,6 @@ bool saveApplSettings()
     qs.setItem<QString>("Qucsator",QucsSettings.Qucsator);
     qs.setItem<int>("Nprocs",QucsSettings.NProcs);
     qs.setItem<QString>("S4Q_workdir",QucsSettings.S4Qworkdir);
-    qs.setItem<QString>("SimParameters",QucsSettings.SimParameters);
     qs.setItem<QString>("OctaveExecutable",QucsSettings.OctaveExecutable);
     qs.setItem<QString>("OpenVAFExecutable",QucsSettings.OpenVAFExecutable);
     qs.setItem<QString>("QucsHomeDir", QucsSettings.qucsWorkspaceDir.canonicalPath());

--- a/qucs/main.h
+++ b/qucs/main.h
@@ -83,7 +83,6 @@ struct tQucsSettings {
   QString XyceParExecutable;
   QString SpiceOpusExecutable;
   QString S4Qworkdir;
-  QString SimParameters;
   unsigned int NProcs; // Number of processors for Xyce
   QString OctaveExecutable; // OctaveExecutable location
   QString QucsOctave; // OUCS_OCTAVE variable


### PR DESCRIPTION
This PR implements the feature requested by #1152. Now the CLI parameters are set for each simulator individually. 

![image](https://github.com/user-attachments/assets/1079e8bc-a760-4e08-a1e7-f9ed83272031)
