### PR TITLE
Fix compiler warnings

### DIFF
--- a/qucs-activefilter/main.cpp
+++ b/qucs-activefilter/main.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
     QString Lang = QucsSettings.Language;
     if(Lang.isEmpty())
       Lang = QString(QLocale::system().name());
-    tor.load( QStringLiteral("qucs_") + Lang, LangDir);
+    static_cast<void>(tor.load( QStringLiteral("qucs_") + Lang, LangDir));
     a.installTranslator( &tor );
 
     QucsActiveFilter *w = new QucsActiveFilter();

--- a/qucs-attenuator/main.cpp
+++ b/qucs-attenuator/main.cpp
@@ -94,7 +94,7 @@ int main( int argc, char ** argv )
   QString lang = QucsSettings.Language;
   if(lang.isEmpty())
     lang = QString(QLocale::system().name());
-  tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir);
+  static_cast<void>(tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir));
   a.installTranslator( &tor );
 
   QucsAttenuator *qucs = new QucsAttenuator();

--- a/qucs-filter/main.cpp
+++ b/qucs-filter/main.cpp
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
   QString lang = QucsSettings.Language;
   if(lang.isEmpty())
     lang = QString(QLocale::system().name());
-  tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir);
+  static_cast<void>(tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir));
   a.installTranslator( &tor );
 
   QucsFilter *qucs = new QucsFilter();

--- a/qucs-powercombining/main.cpp
+++ b/qucs-powercombining/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
     QString lang = QucsSettings.Language;
     if(lang.isEmpty())
       lang = QString(QLocale::system().name());
-    tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir);
+    static_cast<void>(tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir));
     app.installTranslator( &tor );
 
     QucsPowerCombiningTool *PowerCombiningTool = new QucsPowerCombiningTool();

--- a/qucs-s-spar-viewer/main.cpp
+++ b/qucs-s-spar-viewer/main.cpp
@@ -99,7 +99,7 @@ int main( int argc, char ** argv )
   QString lang = QucsSettings.Language;
   if(lang.isEmpty())
     lang = QString(QLocale::system().name());
-  tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir);
+  static_cast<void>(tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir));
   a.installTranslator( &tor );
 
   Qucs_S_SPAR_Viewer *qucs = new Qucs_S_SPAR_Viewer();

--- a/qucs-transcalc/main.cpp
+++ b/qucs-transcalc/main.cpp
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
   QString lang = QucsSettings.Language;
   if(lang.isEmpty())
     lang = QString(QLocale::system().name());
-  tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir);
+  static_cast<void>(tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir));
   a.installTranslator( &tor );
 
   QucsTranscalc *qucs = new QucsTranscalc();

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -900,7 +900,7 @@ int main(int argc, char *argv[])
       lang = loc.name();
 //    lang = QTextCodec::locale();
   }
-  tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir);
+  static_cast<void>(tor.load( QStringLiteral("qucs_") + lang, QucsSettings.LangDir));
   QApplication::installTranslator( &tor );
 
   // This seems to be necessary on a few system to make strtod()


### PR DESCRIPTION
Qt6 QTranslator::load() uses [[nodiscard]] which currently leads to compiler warnings. This is fixed using static_cast<void>.