### PR TITLE
Fixed nested subcircuits processing in Spice Library Device

### DIFF
--- a/qucs/extsimkernels/spicelibcompdialog.cpp
+++ b/qucs/extsimkernels/spicelibcompdialog.cpp
@@ -306,8 +306,10 @@ int SpiceLibCompDialog::parseLibFile(const QString &filename)
         line.remove(0,1);
         QStringList pins = line.split(QRegularExpression("[ \\t]"),Qt::SkipEmptyParts);
         for (const auto &s1: pins) {
-        if (s1 == "PARAMS:") header_start = false;
-        if (!s1.contains('=') && (s1 != "PARAMS:")) {
+          if (s1 == "PARAMS:" || s1 == ".OPTIONAL:") {
+            header_start = false;
+          }
+          if (!s1.contains('=') && (s1 != "PARAMS:") && (s1 != ".OPTIONAL:")) {
             a_subcirPins[subname].append(s1);
           }
         }
@@ -332,8 +334,10 @@ int SpiceLibCompDialog::parseLibFile(const QString &filename)
       tokens.removeFirst();
       tokens.removeFirst();
       for (const auto &s1: tokens) {
-        if (s1 == "PARAMS:") header_start = false;
-        if (!s1.contains('=') && (s1 != "PARAMS:")) {
+        if (s1 == "PARAMS:" || s1 == ".OPTIONAL:") {
+          header_start = false;
+        }
+        if (!s1.contains('=') && (s1 != "PARAMS:") && (s1 != ".OPTIONAL:")) {
           pin_names.append(s1);
         }
       }


### PR DESCRIPTION
This PR fixes the following issues with Spice Library Device:

* Nested subcircuits #1120 
* The .OPTIONAL keyword #1202 

Here is example of nested subcircuits processing. There exist the following side effect. The inner subcircuits inside the main subcircuit are not visible. I think it is not an issue. The inner subcircuits are normally not required. The nested subcircuits are very rare in libraries and forbidden by some SPICE dialects. The only example of such library is the one used in #1120 


![image](https://github.com/user-attachments/assets/e8eede38-1ade-43dc-be62-9294c8977fb2)



