### PR TITLE
Refactor Schematic::sizeOfSelection() and its usages

### DIFF
--- a/qucs/imagewriter.cpp
+++ b/qucs/imagewriter.cpp
@@ -124,7 +124,7 @@ int ImageWriter::print(QWidget *doc)
   int h = all.height();
 
 
-  QRect selected = sch->sizeOfSelection().bounds;
+  QRect selected = sch->currentSelection().bounds;
   int wsel = selected.width();
   int hsel = selected.height();
 

--- a/qucs/imagewriter.cpp
+++ b/qucs/imagewriter.cpp
@@ -124,7 +124,7 @@ int ImageWriter::print(QWidget *doc)
   int h = all.height();
 
 
-  QRect selected = sch->sizeOfSelection();
+  QRect selected = sch->sizeOfSelection().bounds;
   int wsel = selected.width();
   int hsel = selected.height();
 

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -749,7 +749,7 @@ void Schematic::print(QPrinter*, QPainter* painter, bool printAll,
     const QRectF pageSize{0, 0, static_cast<double>(painter->device()->width()),
                           static_cast<double>(painter->device()->height())};
 
-    QRect printedArea = printAll ? allBoundingRect() : sizeOfSelection().bounds;
+    QRect printedArea = printAll ? allBoundingRect() : currentSelection().bounds;
 
     if (printAll && a_showFrame) {
         int frame_width, frame_height;
@@ -977,7 +977,7 @@ void Schematic::zoomToSelection() {
                     return;
                 }
 
-    const QRect selectedBoundingRect{ sizeOfSelection().bounds };
+    const QRect selectedBoundingRect{ currentSelection().bounds };
 
     // Working with raw coordinates is clumsy, abstract them out
     const QRect usedBoundingRect{a_UsedX1, a_UsedY1, a_UsedX2 - a_UsedX1, a_UsedY2 - a_UsedY1};
@@ -1280,7 +1280,7 @@ void Schematic::sizeOfAll(int &xmin, int &ymin, int &xmax, int &ymax)
     }
 }
 
-Schematic::Selection Schematic::sizeOfSelection() const {
+Schematic::Selection Schematic::currentSelection() const {
     int xmin = INT_MAX;
     int ymin = INT_MAX;
     int xmax = INT_MIN;

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -103,7 +103,19 @@ public:
     Returns the smallest rectangle enclosing all elements of schematic
   */
   QRect allBoundingRect();
-  QRect  sizeOfSelection() const;
+
+  struct Selection {
+    QRect bounds;
+    std::vector<Component*> components;
+    std::vector<Wire*> wires;
+    std::vector<Painting*> paintings;
+    std::vector<Diagram*> diagrams;
+    std::vector<WireLabel*> labels;
+    std::vector<Marker*> markers;
+    std::vector<Node*> nodes;
+  };
+
+  Selection  sizeOfSelection() const;
   bool  rotateElements();
   bool  mirrorXComponents();
   bool  mirrorYComponents();

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -115,7 +115,7 @@ public:
     std::vector<Node*> nodes;
   };
 
-  Selection  sizeOfSelection() const;
+  Selection  currentSelection() const;
   bool  rotateElements();
   bool  mirrorXComponents();
   bool  mirrorYComponents();


### PR DESCRIPTION
Hi!

Nothing fancy comes with this PR, just a bit of refactoring to replace a recurring pattern (pseudocode):
```
for (comp : all_components) {
  if (!comp->isSelected) continue;
  ...
} 
```

Member function `Schematic::sizeOfSelection()` is renamed to `currentSelection` and is made to return not only selection bounds, but also containers with pointers to selected elements, which enables to iterate over selected elements directly:
```
for (comp : currentSelection().components) {
  ...
} 
```