### PR TITLE
Replace some Q3PtrList usages with QList

### DIFF
--- a/qucs/mouseactions.h
+++ b/qucs/mouseactions.h
@@ -50,7 +50,7 @@ public:
   QMouseEvent *focusMEvent;
 
   int  MAx1, MAy1,MAx2, MAy2, MAx3, MAy3;  // cache for mouse movements
-  Q3PtrList<Element> movingElements;
+  QList<Element*> movingElements;
   int movingRotated;
 
   // menu appearing by right mouse button click on component
@@ -123,8 +123,8 @@ public:
   void paintElementsScheme(Schematic*);
   void rotateElements(Schematic*, int&, int&);
   void moveElements(Schematic*, int&, int&);
-  static void moveElements(Q3PtrList<Element>*, int, int);
-  void endElementMoving(Schematic*, Q3PtrList<Element>*);
+  static void moveElements(QList<Element*>*, int, int);
+  void endElementMoving(Schematic*, QList<Element*>*);
   void rightPressMenu(Schematic*, QMouseEvent*, float, float);
 };
 

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -1127,9 +1127,19 @@ void QucsApp::slotCursorLeft(bool left)
   }
   if(!editText->isHidden()) return;  // for edit of component property ?
 
-  Q3PtrList<Element> movingElements;
+  QList<Element*> movingElements;
   Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
-  int markerCount = Doc->copySelectedElements(&movingElements);
+  int markerCount = 0;
+  {
+    // Q3PtrList is long time deprecated and has to be replaced with another
+    // container type, which is not always easy. Here it's simpler to use it
+    // once and go back to QList, because copySelectedElements() uses API
+    // unique to Q3PtrList and to refactor it is a piece of work
+    Q3PtrList<Element> temp_buffer;
+    temp_buffer.setAutoDelete(false);
+    markerCount = Doc->copySelectedElements(&temp_buffer);
+    for (auto* e : temp_buffer) { movingElements.append(e); }
+  }
 
   if((movingElements.count() - markerCount) < 1) {
     if(markerCount > 0) {  // only move marker if nothing else selected
@@ -1193,9 +1203,19 @@ void QucsApp::slotCursorUp(bool up)
     return;
   }
 
-  Q3PtrList<Element> movingElements;
+  QList<Element*> movingElements;
   Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
-  int markerCount = Doc->copySelectedElements(&movingElements);
+  int markerCount = 0;
+  {
+    // Q3PtrList is long time deprecated and has to be replaced with another
+    // container type, which is not always easy. Here it's simpler to use it
+    // once and go back to QList, because copySelectedElements() uses API
+    // unique to Q3PtrList and to refactor it is a piece of work
+    Q3PtrList<Element> temp_buffer;
+    temp_buffer.setAutoDelete(false);
+    markerCount = Doc->copySelectedElements(&temp_buffer);
+    for (auto* e : temp_buffer) { movingElements.append(e); }
+  }
 
   if((movingElements.count() - markerCount) < 1) { // all selections are markers
     if(markerCount > 0) {  // only move marker if nothing else selected

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1658,7 +1658,7 @@ void Schematic::cut()
 
 // ---------------------------------------------------
 // Performs paste function from clipboard
-bool Schematic::paste(QTextStream *stream, Q3PtrList<Element> *pe)
+bool Schematic::paste(QTextStream *stream, QList<Element*> *pe)
 {
     return pasteFromClipboard(stream, pe);
 }

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -175,7 +175,7 @@ public:
 
   void    cut();
   void    copy();
-  bool    paste(QTextStream*, Q3PtrList<Element>*);
+  bool    paste(QTextStream*, QList<Element*>*);
   bool    load();
   int     save();
   int     saveSymbolCpp (void);
@@ -445,8 +445,8 @@ public:
   void  deleteWire(Wire*);
 
   Marker* setMarker(int, int);
-  void    markerLeftRight(bool, Q3PtrList<Element>*);
-  void    markerUpDown(bool, Q3PtrList<Element>*);
+  void    markerLeftRight(bool, QList<Element*>*);
+  void    markerUpDown(bool, QList<Element*>*);
 
   Element* selectElement(float, float, bool, int *index=0);
   void     deselectElements(Element*) const;
@@ -522,15 +522,15 @@ private:
 
   bool loadProperties(QTextStream*);
   void simpleInsertComponent(Component*);
-  bool loadComponents(QTextStream*, Q3PtrList<Component> *List=0);
+  bool loadComponents(QTextStream*, QList<Component*> *List=0);
   void simpleInsertWire(Wire*);
-  bool loadWires(QTextStream*, Q3PtrList<Element> *List=0);
-  bool loadDiagrams(QTextStream*, Q3PtrList<Diagram>*);
-  bool loadPaintings(QTextStream*, Q3PtrList<Painting>*);
+  bool loadWires(QTextStream*, QList<Element*> *List=0);
+  bool loadDiagrams(QTextStream*, QList<Diagram*>*);
+  bool loadPaintings(QTextStream*, QList<Painting*>*);
   bool loadIntoNothing(QTextStream*);
 
   QString createClipboardFile();
-  bool    pasteFromClipboard(QTextStream *, Q3PtrList<Element>*);
+  bool    pasteFromClipboard(QTextStream *, QList<Element*>*);
 
   QString createUndoString(char);
   bool    rebuild(QString *);

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -981,14 +981,14 @@ Marker* Schematic::setMarker(int x, int y)
 
 // ---------------------------------------------------
 // Moves the marker pointer left/right on the graph.
-void Schematic::markerLeftRight(bool left, Q3PtrList<Element> *Elements)
+void Schematic::markerLeftRight(bool left, QList<Element*> *Elements)
 {
     bool acted = false;
-    for(auto i : *Elements) {
-        Marker* pm = prechecked_cast<Marker*>(i);
-        assert(pm);
-        if(pm->moveLeftRight(left))
-            acted = true;
+    for (auto* e : *Elements) {
+        if (auto* pm = dynamic_cast<Marker*>(e)) {
+            if (pm->moveLeftRight(left))
+                acted = true;
+            }
     }
 
     if(acted)  setChanged(true, true, 'm');
@@ -996,14 +996,14 @@ void Schematic::markerLeftRight(bool left, Q3PtrList<Element> *Elements)
 
 // ---------------------------------------------------
 // Moves the marker pointer up/down on the more-dimensional graph.
-void Schematic::markerUpDown(bool up, Q3PtrList<Element> *Elements)
+void Schematic::markerUpDown(bool up, QList<Element*> *Elements)
 {
-    Marker *pm;
     bool acted = false;
-    for(pm = (Marker*)Elements->first(); pm!=0; pm = (Marker*)Elements->next())
-    {
-        if(pm->moveUpDown(up))
-            acted = true;
+    for (auto* e : *Elements) {
+        if (auto* pm = dynamic_cast<Marker*>(e)) {
+            if (pm->moveUpDown(up))
+                acted = true;
+        }
     }
 
     if(acted)  setChanged(true, true, 'm');


### PR DESCRIPTION
Hi!

This patch replaces Q3PtrList with QList wherever possible. This mostly involves API (member functions) of Schematic and Mouseactions. Where it is not possible to get rid of Q3PtrList completely I inserted a "shim" which translates from QList to Q3PtrList (it's ugly, but it allows to make another step towards #748 completion).


Functionalities which are affected by this change:
- parsing schematic files
- copy-pasting
- moving of elements
- handling of "left" and "right" key presses

I've tested a bit all the mentioned above myself and found no issues, changes are cosmetic despite of their (possibly) scary appearance.