### PR TITLE
Refactor Schematic::recreateComponent() and Component::recreate()

### DIFF
--- a/qucs/components/DLS_1ton.cpp
+++ b/qucs/components/DLS_1ton.cpp
@@ -31,7 +31,7 @@ Component * DLS_1ton::newOne()
 {
   DLS_1ton * p = new DLS_1ton();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/DLS_nto1.cpp
+++ b/qucs/components/DLS_nto1.cpp
@@ -32,7 +32,7 @@ Component * DLS_nto1::newOne()
 {
   DLS_nto1 * p = new DLS_nto1();
   p->Props.front()->Value = Props.front()->Value;
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/MESFET.cpp
+++ b/qucs/components/MESFET.cpp
@@ -163,7 +163,7 @@ Component * MESFET::newOne()
 {
   MESFET * p = new MESFET();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/ac_sim.cpp
+++ b/qucs/components/ac_sim.cpp
@@ -62,7 +62,7 @@ Element* AC_Sim::info(QString& Name, char* &BitmapFile, bool getNewOne)
   return 0;
 }
 
-void AC_Sim::recreate(Schematic*)
+void AC_Sim::recreate()
 {
   if((Props.at(0)->Value == "list") || (Props.at(0)->Value == "const")) {
     // Call them "Symbol" to omit them in the netlist.

--- a/qucs/components/ac_sim.h
+++ b/qucs/components/ac_sim.h
@@ -27,7 +27,7 @@ public:
  ~AC_Sim();
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
-  void recreate(Schematic*);
+  void recreate();
   QString spice_netlist(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
 };
 

--- a/qucs/components/andor4x2.cpp
+++ b/qucs/components/andor4x2.cpp
@@ -41,7 +41,7 @@ Component * andor4x2::newOne()
 {
   andor4x2 * p = new andor4x2();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/andor4x3.cpp
+++ b/qucs/components/andor4x3.cpp
@@ -41,7 +41,7 @@ Component * andor4x3::newOne()
 {
   andor4x3 * p = new andor4x3();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/andor4x4.cpp
+++ b/qucs/components/andor4x4.cpp
@@ -42,7 +42,7 @@ Component * andor4x4::newOne()
 {
   andor4x4 * p = new andor4x4();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/binarytogrey4bit.cpp
+++ b/qucs/components/binarytogrey4bit.cpp
@@ -42,7 +42,7 @@ Component * binarytogrey4bit::newOne()
 {
   binarytogrey4bit * p = new binarytogrey4bit();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/bjt.cpp
+++ b/qucs/components/bjt.cpp
@@ -38,7 +38,7 @@ Component* BJT::newOne()
 {
   BJT* p = new BJT();
   p->Props.front()->Value = Props.front()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 
@@ -101,7 +101,7 @@ Element* BJT::info_pnp(QString& Name, char* &BitmapFile, bool getNewOne)
   if(getNewOne) {
     BJT* p = new BJT();
     p->Props.at(0)->Value = "pnp";
-    p->recreate(0);
+    p->recreate();
     return p;
   }
   return 0;

--- a/qucs/components/bjtsub.cpp
+++ b/qucs/components/bjtsub.cpp
@@ -141,7 +141,7 @@ Component* BJTsub::newOne()
 {
   BJTsub* p = new BJTsub();
   p->Props.front()->Value = Props.front()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 
@@ -164,7 +164,7 @@ Element* BJTsub::info_pnp(QString& Name, char* &BitmapFile, bool getNewOne)
   if(getNewOne) {
     BJTsub* p = new BJTsub();
     p->Props.front()->Value = "pnp";
-    p->recreate(0);
+    p->recreate();
     return p;
   }
   return 0;

--- a/qucs/components/comp_1bit.cpp
+++ b/qucs/components/comp_1bit.cpp
@@ -42,7 +42,7 @@ Component * comp_1bit::newOne()
 {
   comp_1bit * p = new comp_1bit();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/comp_2bit.cpp
+++ b/qucs/components/comp_2bit.cpp
@@ -41,7 +41,7 @@ Component * comp_2bit::newOne()
 {
   comp_2bit * p = new comp_2bit();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/comp_4bit.cpp
+++ b/qucs/components/comp_4bit.cpp
@@ -41,7 +41,7 @@ Component * comp_4bit::newOne()
 {
   comp_4bit * p = new comp_4bit();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -1431,11 +1431,7 @@ void Component::copyComponent(Component *pc) {
 // ********          Functions of class MultiViewComponent        ********
 // ********                                                       ********
 // ***********************************************************************
-void MultiViewComponent::recreate(Schematic *Doc) {
-    if (Doc) {
-        Doc->detachComp(this);
-    }
-
+void MultiViewComponent::recreate() {
     Ellipses.clear();
     Texts.clear();
     Ports.clear();
@@ -1457,10 +1453,6 @@ void MultiViewComponent::recreate(Schematic *Doc) {
 
     rotated = rrot;   // restore properties (were changed by rotate/mirror)
     mirroredX = mmir;
-
-    if (Doc) {
-        Doc->insertRawComponent(this);
-    }
 }
 
 
@@ -1791,7 +1783,7 @@ Component *getComponentFromName(QString &Line, Schematic *p) {
     cstr = c->Name;   // is perhaps changed in "recreate" (e.g. subcircuit)
     int x = c->tx, y = c->ty;
     c->setSchematic(p);
-    c->recreate(0);
+    c->recreate();
     c->Name = cstr;
     c->tx = x;
     c->ty = y;

--- a/qucs/components/component.h
+++ b/qucs/components/component.h
@@ -40,7 +40,7 @@ public:
   virtual ~Component() {};
 
   virtual Component* newOne();
-  virtual void recreate(Schematic*) {};
+  virtual void recreate() {};
   QString getNetlist();
   QString getSpiceNetlist(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
   QString getVerilogACode();
@@ -140,7 +140,7 @@ public:
   MultiViewComponent() {};
   virtual ~MultiViewComponent() {};
 
-  void recreate(Schematic*);
+  void recreate();
 
 protected:
   virtual void createSymbol() {};

--- a/qucs/components/dff_SR.cpp
+++ b/qucs/components/dff_SR.cpp
@@ -46,7 +46,7 @@ Component * dff_SR::newOne()
   dff_SR * p = new dff_SR();
 
   p->Props.front()->Value = Props.front()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/dmux2to4.cpp
+++ b/qucs/components/dmux2to4.cpp
@@ -41,7 +41,7 @@ Component * dmux2to4::newOne()
 {
   dmux2to4 * p = new dmux2to4();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/dmux3to8.cpp
+++ b/qucs/components/dmux3to8.cpp
@@ -42,7 +42,7 @@ Component * dmux3to8::newOne()
 {
   dmux3to8 * p = new dmux3to8();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/dmux4to16.cpp
+++ b/qucs/components/dmux4to16.cpp
@@ -41,7 +41,7 @@ Component * dmux4to16::newOne()
 {
   dmux4to16 * p = new dmux4to16();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/eqndefined.cpp
+++ b/qucs/components/eqndefined.cpp
@@ -56,7 +56,7 @@ Component* EqnDefined::newOne()
   EqnDefined* p = new EqnDefined();
   p->Props.at(0)->Value = Props.at(0)->Value;
   p->Props.at(1)->Value = Props.at(1)->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 
@@ -70,7 +70,7 @@ Element* EqnDefined::info(QString& Name, char* &BitmapFile, bool getNewOne)
     EqnDefined* p = new EqnDefined();
     p->Props.at(0)->Value = "explicit";
     p->Props.at(1)->Value = "1";
-    p->recreate(0);
+    p->recreate();
     return p;
   }
   return 0;

--- a/qucs/components/etr_sim.h
+++ b/qucs/components/etr_sim.h
@@ -27,7 +27,6 @@ public:
   ~ETR_Sim();
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
-//  void recreate(Schematic*);
 };
 
 #endif

--- a/qucs/components/fa1b.cpp
+++ b/qucs/components/fa1b.cpp
@@ -41,7 +41,7 @@ Component * fa1b::newOne()
 {
   fa1b * p = new fa1b();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/fa2b.cpp
+++ b/qucs/components/fa2b.cpp
@@ -42,7 +42,7 @@ Component * fa2b::newOne()
 {
   fa2b * p = new fa2b();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/gatedDlatch.cpp
+++ b/qucs/components/gatedDlatch.cpp
@@ -43,7 +43,7 @@ Component * gatedDlatch::newOne()
 {
   gatedDlatch * p = new gatedDlatch();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/greytobinary4bit.cpp
+++ b/qucs/components/greytobinary4bit.cpp
@@ -42,7 +42,7 @@ Component * greytobinary4bit::newOne()
 {
   greytobinary4bit * p = new greytobinary4bit();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/ha1b.cpp
+++ b/qucs/components/ha1b.cpp
@@ -41,7 +41,7 @@ Component * ha1b::newOne()
 {
   ha1b * p = new ha1b();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/hic2_full.cpp
+++ b/qucs/components/hic2_full.cpp
@@ -315,7 +315,7 @@ Component * hic2_full::newOne()
 {
   hic2_full * p = new hic2_full();
   p->Props.getFirst()->Value = Props.getFirst()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/hpribin4bit.cpp
+++ b/qucs/components/hpribin4bit.cpp
@@ -41,7 +41,7 @@ Component * hpribin4bit::newOne()
 {
   hpribin4bit * p = new hpribin4bit();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/jfet.cpp
+++ b/qucs/components/jfet.cpp
@@ -90,7 +90,7 @@ Component* JFET::newOne()
 {
   JFET* p = new JFET();
   p->Props.front()->Value = Props.front()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 
@@ -163,7 +163,7 @@ Element* JFET::info_p(QString& Name, char* &BitmapFile, bool getNewOne)
   if(getNewOne) {
     JFET* p = new JFET();
     p->Props.front()->Value = "pfet";
-    p->recreate(0);
+    p->recreate();
     return p;
   }
   return 0;

--- a/qucs/components/jkff_SR.cpp
+++ b/qucs/components/jkff_SR.cpp
@@ -45,7 +45,7 @@ Component * jkff_SR::newOne()
 {
   jkff_SR * p = new jkff_SR();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/libcomp.cpp
+++ b/qucs/components/libcomp.cpp
@@ -51,7 +51,7 @@ Component* LibComp::newOne()
   LibComp *p = new LibComp();
   p->Props.at(0)->Value = Props.at(0)->Value;
   p->Props.at(1)->Value = Props.at(1)->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/log_amp.cpp
+++ b/qucs/components/log_amp.cpp
@@ -76,7 +76,7 @@ Component * log_amp::newOne()
 {
   log_amp * p = new log_amp();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/logic_0.cpp
+++ b/qucs/components/logic_0.cpp
@@ -39,7 +39,7 @@ Component * logic_0::newOne()
 {
   logic_0 * p = new logic_0();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/logic_1.cpp
+++ b/qucs/components/logic_1.cpp
@@ -38,7 +38,7 @@ Component * logic_1::newOne()
 {
   logic_1 * p = new logic_1();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 
 }

--- a/qucs/components/logical_and.cpp
+++ b/qucs/components/logical_and.cpp
@@ -37,7 +37,7 @@ Component* Logical_AND::newOne()
   Logical_AND* p = new Logical_AND();
   p->Props.front()->Value = Props.front()->Value;
   p->Props.back()->Value = Props.back()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/logical_buf.cpp
+++ b/qucs/components/logical_buf.cpp
@@ -121,7 +121,7 @@ Component* Logical_Buf::newOne()
 {
   Logical_Buf* p = new Logical_Buf();
   p->Props.back()->Value = Props.back()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/logical_inv.cpp
+++ b/qucs/components/logical_inv.cpp
@@ -138,7 +138,7 @@ Component* Logical_Inv::newOne()
 {
   Logical_Inv* p = new Logical_Inv();
   p->Props.back()->Value = Props.back()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/logical_nand.cpp
+++ b/qucs/components/logical_nand.cpp
@@ -37,7 +37,7 @@ Component* Logical_NAND::newOne()
   Logical_NAND* p = new Logical_NAND();
   p->Props.front()->Value = Props.front()->Value;
   p->Props.back()->Value = Props.back()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/logical_nor.cpp
+++ b/qucs/components/logical_nor.cpp
@@ -37,7 +37,7 @@ Component* Logical_NOR::newOne()
   Logical_NOR* p = new Logical_NOR();
   p->Props.front()->Value = Props.front()->Value;
   p->Props.back()->Value = Props.back()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/logical_or.cpp
+++ b/qucs/components/logical_or.cpp
@@ -37,7 +37,7 @@ Component* Logical_OR::newOne()
   Logical_OR* p = new Logical_OR();
   p->Props.front()->Value = Props.front()->Value;
   p->Props.back()->Value = Props.back()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/logical_xnor.cpp
+++ b/qucs/components/logical_xnor.cpp
@@ -37,7 +37,7 @@ Component* Logical_XNOR::newOne()
   Logical_XNOR* p = new Logical_XNOR();
   p->Props.front()->Value = Props.front()->Value;
   p->Props.back()->Value = Props.back()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/logical_xor.cpp
+++ b/qucs/components/logical_xor.cpp
@@ -37,7 +37,7 @@ Component* Logical_XOR::newOne()
   Logical_XOR* p = new Logical_XOR();
   p->Props.front()->Value = Props.front()->Value;
   p->Props.back()->Value = Props.back()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/mod_amp.cpp
+++ b/qucs/components/mod_amp.cpp
@@ -61,7 +61,7 @@ Component * mod_amp::newOne()
 {
   mod_amp * p = new mod_amp();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/mosfet.cpp
+++ b/qucs/components/mosfet.cpp
@@ -40,7 +40,7 @@ Component* MOSFET::newOne()
   MOSFET* p = new MOSFET();
   p->Props.at(0)->Value = Props.at(0)->Value;
   p->Props.at(1)->Value = Props.at(1)->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 
@@ -64,7 +64,7 @@ Element* MOSFET::info_p(QString& Name, char* &BitmapFile, bool getNewOne)
     MOSFET* p = new MOSFET();
     p->Props.at(0)->Value = "pfet";
     p->Props.at(1)->Value = "-1.0 V";
-    p->recreate(0);
+    p->recreate();
     return p;
   }
   return 0;
@@ -79,7 +79,7 @@ Element* MOSFET::info_depl(QString& Name, char* &BitmapFile, bool getNewOne)
   if(getNewOne) {
     MOSFET* p = new MOSFET();
     p->Props.at(1)->Value = "-1.0 V";
-    p->recreate(0);
+    p->recreate();
     return p;
   }
   return 0;

--- a/qucs/components/mosfet_sub.cpp
+++ b/qucs/components/mosfet_sub.cpp
@@ -146,7 +146,7 @@ Component* MOSFET_sub::newOne()
   MOSFET_sub* p = new MOSFET_sub();
   p->Props.at(0)->Value = Props.at(0)->Value;
   p->Props.at(1)->Value = Props.at(1)->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 
@@ -243,7 +243,7 @@ Element* MOSFET_sub::info_p(QString& Name,
     MOSFET_sub* p = new MOSFET_sub();
     p->Props.at(0)->Value = "pfet";
     p->Props.at(1)->Value = "-1.0 V";
-    p->recreate(0);
+    p->recreate();
     return p;
   }
   return 0;
@@ -259,7 +259,7 @@ Element* MOSFET_sub::info_depl(QString& Name,
   if(getNewOne) {
     MOSFET_sub* p = new MOSFET_sub();
     p->Props.at(1)->Value = "-1.0 V";
-    p->recreate(0);
+    p->recreate();
     return p;
   }
   return 0;

--- a/qucs/components/mutualx.cpp
+++ b/qucs/components/mutualx.cpp
@@ -61,7 +61,7 @@ Element* MutualX::info(QString& Name, char* &BitmapFile, bool getNewOne)
   if(getNewOne) {
       MutualX* p =  new MutualX();
       p->Props.at(0)->Value = "2";
-      p->recreate(0);
+      p->recreate();
       return p;
   }
   return 0;
@@ -71,7 +71,7 @@ Component* MutualX::newOne()
 {
     MutualX *p  = new MutualX();
     p->Props.at(0)->Value=Props.at(0)->Value;
-    p->recreate(0);
+    p->recreate();
     return p;
 }
 

--- a/qucs/components/mux2to1.cpp
+++ b/qucs/components/mux2to1.cpp
@@ -41,7 +41,7 @@ Component * mux2to1::newOne()
 {
   mux2to1 * p = new mux2to1();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/mux4to1.cpp
+++ b/qucs/components/mux4to1.cpp
@@ -41,7 +41,7 @@ Component * mux4to1::newOne()
 {
   mux4to1 * p = new mux4to1();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/mux8to1.cpp
+++ b/qucs/components/mux8to1.cpp
@@ -42,7 +42,7 @@ Component * mux8to1::newOne()
 {
   mux8to1 * p = new mux8to1();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/nigbt.cpp
+++ b/qucs/components/nigbt.cpp
@@ -82,7 +82,7 @@ Component * nigbt::newOne()
 {
   nigbt * p = new nigbt();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/pad2bit.cpp
+++ b/qucs/components/pad2bit.cpp
@@ -30,7 +30,7 @@ Component * pad2bit::newOne()
 {
   pad2bit * p = new pad2bit();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/pad3bit.cpp
+++ b/qucs/components/pad3bit.cpp
@@ -30,7 +30,7 @@ Component * pad3bit::newOne()
 {
   pad3bit * p = new pad3bit();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/pad4bit.cpp
+++ b/qucs/components/pad4bit.cpp
@@ -30,7 +30,7 @@ Component * pad4bit::newOne()
 {
   pad4bit * p = new pad4bit();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/param_sweep.cpp
+++ b/qucs/components/param_sweep.cpp
@@ -62,7 +62,7 @@ Element* Param_Sweep::info(QString& Name, char* &BitmapFile, bool getNewOne)
   return 0;
 }
 
-void Param_Sweep::recreate(Schematic*)
+void Param_Sweep::recreate()
 {
   if((Props.at(1)->Value == "list") || (Props.at(1)->Value == "const")) {
     // Call them "Symbol" to omit them in the netlist.

--- a/qucs/components/param_sweep.h
+++ b/qucs/components/param_sweep.h
@@ -27,7 +27,7 @@ public:
   ~Param_Sweep();
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
-  void recreate(Schematic*);
+  void recreate();
 
   QString getNgspiceBeforeSim(QString sim, int lvl=0);
   QString getNgspiceAfterSim(QString sim, int lvl=0);

--- a/qucs/components/photodiode.cpp
+++ b/qucs/components/photodiode.cpp
@@ -87,7 +87,7 @@ Component * photodiode::newOne()
 {
   photodiode * p = new photodiode();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/phototransistor.cpp
+++ b/qucs/components/phototransistor.cpp
@@ -103,7 +103,7 @@ Component * phototransistor::newOne()
 {
   phototransistor * p = new phototransistor();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/potentiometer.cpp
+++ b/qucs/components/potentiometer.cpp
@@ -60,7 +60,7 @@ Component * potentiometer::newOne()
 {
   potentiometer * p = new potentiometer();
   p->Props.front()->Value = Props.front()->Value;
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/rfedd.cpp
+++ b/qucs/components/rfedd.cpp
@@ -57,7 +57,7 @@ Component* RFedd::newOne()
   RFedd* p = new RFedd();
   p->Props.at(0)->Value = Props.at(0)->Value;
   p->Props.at(1)->Value = Props.at(1)->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 
@@ -71,7 +71,7 @@ Element* RFedd::info(QString& Name, char* &BitmapFile, bool getNewOne)
     RFedd* p = new RFedd();
     p->Props.at(0)->Value = "Y";
     p->Props.at(1)->Value = "2";
-    p->recreate(0);
+    p->recreate();
     return p;
   }
   return 0;

--- a/qucs/components/rfedd2p.cpp
+++ b/qucs/components/rfedd2p.cpp
@@ -56,7 +56,7 @@ Component* RFedd2P::newOne()
 {
   RFedd2P* p = new RFedd2P();
   p->Props.at(0)->Value = Props.at(0)->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 
@@ -69,7 +69,7 @@ Element* RFedd2P::info(QString& Name, char* &BitmapFile, bool getNewOne)
   if(getNewOne) {
     RFedd2P* p = new RFedd2P();
     p->Props.at(0)->Value = "Y";
-    p->recreate(0);
+    p->recreate();
     return p;
   }
   return 0;

--- a/qucs/components/sp_sim.cpp
+++ b/qucs/components/sp_sim.cpp
@@ -71,7 +71,7 @@ Element* SP_Sim::info(QString& Name, char* &BitmapFile, bool getNewOne)
   return 0;
 }
 
-void SP_Sim::recreate(Schematic*)
+void SP_Sim::recreate()
 {
   if((Props.at(0)->Value == "list") || (Props.at(0)->Value == "const")) {
     // Call them "Symbol" to omit them in the netlist.

--- a/qucs/components/sp_sim.h
+++ b/qucs/components/sp_sim.h
@@ -35,7 +35,7 @@ public:
   ~SP_Sim();
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
-  void recreate(Schematic*);
+  void recreate();
   QString spice_netlist(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
   QStringList getExtraVariables();
 };

--- a/qucs/components/sparamfile.cpp
+++ b/qucs/components/sparamfile.cpp
@@ -54,7 +54,7 @@ Component* SParamFile::newOne()
 {
   SParamFile* p = new SParamFile();
   p->Props.back()->Value = Props.back()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 
@@ -68,7 +68,7 @@ Element* SParamFile::info(QString& Name, char* &BitmapFile, bool getNewOne)
     SParamFile* p = new SParamFile();
     p->Props.front()->Value = "test.s3p";
     p->Props.back()->Value = "3";
-    p->recreate(0);
+    p->recreate();
     return p;
   }
   return 0;
@@ -94,7 +94,7 @@ Element* SParamFile::info2(QString& Name, char* &BitmapFile, bool getNewOne)
     SParamFile* p = new SParamFile();
     p->Props.front()->Value = "test.s2p";
     p->Props.back()->Value = "2";
-    p->recreate(0);
+    p->recreate();
     return p;
   }
   return 0;

--- a/qucs/components/spicefile.cpp
+++ b/qucs/components/spicefile.cpp
@@ -63,7 +63,7 @@ SpiceFile::SpiceFile()
 Component* SpiceFile::newOne()
 {
   SpiceFile *p = new SpiceFile();
-  p->recreate(0);   // createSymbol() is NOT called in constructor !!!
+  p->recreate();   // createSymbol() is NOT called in constructor !!!
   return p;
 }
 
@@ -75,7 +75,7 @@ Element* SpiceFile::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
   if(getNewOne) {
     SpiceFile *p = new SpiceFile();
-    p->recreate(0);   // createSymbol() is NOT called in constructor !!!
+    p->recreate();   // createSymbol() is NOT called in constructor !!!
     return p;
   }
   return 0;

--- a/qucs/components/subcircuit.cpp
+++ b/qucs/components/subcircuit.cpp
@@ -44,7 +44,7 @@ Subcircuit::Subcircuit() {
 Component *Subcircuit::newOne() {
   Subcircuit *p = new Subcircuit();
   p->Props.front()->Value = Props.front()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 
@@ -55,7 +55,7 @@ Element *Subcircuit::info(QString &Name, char *&BitmapFile, bool getNewOne) {
 
   if (getNewOne) {
     Subcircuit *p = new Subcircuit();
-    p->recreate(0); // createSymbol() is NOT called in constructor !!!
+    p->recreate(); // createSymbol() is NOT called in constructor !!!
     return p;
   }
   return 0;

--- a/qucs/components/switch.cpp
+++ b/qucs/components/switch.cpp
@@ -52,7 +52,7 @@ Component* Switch::newOne()
 {
   Switch *p = new Switch();
   p->Props.front()->Value = Props.front()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/tff_SR.cpp
+++ b/qucs/components/tff_SR.cpp
@@ -45,7 +45,7 @@ Component * tff_SR::newOne()
 {
   tff_SR * p = new tff_SR();
   p->Props.front()->Value = Props.front()->Value; 
-  p->recreate(0); 
+  p->recreate();
   return p;
 }
 

--- a/qucs/components/tr_sim.cpp
+++ b/qucs/components/tr_sim.cpp
@@ -117,7 +117,7 @@ QString TR_Sim::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
     return s.toLower();
 }
 
-void TR_Sim::recreate(Schematic*)
+void TR_Sim::recreate()
 {
   if((Props.at(0)->Value == "list") || (Props.at(0)->Value == "const")) {
     // Call them "Symbol" to omit them in the netlist.

--- a/qucs/components/tr_sim.h
+++ b/qucs/components/tr_sim.h
@@ -28,7 +28,7 @@ public:
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
   QString spice_netlist(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
-  void recreate(Schematic*);
+  void recreate();
 };
 
 #endif

--- a/qucs/components/vacomponent.cpp
+++ b/qucs/components/vacomponent.cpp
@@ -108,7 +108,7 @@ Component *vacomponent::newOne(QString filename)
   vacomponent * p = new vacomponent(filename);
   if (Props.count())
       p->Props.front()->Value = Props.front()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 
 }

--- a/qucs/components/verilogfile.cpp
+++ b/qucs/components/verilogfile.cpp
@@ -45,7 +45,7 @@ Component* Verilog_File::newOne()
 {
   Verilog_File *p = new Verilog_File();
   p->Props.front()->Value = Props.front()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 
@@ -57,7 +57,7 @@ Element* Verilog_File::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
   if(getNewOne) {
     Verilog_File *p = new Verilog_File();
-    p->recreate(0);   // createSymbol() is NOT called in constructor !!!
+    p->recreate();   // createSymbol() is NOT called in constructor !!!
     return p;
   }
   return 0;

--- a/qucs/components/vhdlfile.cpp
+++ b/qucs/components/vhdlfile.cpp
@@ -44,7 +44,7 @@ Component* VHDL_File::newOne()
 {
   VHDL_File *p = new VHDL_File();
   p->Props.front()->Value = Props.front()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 
@@ -56,7 +56,7 @@ Element* VHDL_File::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
   if(getNewOne) {
     VHDL_File *p = new VHDL_File();
-    p->recreate(0);   // createSymbol() is NOT called in constructor !!!
+    p->recreate();   // createSymbol() is NOT called in constructor !!!
     return p;
   }
   return 0;

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -2922,7 +2922,7 @@ void QucsApp::slotSelectSubcircuit(const QModelIndex &idx)
   else
     Comp = new Subcircuit();
   Comp->Props.first()->Value = idx.sibling(idx.row(), 0).data().toString();
-  Comp->recreate(0);
+  Comp->recreate();
   view->selElem = Comp;
 
   MouseMoveAction = &MouseActions::MMoveElement;

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -25,6 +25,7 @@
 
 #include <ranges>
 #include <set>
+#include <stack>
 
 struct Schematic::HealingParams
 {
@@ -1816,70 +1817,52 @@ void Schematic::insertRawComponent(Component *c, bool noOptimize)
     }
 }
 
-// ---------------------------------------------------
-void Schematic::recreateComponent(Component *Comp)
+void Schematic::recreateComponent(Component* comp)
 {
-
-    WireLabel **plMem=0, **pl;
-    int PortCount = Comp->Ports.count();
-
-    if(PortCount > 0)
-    {
-        // Save the labels whose node is not connected to somewhere else.
-        // Otherwise the label would be deleted.
-        pl = plMem = (WireLabel**)malloc(PortCount * sizeof(WireLabel*));
-        for (Port *pp : Comp->Ports)
-            if(pp->Connection->conn_count() < 2)
-            {
-                *(pl++) = pp->Connection->Label;
-                pp->Connection->Label = 0;
-            }
-            else  *(pl++) = 0;
+    std::stack<WireLabel*> saved_labels{};
+    for (auto* port : comp->Ports) {
+        if (port->Connection->Label != nullptr && port->Connection->conn_count() == 1) {
+            saved_labels.push(port->Connection->Label);
+            port->Connection->Label = nullptr;
+        }
     }
+
+    int tx = comp->tx;
+    int ty = comp->ty;
+    int x1 = comp->x1;
+    int x2 = comp->x2;
+    int y1 = comp->y1;
+    int y2 = comp->y2;
+    QString name = comp->Name;  // is sometimes changed by "recreate"
 
     detachComp(comp);
     comp->recreate();  // to apply changes to the schematic symbol
     insertRawComponent(comp);
 
+    comp->Name = name;
 
-    int x = Comp->tx, y = Comp->ty;
-    int x1 = Comp->x1, x2 = Comp->x2, y1 = Comp->y1, y2 = Comp->y2;
-    QString tmp = Comp->Name;    // is sometimes changed by "recreate"
-    Comp->recreate(this);   // to apply changes to the schematic symbol
-    Comp->Name = tmp;
-    if(x < x1)
-        x += Comp->x1 - x1;
-    else if(x > x2)
-        x += Comp->x2 - x2;
-    if(y < y1)
-        y += Comp->y1 - y1;
-    else if(y > y2)
-        y += Comp->y2 - y2;
-    Comp->tx = x;
-    Comp->ty = y;
+    // This is wrong place to adjust component's text position.
+    // It should be better done in "recreate()" (idea for refactoring)
+         if (tx < x1) tx += comp->x1 - x1;
+    else if (tx > x2) tx += comp->x2 - x2;
 
+         if (ty < y1) ty += comp->y1 - y1;
+    else if (ty > y2) ty += comp->y2 - y2;
 
-    if(PortCount > 0)
-    {
-        // restore node labels
-        pl = plMem;
-        for (Port *pp : Comp->Ports)
-        {
-            if(*pl != 0)
-            {
-                (*pl)->cx = pp->Connection->cx;
-                (*pl)->cy = pp->Connection->cy;
-                placeNodeLabel(*pl);
-            }
-            pl++;
-            if((--PortCount) < 1)  break;
-        }
-        for( ; PortCount > 0; PortCount--)
-        {
-            delete (*pl);  // delete not needed labels
-            pl++;
-        }
-        free(plMem);
+    comp->tx = tx;
+    comp->ty = ty;
+
+    for (auto pIt = comp->Ports.begin(); pIt != comp->Ports.end() && !saved_labels.empty(); pIt++) {
+        auto* wl = saved_labels.top();
+        saved_labels.pop();
+        auto* port = *pIt;
+        wl->cx = port->Connection->cx;
+        wl->cy = port->Connection->cy;
+        placeNodeLabel(wl);
+    }
+    while (!saved_labels.empty()) {
+        delete saved_labels.top();
+        saved_labels.pop();
     }
 }
 

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -1837,6 +1837,10 @@ void Schematic::recreateComponent(Component *Comp)
             else  *(pl++) = 0;
     }
 
+    detachComp(comp);
+    comp->recreate();  // to apply changes to the schematic symbol
+    insertRawComponent(comp);
+
 
     int x = Comp->tx, y = Comp->ty;
     int x1 = Comp->x1, x2 = Comp->x2, y1 = Comp->y1, y2 = Comp->y2;

--- a/qucs/spicecomponents/BJT_SPICE.cpp
+++ b/qucs/spicecomponents/BJT_SPICE.cpp
@@ -107,7 +107,7 @@ Component* BJT_SPICE::newOne()
     p->getProperty("Pins")->Value = getProperty("Pins")->Value;
     p->getProperty("Letter")->Value = getProperty("Letter")->Value;
     p->getProperty("type")->Value = getProperty("type")->Value;
-    p->recreate(0);
+    p->recreate();
     return p;
 }
 
@@ -129,7 +129,7 @@ Element* BJT_SPICE::infoNPN4(QString& Name, char* &BitmapFile, bool getNewOne)
       auto p = new BJT_SPICE();
       p->Props.at(0)->Value = "4";
       p->Props.at(1)->Value = "npn";
-      p->recreate(0);
+      p->recreate();
       return p;
   }
   return 0;
@@ -144,7 +144,7 @@ Element* BJT_SPICE::infoPNP4(QString& Name, char* &BitmapFile, bool getNewOne)
       auto p = new BJT_SPICE();
       p->Props.at(0)->Value = "4";
       p->Props.at(1)->Value = "pnp";
-      p->recreate(0);
+      p->recreate();
       return p;
   }
   return 0;
@@ -160,7 +160,7 @@ Element* BJT_SPICE::infoNPN5(QString& Name, char* &BitmapFile, bool getNewOne)
       auto p = new BJT_SPICE();
       p->Props.at(0)->Value = "5";
       p->Props.at(1)->Value = "npn";
-      p->recreate(0);
+      p->recreate();
       return p;
   }
   return 0;
@@ -175,7 +175,7 @@ Element* BJT_SPICE::infoPNP5(QString& Name, char* &BitmapFile, bool getNewOne)
       auto p = new BJT_SPICE();
       p->Props.at(0)->Value = "5";
       p->Props.at(1)->Value = "pnp";
-      p->recreate(0);
+      p->recreate();
       return p;
   }
   return 0;

--- a/qucs/spicecomponents/C_SPICE.cpp
+++ b/qucs/spicecomponents/C_SPICE.cpp
@@ -77,7 +77,7 @@ Component* C_SPICE::newOne()
     auto p = new C_SPICE();
     p->getProperty("Pins")->Value = getProperty("Pins")->Value;
     p->getProperty("Letter")->Value = getProperty("Letter")->Value;
-    p->recreate(0);
+    p->recreate();
     return p;
 }
 
@@ -98,7 +98,7 @@ Element* C_SPICE::info_C3(QString& Name, char* &BitmapFile, bool getNewOne)
   if(getNewOne)  {
       auto p = new C_SPICE();
       p->Props.at(5)->Value = "3";
-      p->recreate(0);
+      p->recreate();
       return p;
   }
   return 0;

--- a/qucs/spicecomponents/DIODE_SPICE.cpp
+++ b/qucs/spicecomponents/DIODE_SPICE.cpp
@@ -82,7 +82,7 @@ Component* DIODE_SPICE::newOne()
     auto p = new DIODE_SPICE();
     p->getProperty("Pins")->Value = getProperty("Pins")->Value;
     p->getProperty("Letter")->Value = getProperty("Letter")->Value;
-    p->recreate(0);
+    p->recreate();
     return p;
 }
 
@@ -103,7 +103,7 @@ Element* DIODE_SPICE::info_DIODE3(QString& Name, char* &BitmapFile, bool getNewO
   if(getNewOne)  {
       auto p = new DIODE_SPICE();
       p->Props.at(5)->Value = "3";
-      p->recreate(0);
+      p->recreate();
       return p;
   }
   return 0;

--- a/qucs/spicecomponents/MOS_SPICE.cpp
+++ b/qucs/spicecomponents/MOS_SPICE.cpp
@@ -60,7 +60,7 @@ Component* MOS_SPICE::newOne()
     p->getProperty("Pins")->Value = getProperty("Pins")->Value;
     p->getProperty("Letter")->Value = getProperty("Letter")->Value;
     p->getProperty("type")->Value = getProperty("type")->Value;
-    p->recreate(0);
+    p->recreate();
     return p;
 }
 
@@ -83,7 +83,7 @@ Element* MOS_SPICE::info_NM3pin(QString& Name, char* &BitmapFile, bool getNewOne
       p->Props.at(0)->Value = "M";
       p->Props.at(1)->Value = "3";
       p->Props.at(2)->Value = "nmos";
-      p->recreate(0);
+      p->recreate();
       return p;
   }
   return 0;
@@ -99,7 +99,7 @@ Element* MOS_SPICE::info_PM3pin(QString& Name, char* &BitmapFile, bool getNewOne
       p->Props.at(0)->Value = "M";
       p->Props.at(1)->Value = "3";
       p->Props.at(2)->Value = "pmos";
-      p->recreate(0);
+      p->recreate();
       return p;
   }
   return 0;
@@ -116,7 +116,7 @@ Element* MOS_SPICE::info_NX3pin(QString& Name, char* &BitmapFile, bool getNewOne
       p->Props.at(0)->Value = "X";
       p->Props.at(1)->Value = "3";
       p->Props.at(2)->Value = "nmos";
-      p->recreate(0);
+      p->recreate();
       return p;
   }
   return 0;
@@ -133,7 +133,7 @@ Element* MOS_SPICE::info_PX3pin(QString& Name, char* &BitmapFile, bool getNewOne
       p->Props.at(0)->Value = "X";
       p->Props.at(1)->Value = "3";
       p->Props.at(2)->Value = "pmos";
-      p->recreate(0);
+      p->recreate();
       return p;
   }
   return 0;
@@ -150,7 +150,7 @@ Element* MOS_SPICE::info_NX4pin(QString& Name, char* &BitmapFile, bool getNewOne
       p->Props.at(0)->Value = "X";
       p->Props.at(1)->Value = "4";
       p->Props.at(2)->Value = "nmos";
-      p->recreate(0);
+      p->recreate();
       return p;
   }
   return 0;
@@ -167,7 +167,7 @@ Element* MOS_SPICE::info_PX4pin(QString& Name, char* &BitmapFile, bool getNewOne
       p->Props.at(0)->Value = "X";
       p->Props.at(1)->Value = "4";
       p->Props.at(2)->Value = "pmos";
-      p->recreate(0);
+      p->recreate();
       return p;
   }
   return 0;

--- a/qucs/spicecomponents/R_SPICE.cpp
+++ b/qucs/spicecomponents/R_SPICE.cpp
@@ -81,7 +81,7 @@ Component* R_SPICE::newOne()
     auto p = new R_SPICE();
     p->getProperty("Pins")->Value = getProperty("Pins")->Value;
     p->getProperty("Letter")->Value = getProperty("Letter")->Value;
-    p->recreate(0);
+    p->recreate();
     return p;
 }
 
@@ -102,7 +102,7 @@ Element* R_SPICE::info_R3(QString& Name, char* &BitmapFile, bool getNewOne)
   if(getNewOne)  {
       auto p = new R_SPICE();
       p->Props.at(5)->Value = "3";
-      p->recreate(0);
+      p->recreate();
       return p;
   }
   return 0;

--- a/qucs/spicecomponents/spicegeneric.cpp
+++ b/qucs/spicecomponents/spicegeneric.cpp
@@ -48,7 +48,7 @@ SpiceGeneric::SpiceGeneric()
 Component* SpiceGeneric::newOne()
 {
   SpiceGeneric *p = new SpiceGeneric();
-  p->recreate(0);   // createSymbol() is NOT called in constructor !!!
+  p->recreate();   // createSymbol() is NOT called in constructor !!!
   return p;
 }
 
@@ -60,7 +60,7 @@ Element* SpiceGeneric::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
   if(getNewOne) {
     SpiceGeneric *p = new SpiceGeneric();
-    p->recreate(0);   // createSymbol() is NOT called in constructor !!!
+    p->recreate();   // createSymbol() is NOT called in constructor !!!
     return p;
   }
   return 0;

--- a/qucs/spicecomponents/spicelibcomp.cpp
+++ b/qucs/spicecomponents/spicelibcomp.cpp
@@ -60,7 +60,7 @@ Component* SpiceLibComp::newOne()
 {
   SpiceLibComp *p = new SpiceLibComp();
   p->Props.front()->Value = Props.front()->Value;
-  p->recreate(0);
+  p->recreate();
   return p;
 }
 
@@ -72,7 +72,7 @@ Element* SpiceLibComp::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
   if(getNewOne) {
     SpiceLibComp *p = new SpiceLibComp();
-    p->recreate(0);   // createSymbol() is NOT called in constructor !!!
+    p->recreate();   // createSymbol() is NOT called in constructor !!!
     return p;
   }
   return 0;

--- a/qucs/spicecomponents/xspicegeneric.cpp
+++ b/qucs/spicecomponents/xspicegeneric.cpp
@@ -47,7 +47,7 @@ XspiceGeneric::XspiceGeneric()
 Component* XspiceGeneric::newOne()
 {
   XspiceGeneric *p = new XspiceGeneric();
-  p->recreate(0);   // createSymbol() is NOT called in constructor !!!
+  p->recreate();   // createSymbol() is NOT called in constructor !!!
   return p;
 }
 
@@ -59,7 +59,7 @@ Element* XspiceGeneric::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
   if(getNewOne) {
     XspiceGeneric *p = new XspiceGeneric();
-    p->recreate(0);   // createSymbol() is NOT called in constructor !!!
+    p->recreate();   // createSymbol() is NOT called in constructor !!!
     return p;
   }
   return 0;


### PR DESCRIPTION
Hi!

Among dozens of calls to Component::recreate() only one (!) was actually passing non-nullptr as argument i.e. recreate() had logic required only by a single specific call, which was made from Schematic::recreateComponent(). Naturally, the best option was to to move that logic out from recreate() to recreateComponent() and turn Component::recreate() into a nice zero argument function.

Also, refactor recreateComponent() to get rid of calls to malloc() and free().