### PR TITLE
Make future wire more thicker when laying a new wire

### DIFF
--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -584,9 +584,15 @@ void Schematic::drawPostPaintEvents(QPainter* painter) {
             painter->fillRect(p.x1, p.y1, p.x2, p.y2, QColor(200, 220, 240, 100));
             painter->drawRect(p.x1, p.y1, p.x2, p.y2);
             break;
-        case _Line:
+        case _Line: {
+            painter->save();
+            QPen lp{painter->pen()};
+            lp.setWidth(p.a == 0 ? 1 : p.a);
+            painter->setPen(lp);
             painter->drawLine(p.x1, p.y1, p.x2, p.y2);
+            painter->restore();
             break;
+        }
         case _Ellipse:
             painter->drawEllipse(p.x1, p.y1, p.x2, p.y2);
             break;

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -3213,7 +3213,7 @@ void Schematic::showEphemeralWire(const QPoint& a, const QPoint& b) noexcept {
     for (std::size_t i = 1; i < points.size(); i++) {
         auto m = points[i-1];
         auto n = points[i];
-	PostPaintEvent(_Line, m.x(), m.y(), n.x(), n.y());
+        PostPaintEvent(_Line, m.x(), m.y(), n.x(), n.y(), 3);
     }
 
 }


### PR DESCRIPTION
Hi!

In #1232 I made ephemeral wires (i.e. "planned" or "future" wires) too thin, they are not visible behind the aim cross. This PR fixes it making future thicker and distinctly visible. Video explains it better

https://github.com/user-attachments/assets/931a5102-894a-4e02-9881-555d29f4fdfd

