### PR TITLE
Fix Xyce IC for Tline

### DIFF
--- a/qucs/spicecomponents/LTL_SPICE.cpp
+++ b/qucs/spicecomponents/LTL_SPICE.cpp
@@ -121,7 +121,11 @@ QString LTL_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
         s += QStringLiteral(" NL=%1").arg(Nl);
     }
 
-    s += QStringLiteral(" IC=%5, %6, %7, %8 \n").arg(V1).arg(I1).arg(V2).arg(I2);
+    if (dialect == spicecompat::SPICEXyce) {
+      s += "\n"; // Xyce doesn't support IC
+    } else {
+      s += QStringLiteral(" IC=%5, %6, %7, %8 \n").arg(V1).arg(I1).arg(V2).arg(I2);
+    }
 
     return s;
 }


### PR DESCRIPTION
This PR fixes #1274 and makes simulation of TLine with Xyce possible. Define unused parameters as empty strings. 

![image](https://github.com/user-attachments/assets/8f61d5aa-5a17-4696-a36c-9ae92c8fffd0)
