### PR TITLE
Fix crash when coordinates of wire ends are in wrong order

### DIFF
--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -983,7 +983,26 @@ bool Schematic::loadWires(QTextStream *stream, QList<Element*> *List)
       List->append(w);
       if(w->Label)  List->append(w->Label);
     }
-    else simpleInsertWire(w);
+    else {
+      // Quick fix for ra3xdh#1273.
+      //
+      // A wire whose (x1,y1) coordinates are not less than (x2,y2)
+      // coordinates somehow deals some damage like crashes or funny behaviour.
+      //
+      // I wasn't able to understand how exactly this happens, i.e. why it's
+      // important to have x1 less than x2 for a wire, so I decided to fix this
+      // in a most straightforward way by "normalizing" the wire before installing
+      // it into schematic
+      if (w->x1 > w->x2) {
+        std::swap(w->x1, w->x2);
+        std::swap(w->y1, w->y2);
+      } else if (w->x1 == w->x2 && w->y1 > w->y2) {
+        std::swap(w->x1, w->x2);
+        std::swap(w->y1, w->y2);
+      }
+
+      simpleInsertWire(w);
+    }
   }
 
   QMessageBox::critical(0, QObject::tr("Error"),


### PR DESCRIPTION
A wire loaded from a file so that its x1 coordinate is larger than x2 coordinate causes crash. Somehow it's crucial that x1 is less than x2. How is exactly it's crucial is not so easy to grasp so it's easier just to go with it.

This commit fixes crashes by adding "normalization" of coordinates just before installing the loaded wire into schematic.

Fix ra3xdh#1273