### PR TITLE
update qt6.9.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ env:
   EXECUTABLE_NAME: "qucs-s"
   PUBLISHER_NAME: "The Qucs-S Team"
   BUILD_TYPE: Release
-  QT_VERSION: 6.8.2
+  QT_VERSION: 6.9.0
   QUCS_MACOS_BIN: ${{github.workspace}}/build/qucs/qucs-s.app/Contents/MacOS/bin
   QUCS_MACOS_RESOURCES: ${{github.workspace}}/build/qucs/qucs-s.app/Contents/MacOS/share/qucs-s
   NGSPICE_URL: https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/44.2/ngspice-44.2_64.7z
@@ -98,7 +98,6 @@ jobs:
           cmake -B ${{github.workspace}}/build -G 'Ninja' \
                 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
                 -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/AppDir/usr \
-                -DWITH_QT6=ON \
                 -DCI_VERSION="${{env.VERSION}}"
 
     - name: 'Build'
@@ -182,7 +181,7 @@ jobs:
     - name: 'Configure CMake'
       run: |
         cmake -B ${{github.workspace}}/build  -G 'Ninja' \
-              -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DWITH_QT6=1 \
+              -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
               -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 \
               -DCMAKE_OSX_ARCHITECTURES="x86_64" \
               -DCI_VERSION="${{env.VERSION}}"
@@ -278,7 +277,7 @@ jobs:
     - name: 'Configure CMake'
       run: |
         cmake -B ${{github.workspace}}/build  -G 'Ninja' \
-              -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DWITH_QT6=1 \
+              -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
               -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
               -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
               -DCI_VERSION="${{env.VERSION}}"
@@ -373,7 +372,7 @@ jobs:
       
     - name: 'Configure CMake'
       run: |
-        cmake -B ${{github.workspace}}\build -G 'Ninja' -DWITH_QT6=1  `
+        cmake -B ${{github.workspace}}\build -G 'Ninja'  `
               -DCMAKE_INSTALL_PREFIX=${{github.workspace}}\build\qucs-suite  `
               -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl  `
               -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}   `
@@ -484,7 +483,6 @@ jobs:
         cmake.exe -B build/ -G 'Ninja' \
                   -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
                   -DCMAKE_INSTALL_PREFIX=build/qucs-suite  \
-                  -DWITH_QT6=ON \
                   -DCI_VERSION="${{env.VERSION}}"
         cmake.exe --build build/ --parallel --config ${{env.BUILD_TYPE}}
 


### PR DESCRIPTION
Hi, this PR make this changes.

- qt6 updated to v6.9.0 for macOS and linux, msys2 already updated. 
- removed WITH_QT6 flag.