### PR TITLE
fix: Make label root follow its host node when the node is moving

### DIFF
--- a/qucs/node.cpp
+++ b/qucs/node.cpp
@@ -98,3 +98,12 @@ Element* Node::other_than(Element* elem) const
 
   return other == connections.end() ? nullptr : *other;
 }
+
+bool Node::moveCenter(int dx, int dy) noexcept
+{
+  Element::moveCenter(dx, dy);
+  if (Label != nullptr) {
+    Label->moveRoot(dx, dy);
+  }
+  return dx != 0 || dy != 0;
+}

--- a/qucs/node.h
+++ b/qucs/node.h
@@ -54,6 +54,8 @@ public:
   const_iterator begin() const;
   const_iterator end() const;
 
+  bool moveCenter(int dx, int dy) noexcept override;
+
   QString Name;  // node name used by creation of netlist
   QString DType; // type of node (used by digital files)
   int State;	 // remember some things during some operations


### PR DESCRIPTION
I forgot to override moveCenter() in Node and it used inherited implementation which doesn't account label.

Fix ra3xdh#1293