### PR TITLE
Fix selecting of ID_text

### DIFF
--- a/qucs/paintings/id_text.cpp
+++ b/qucs/paintings/id_text.cpp
@@ -150,3 +150,9 @@ bool ID_Text::Dialog(QWidget *parent)
   auto d = std::make_unique<ID_Dialog>(this, parent);
   return d->exec() != QDialog::Rejected;
 }
+
+QRect ID_Text::boundingRect() const noexcept
+{
+  return QRect{x1, y1, x2, y2}  // x2 and y2 are width and height respectively
+    .normalized();
+}

--- a/qucs/paintings/id_text.h
+++ b/qucs/paintings/id_text.h
@@ -51,6 +51,8 @@ public:
 
   bool Dialog(QWidget* parent = nullptr) override;
 
+  QRect boundingRect() const noexcept override;
+
   QString prefix;
   std::vector<std::unique_ptr<SubParameter>> subParameters;
 };


### PR DESCRIPTION
ID_text stores its width and height in x2 and y2 members, but default implementation of boundingRect() treats them as coordinates of right and bottom sides of bounds. Overriding boundingRect() with proper behaviour resolves the issue.

Fix ra3xdh#1295