### PR TITLE
Avoid crash when moving a part of loop-wire

### DIFF
--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -34,7 +34,7 @@ struct Schematic::HealingParams
 };
 
 constexpr Schematic::HealingParams mousyMutationParams{
-    .m_healer_params = {.allowWireReshaping = false, .allowWireRelaying = true, .wireRelayingDepth = 3}
+    .m_healer_params = {.allowWireReshaping = false, .allowWireRelaying = false, .wireRelayingDepth = 3}
 };
 
 constexpr Schematic::HealingParams keyboardMutationParams{


### PR DESCRIPTION
When laying wires anew in the process of moving a group of elements there is lookup for a "stable" node which is preformed by traversing along the wires. If traversed wire line connects to moved elements and it consists of "depth" number of wires or more, then traversal stops before it gets to know that there is a moved element on other end of the wire line.

This commit rewrites traversal logic making it always go at full length at first and then step back if needed.

Fixes ra3xdh#1294