### PR TITLE
Make grid-step size wires selectable

### DIFF
--- a/qucs/node.cpp
+++ b/qucs/node.cpp
@@ -68,7 +68,7 @@ void Node::paint(QPainter* painter) const {
 
 bool Node::getSelected(int x, int y)
 {
-  return cx - 5 <= x && x <= cx + 5 && cy - 5 <= y && y <= cy + 5;
+  return cx - 3 <= x && x <= cx + 3 && cy - 3 <= y && y <= cy + 3;
 }
 
 void Node::setName(const QString& name, const QString& value, int x, int y)


### PR DESCRIPTION
On very short (10 units) wires their nodes' click-selection regions overlap the wire completely thus making it unselectable.

This commit shrinks the click-selection region of node, which leads to a little "gap" between them on very short wires.



https://github.com/user-attachments/assets/9d676e46-194a-497a-b9fc-e90d1c9937f5

