### PR TITLE
Fix ellipse selection

### DIFF
--- a/qucs/geometry/shapes.h
+++ b/qucs/geometry/shapes.h
@@ -12,11 +12,11 @@ namespace geom {
 inline bool is_inside_ellipse(const QPoint m, const QRect& bounds, int tolerance)
 {
     const auto m_rel_center = (m - bounds.center());
-    const auto half_width = bounds.width() / 2.0;
-    const auto half_height = bounds.height() / 2.0;
+    const auto radius_x = bounds.width() / 2.0;
+    const auto radius_y = bounds.height() / 2.0;
 
-    auto oa = m_rel_center.x() / (half_width + tolerance);
-    auto ob = m_rel_center.y() / (half_height + tolerance);
+    auto oa = m_rel_center.x() / (radius_x + tolerance);
+    auto ob = m_rel_center.y() / (radius_y + tolerance);
 
     return oa*oa + ob*ob <= 1.0;
 }
@@ -24,19 +24,19 @@ inline bool is_inside_ellipse(const QPoint m, const QRect& bounds, int tolerance
 inline bool is_near_ellipse(const QPoint m, const QRect& bounds, int tolerance)
 {
     const auto m_rel_center = (m - bounds.center());
-    const auto half_width = bounds.width() / 2.0;
-    const auto half_height = bounds.height() / 2.0;
+    const auto radius_x = bounds.width() / 2.0;
+    const auto radius_y = bounds.height() / 2.0;
 
     // outer ellipse
-    auto oa = m_rel_center.x() / (half_width + tolerance);
-    auto ob = m_rel_center.y() / (half_height + tolerance);
+    auto oa = m_rel_center.x() / (radius_x + tolerance);
+    auto ob = m_rel_center.y() / (radius_y + tolerance);
 
     auto inside_outer = oa*oa + ob*ob <= 1.0;
     if (!inside_outer) return false;
 
     // inner ellipse
-    auto ia = m_rel_center.x() / (half_width - tolerance);
-    auto ib = m_rel_center.y() / (half_height - tolerance);
+    auto ia = m_rel_center.x() / (radius_x - tolerance);
+    auto ib = m_rel_center.y() / (radius_y - tolerance);
 
     return inside_outer && (ia*ia + ib*ib >= 1.0);
 }

--- a/qucs/geometry/shapes.h
+++ b/qucs/geometry/shapes.h
@@ -1,10 +1,7 @@
 #ifndef GEOMETRY_SHAPES_H
 #define GEOMETRY_SHAPES_H
 
-#include "concepts.h"
 #include <QRect>
-#include <cmath>
-#include <QDebug>
 
 namespace qucs_s {
 namespace geom {

--- a/qucs/geometry/shapes.h
+++ b/qucs/geometry/shapes.h
@@ -11,7 +11,7 @@ namespace geom {
 
 inline bool is_inside_ellipse(const QPoint m, const QRect& bounds, int tolerance)
 {
-    const auto m_rel_center = (m - bounds.center());
+    const auto m_rel_center = (m - QRectF(bounds).center());
     const auto radius_x = bounds.width() / 2.0;
     const auto radius_y = bounds.height() / 2.0;
 
@@ -23,7 +23,7 @@ inline bool is_inside_ellipse(const QPoint m, const QRect& bounds, int tolerance
 
 inline bool is_near_ellipse(const QPoint m, const QRect& bounds, int tolerance)
 {
-    const auto m_rel_center = (m - bounds.center());
+    const auto m_rel_center = (m - QRectF(bounds).center());
     const auto radius_x = bounds.width() / 2.0;
     const auto radius_y = bounds.height() / 2.0;
 


### PR DESCRIPTION
Here is a handful of changes to ellipse, most important is the fix of selecting of an empty ellipse by clicking on its north-west and south-east quarters. 