### PR TITLE
Refactor usages of Wire

### DIFF
--- a/qucs/healer.cpp
+++ b/qucs/healer.cpp
@@ -125,9 +125,9 @@ QPoint GenericPort::center() const
         case PortType::Component:
             return m_comp->center() + QPoint{m_port->x, m_port->y};
         case PortType::WireOne:
-            return QPoint{m_wire->x1, m_wire->y1};
+            return m_wire->P1();
         case PortType::WireTwo:
-            return QPoint{m_wire->x2, m_wire->y2};
+            return m_wire->P2();
     }
     assert(false);
 }
@@ -312,8 +312,8 @@ bool isSpecialCase(const JointStateAssessor& jsa)
     Wire* single_wire = jsa.portLocations().lower_bound(*single_wire_port_loc)->second->host<Wire>();
     assert(single_wire != nullptr);
 
-    const QPoint p1{single_wire->x1, single_wire->y1};
-    const QPoint p2{single_wire->x2, single_wire->y2};
+    const QPoint p1 = single_wire->P1();
+    const QPoint p2 = single_wire->P2();
     return *other_loc == p1 || *other_loc == p2 || geom::is_between(*other_loc, p1, p2);
 }
 

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -440,6 +440,7 @@ private:
 
 public:
   Node* provideNode(int, int);
+  Node* provideNode(const QPoint& p) { return provideNode(p.x(), p.y()); }
   Node* selectedNode(int, int);
 
   qucs_s::wire::Planner a_wirePlanner;

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -543,14 +543,9 @@ Wire* Schematic::splitWire(Wire *source_wire, Node *splitter_node)
     Wire *new_wire = new Wire(splitter_node->cx, splitter_node->cy, source_wire->x2, source_wire->y2, splitter_node, source_wire->Port2);
     new_wire->isSelected = source_wire->isSelected;
 
-    source_wire->x2 = splitter_node->cx;
-    source_wire->y2 = splitter_node->cy;
-    source_wire->cx = (source_wire->x1 + source_wire->x2) / 2;
-    source_wire->cy = (source_wire->y1 + source_wire->y2) / 2;
-    source_wire->Port2 = splitter_node;
+    source_wire->connectPort2(splitter_node);
 
     new_wire->Port2->connect(new_wire);
-    splitter_node->connect(source_wire);
     splitter_node->connect(new_wire);
     new_wire->Port2->disconnect(source_wire);
     a_Wires->push_back(new_wire);
@@ -2371,12 +2366,8 @@ std::pair<bool,Node*> Schematic::installWire(Wire* wire)
 
         if (!has_been_used) {
             // … the given wire hasn't been used yet. Fill the gap with it.
-            wire->Port1 = node_pair.first;
-            wire->Port1->connect(wire);
-            wire->Port2 = node_pair.second;
-            wire->Port2->connect(wire);
-            wire->setP1(wire->Port1->center());
-            wire->setP2(wire->Port2->center());
+            wire->connectPort1(node_pair.first);
+            wire->connectPort2(node_pair.second);
             a_Wires->push_back(wire);
             has_been_used = true;
             has_changes = true;
@@ -2428,14 +2419,8 @@ std::pair<bool,Node*> Schematic::installWire(Wire* wire)
         delete existing_wire;
 
         // Put the given wire in place of deleted one
-        wire->Port1 = last_pair.first;
-        wire->Port1->connect(wire);
-        wire->Port2 = last_pair.second;
-        wire->Port2->connect(wire);
-
-        // Update given wire dimensions
-        wire->setP1(wire->Port1->center());
-        wire->setP2(wire->Port2->center());
+        wire->connectPort1(last_pair.first);
+        wire->connectPort2(last_pair.second);
 
         a_Wires->push_back(wire);
     }

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -538,32 +538,32 @@ Wire* Schematic::selectedWire(int x, int y)
 
 // ---------------------------------------------------
 // Splits the wire "*pw" into two pieces by the node "*pn".
-Wire* Schematic::splitWire(Wire *pw, Node *pn)
+Wire* Schematic::splitWire(Wire *source_wire, Node *splitter_node)
 {
-    Wire *newWire = new Wire(pn->cx, pn->cy, pw->x2, pw->y2, pn, pw->Port2);
-    newWire->isSelected = pw->isSelected;
+    Wire *new_wire = new Wire(splitter_node->cx, splitter_node->cy, source_wire->x2, source_wire->y2, splitter_node, source_wire->Port2);
+    new_wire->isSelected = source_wire->isSelected;
 
-    pw->x2 = pn->cx;
-    pw->y2 = pn->cy;
-    pw->cx = (pw->x1 + pw->x2) / 2;
-    pw->cy = (pw->y1 + pw->y2) / 2;
-    pw->Port2 = pn;
+    source_wire->x2 = splitter_node->cx;
+    source_wire->y2 = splitter_node->cy;
+    source_wire->cx = (source_wire->x1 + source_wire->x2) / 2;
+    source_wire->cy = (source_wire->y1 + source_wire->y2) / 2;
+    source_wire->Port2 = splitter_node;
 
-    newWire->Port2->connect(newWire);
-    pn->connect(pw);
-    pn->connect(newWire);
-    newWire->Port2->disconnect(pw);
-    a_Wires->push_back(newWire);
+    new_wire->Port2->connect(new_wire);
+    splitter_node->connect(source_wire);
+    splitter_node->connect(new_wire);
+    new_wire->Port2->disconnect(source_wire);
+    a_Wires->push_back(new_wire);
 
-    if(pw->Label)
-        if((pw->Label->cx > pn->cx) || (pw->Label->cy > pn->cy))
+    if(source_wire->Label)
+        if((source_wire->Label->cx > splitter_node->cx) || (source_wire->Label->cy > splitter_node->cy))
         {
-            newWire->Label = pw->Label;   // label goes to the new wire
-            pw->Label = 0;
-            newWire->Label->pOwner = newWire;
+            new_wire->Label = source_wire->Label;   // label goes to the new wire
+            source_wire->Label = 0;
+            new_wire->Label->pOwner = new_wire;
         }
 
-    return newWire;
+    return new_wire;
 }
 
 // Deletes the wire and the nodes it was connected to if they

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -2336,8 +2336,8 @@ std::pair<bool,Node*> Schematic::installWire(Wire* wire)
     assert(wire->Port1 == nullptr);
     assert(wire->Port2 == nullptr);
 
-    auto* port1 = provideNode(wire->x1, wire->y1);
-    auto* port2 = provideNode(wire->x2, wire->y2);
+    auto* port1 = provideNode(wire->P1());
+    auto* port2 = provideNode(wire->P2());
 
     auto crossed_nodes =
         qucs_s::geom::on_line(port1, port2, a_Nodes->begin(), a_Nodes->end());
@@ -2546,7 +2546,7 @@ public:
     }
 
     void replaceNode(qucs_s::GenericPort* port) override {
-        port->replaceNodeWith(sch->provideNode(port->center().x(), port->center().y()));
+        port->replaceNodeWith(sch->provideNode(port->center()));
     }
 };
 

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -332,7 +332,7 @@ Node* Schematic::provideNode(int x, int y)
     // Check if the new node lies upon an existing wire
     for (auto* wire : *a_Wires)
     {
-        if (qucs_s::geom::is_between(new_node, QPoint{wire->x1, wire->y1}, QPoint{wire->x2, wire->y2})) {
+        if (qucs_s::geom::is_between(new_node, wire->P1(), wire->P2())) {
             // split the wire into two wires
             splitWire(wire, new_node);
             return new_node;
@@ -454,10 +454,8 @@ Wire* merge_wires_at_node(Node* node) {
     if (!extended_wire->isSelected) extended_wire->isSelected = dissapearing_wire->isSelected;
 
     // Update wire dimensions
-    extended_wire->x1 = extended_wire->Port1->x();
-    extended_wire->y1 = extended_wire->Port1->y();
-    extended_wire->x2 = extended_wire->Port2->x();
-    extended_wire->y2 = extended_wire->Port2->y();
+    extended_wire->setP1(extended_wire->Port1->center());
+    extended_wire->setP2(extended_wire->Port2->center());
 
     if (label != extended_wire->Label) {
         delete extended_wire->Label;
@@ -1545,8 +1543,8 @@ bool Schematic::elementsOnGrid()
     std::ranges::for_each(selection.labels, onGridSetter);
     std::ranges::for_each(selection.markers, onGridSetter);
     std::ranges::for_each(selection.wires, [&any_set, this](Wire* w) {
-        auto p1_moved = w->setP1(setOnGrid(QPoint{w->x1, w->y1}));
-        auto p2_moved = w->setP2(setOnGrid(QPoint{w->x2, w->y2}));
+        auto p1_moved = w->setP1(setOnGrid(w->P1()));
+        auto p2_moved = w->setP2(setOnGrid(w->P2()));
         any_set = p1_moved || p2_moved || any_set;
     });
 
@@ -2377,10 +2375,8 @@ std::pair<bool,Node*> Schematic::installWire(Wire* wire)
             wire->Port1->connect(wire);
             wire->Port2 = node_pair.second;
             wire->Port2->connect(wire);
-            wire->x1 = wire->Port1->x();
-            wire->y1 = wire->Port1->y();
-            wire->x2 = wire->Port2->x();
-            wire->y2 = wire->Port2->y();
+            wire->setP1(wire->Port1->center());
+            wire->setP2(wire->Port2->center());
             a_Wires->push_back(wire);
             has_been_used = true;
             has_changes = true;
@@ -2438,10 +2434,8 @@ std::pair<bool,Node*> Schematic::installWire(Wire* wire)
         wire->Port2->connect(wire);
 
         // Update given wire dimensions
-        wire->x1 = wire->Port1->x();
-        wire->y1 = wire->Port1->y();
-        wire->x2 = wire->Port2->x();
-        wire->y2 = wire->Port2->y();
+        wire->setP1(wire->Port1->center());
+        wire->setP2(wire->Port2->center());
 
         a_Wires->push_back(wire);
     }

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -540,14 +540,9 @@ Wire* Schematic::selectedWire(int x, int y)
 // Splits the wire "*pw" into two pieces by the node "*pn".
 Wire* Schematic::splitWire(Wire *source_wire, Node *splitter_node)
 {
-    Wire *new_wire = new Wire(splitter_node->cx, splitter_node->cy, source_wire->x2, source_wire->y2, splitter_node, source_wire->Port2);
+    Wire *new_wire = new Wire(splitter_node, source_wire->Port2);
     new_wire->isSelected = source_wire->isSelected;
-
     source_wire->connectPort2(splitter_node);
-
-    new_wire->Port2->connect(new_wire);
-    splitter_node->connect(new_wire);
-    new_wire->Port2->disconnect(source_wire);
     a_Wires->push_back(new_wire);
 
     if(source_wire->Label)
@@ -2374,12 +2369,7 @@ std::pair<bool,Node*> Schematic::installWire(Wire* wire)
         } else {
             // … the given wire has been already used to fill another gap.
             // Fill this gap with a brand new wire.
-	        auto* w = new Wire(node_pair.first->x(), node_pair.first->y(),
-			                   node_pair.second->x(), node_pair.second->y());
-            w->Port1 = node_pair.first;
-            w->Port1->connect(w);
-            w->Port2 = node_pair.second;
-            w->Port2->connect(w);
+	        auto* w = new Wire(node_pair.first, node_pair.second);
             a_Wires->push_back(w);
             has_changes = true;
         }
@@ -2793,15 +2783,9 @@ void Schematic::dumbConnectWithWire(const QPoint& a, const QPoint& b) noexcept {
         auto m = points[i-1];
         auto n = points[i];
 
-        auto* wire = new Wire(m.x(), m.y(), n.x(), n.y());
+        auto* wire = new Wire(new Node(m.x(), m.y()), new Node(n.x(), n.y()));
         a_Wires->push_back(wire);
-
-        wire->Port1 = new Node(m.x(), m.y());
-        wire->Port1->connect(wire);
         a_Nodes->push_back(wire->Port1);
-
-        wire->Port2 = new Node(n.x(), n.y());
-        wire->Port2->connect(wire);
         a_Nodes->push_back(wire->Port2);
     }
 }

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -909,7 +909,7 @@ bool Schematic::loadWires(QTextStream *stream, std::list<Element*> *List)
     Line = Line.trimmed();
     if(Line.isEmpty()) continue;
 
-    w = new Wire(0,0,0,0, nullptr, nullptr);
+    w = new Wire();
     if(!w->load(Line)) {
       QMessageBox::critical(0, QObject::tr("Error"),
       QObject::tr("Format Error:\nWrong 'wire' line format!"));

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -935,23 +935,6 @@ bool Schematic::loadWires(QTextStream *stream, std::list<Element*> *List)
       if(w->Label)  List->push_back(w->Label);
     }
     else {
-      // Quick fix for ra3xdh#1273.
-      //
-      // A wire whose (x1,y1) coordinates are not less than (x2,y2)
-      // coordinates somehow deals some damage like crashes or funny behaviour.
-      //
-      // I wasn't able to understand how exactly this happens, i.e. why it's
-      // important to have x1 less than x2 for a wire, so I decided to fix this
-      // in a most straightforward way by "normalizing" the wire before installing
-      // it into schematic
-      if (w->x1 > w->x2) {
-        std::swap(w->x1, w->x2);
-        std::swap(w->y1, w->y2);
-      } else if (w->x1 == w->x2 && w->y1 > w->y2) {
-        std::swap(w->x1, w->x2);
-        std::swap(w->y1, w->y2);
-      }
-
       simpleInsertWire(w);
     }
   }

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -876,7 +876,7 @@ bool Schematic::loadComponents(QTextStream *stream, std::list<Component*> *List)
 // Inserts a wire without performing logic for optimizing.
 void Schematic::simpleInsertWire(Wire *pw)
 {
-  Node* pn = provideNode(pw->x1, pw->y1);
+  Node* pn = provideNode(pw->P1());
 
   if(pw->P1() == pw->P2()) {
     pn->Label = pw->Label;   // wire with length zero are just node labels
@@ -891,7 +891,7 @@ void Schematic::simpleInsertWire(Wire *pw)
   pn->connect(pw);  // connect schematic node to component node
   pw->Port1 = pn;
 
-  pn = provideNode(pw->x2, pw->y2);
+  pn = provideNode(pw->P2());
   pn->connect(pw);  // connect schematic node to component node
   pw->Port2 = pn;
 

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -878,7 +878,7 @@ void Schematic::simpleInsertWire(Wire *pw)
 {
   Node* pn = provideNode(pw->x1, pw->y1);
 
-  if(pw->x1 == pw->x2) if(pw->y1 == pw->y2) {
+  if(pw->P1() == pw->P2()) {
     pn->Label = pw->Label;   // wire with length zero are just node labels
     if (pn->Label) {
       pn->Label->Type = isNodeLabel;
@@ -922,7 +922,7 @@ bool Schematic::loadWires(QTextStream *stream, std::list<Element*> *List)
       // Only the label is kept, so it becomes "free" i.e. not having
       // a host element like wire or node. We must be careful to treat
       // such labels in a special way in other parts of the codebase.
-      if (w->x1 == w->x2 && w->y1 == w->y2 && w->Label) {
+      if (w->P1() == w->P2() && w->Label) {
         w->Label->Type = isNodeLabel;
         List->push_back(w->Label);
         w->Label->pOwner = nullptr;

--- a/qucs/wire.cpp
+++ b/qucs/wire.cpp
@@ -183,6 +183,20 @@ bool Wire::load(const QString& _s)
   y2 = n.toInt(&ok);
   if(!ok) return false;
 
+  // Quick fix for ra3xdh#1273 (25.03.25)
+  //
+  // A wire whose (x1,y1) coordinates are not less than (x2,y2)
+  // coordinates somehow deals some damage like crashes or funny behaviour.
+  //
+  // I wasn't able to understand how exactly this happens, i.e. why it's
+  // important to have x1 less than x2 for a wire, so I decided to fix this
+  // in a most straightforward way by "normalizing" the wire before installing
+  // it into schematic
+  if (x1 > x2 || (x1 == x2 && y1 > y2)) {
+    std::swap(x1, x2);
+    std::swap(y1, y2);
+  }
+
   // Update center
   cx = (x1 + x2) / 2;
   cy = (y1 + y2) / 2;

--- a/qucs/wire.cpp
+++ b/qucs/wire.cpp
@@ -270,3 +270,37 @@ bool Wire::setP2(const QPoint& new_p2)
 
   return true;
 }
+
+void Wire::connectPort1(Node* n)
+{
+  assert(n != nullptr);
+
+  if (n == Port1) {
+    return;
+  }
+
+  if (Port1 != nullptr) {
+    Port1->disconnect(this);
+  }
+
+  n->connect(this);
+  Port1 = n;
+  setP1(Port1->center());
+}
+
+void Wire::connectPort2(Node* n)
+{
+  assert(n != nullptr);
+
+  if (n == Port2) {
+    return;
+  }
+
+  if (Port2 != nullptr) {
+    Port2->disconnect(this);
+  }
+
+  n->connect(this);
+  Port2 = n;
+  setP2(Port2->center());
+}

--- a/qucs/wire.cpp
+++ b/qucs/wire.cpp
@@ -21,7 +21,7 @@
 
 #include <QPainter>
 
-Wire::Wire(int _x1, int _y1, int _x2, int _y2, Node *n1, Node *n2)
+Wire::Wire(int _x1, int _y1, int _x2, int _y2)
 {
   x1 = _x1;
   y1 = _y1;
@@ -32,12 +32,18 @@ Wire::Wire(int _x1, int _y1, int _x2, int _y2, Node *n1, Node *n2)
   cx = (x1 + x2) / 2;
   cy = (y1 + y2) / 2;
 
-  Port1 = n1;
-  Port2 = n2;
+  Port1 = nullptr;
+  Port2 = nullptr;
   Label = nullptr;
 
   Type = isWire;
   isSelected = false;
+}
+
+Wire::Wire(Node* n1, Node* n2)
+{
+  connectPort1(n1);
+  connectPort2(n2);
 }
 
 Wire::~Wire()

--- a/qucs/wire.cpp
+++ b/qucs/wire.cpp
@@ -28,9 +28,7 @@ Wire::Wire(int _x1, int _y1, int _x2, int _y2)
   x2 = _x2;
   y2 = _y2;
 
-  // Update center
-  cx = (x1 + x2) / 2;
-  cy = (y1 + y2) / 2;
+  updateCenter();
 
   Port1 = nullptr;
   Port2 = nullptr;
@@ -197,9 +195,7 @@ bool Wire::load(const QString& _s)
     std::swap(y1, y2);
   }
 
-  // Update center
-  cx = (x1 + x2) / 2;
-  cy = (y1 + y2) / 2;
+  updateCenter();
 
   n = s.section('"',1,1);
   if(!n.isEmpty()) {     // is wire labeled ?
@@ -256,9 +252,7 @@ bool Wire::setP1(const QPoint& new_p1)
   x1 = new_p1.x();
   y1 = new_p1.y();
 
-  // Update center
-  cx = std::midpoint(x1, x2);
-  cy = std::midpoint(y1, y2);
+  updateCenter();
 
   return true;
 }
@@ -284,9 +278,7 @@ bool Wire::setP2(const QPoint& new_p2)
   x2 = new_p2.x();
   y2 = new_p2.y();
 
-  // Update center
-  cx = std::midpoint(x1, x2);
-  cy = std::midpoint(y1, y2);
+  updateCenter();
 
   return true;
 }
@@ -323,4 +315,9 @@ void Wire::connectPort2(Node* n)
   n->connect(this);
   Port2 = n;
   setP2(Port2->center());
+}
+
+inline void Wire::updateCenter() noexcept {
+  cx = std::midpoint(x1, x2);
+  cy = std::midpoint(y1, y2);
 }

--- a/qucs/wire.h
+++ b/qucs/wire.h
@@ -61,6 +61,9 @@ public:
 
   void connectPort1(Node* n);
   void connectPort2(Node* n);
+
+private:
+  void updateCenter() noexcept;
 };
 
 #endif

--- a/qucs/wire.h
+++ b/qucs/wire.h
@@ -28,7 +28,8 @@ class QString;
 
 class Wire : public Conductor {
 public:
-  Wire(int _x1=0, int _y1=0, int _x2=0, int _y2=0, Node *n1=0, Node *n2=0);
+  Wire(int _x1=0, int _y1=0, int _x2=0, int _y2=0);
+  Wire(Node* n1, Node* n2);
  ~Wire() override;
 
   void paint(QPainter* painter) const;

--- a/qucs/wire.h
+++ b/qucs/wire.h
@@ -58,6 +58,8 @@ public:
   QPoint P1() const { return {x1, y1}; }
   QPoint P2() const { return {x2, y2}; }
 
+  void connectPort1(Node* n);
+  void connectPort2(Node* n);
 };
 
 #endif


### PR DESCRIPTION
Here are little changes here and there to make usage of Wire a bit cleaner. Mostly by removing explicit actions like "set this node as port1, update coordinates x1, y1, update coordinates of center, etc." in favour of API calls which hide all the details. Another goal was to get rid of direct access to member fields x1, y1, x2, y2.