### PR TITLE
Fix crash when moving a wire or a wired component

### DIFF
--- a/qucs/wire.cpp
+++ b/qucs/wire.cpp
@@ -39,6 +39,7 @@ Wire::Wire(int _x1, int _y1, int _x2, int _y2)
 }
 
 Wire::Wire(Node* n1, Node* n2)
+  : Wire(n1->x(), n1->y(), n2->x(), n2->y())
 {
   connectPort1(n1);
   connectPort2(n2);


### PR DESCRIPTION
This fixes regression introduced in commit 20f83ba7 (ra3xdh#1315). New Wire constructor added in the named commit doesn't properly initialize all member fields which may lead to crashes. It seems that only GCC builds are affected.