### PR TITLE
Add settings for wires

### DIFF
--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -147,6 +147,14 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     appSettingsGrid->addWidget(checkFullTraceNames, 6, 1);
     checkFullTraceNames->setChecked(QucsSettings.fullTraceName);
 
+    appSettingsGrid->addWidget(new QLabel(tr("Flexible wires (requires restart):"), appSettingsTab), 7, 0);
+    allowFlexibleWires = new QCheckBox(appSettingsTab);
+    appSettingsGrid->addWidget(allowFlexibleWires, 7, 1);
+
+    appSettingsGrid->addWidget(new QLabel(tr("Lay wires anew when moving elements (requires restart):"), appSettingsTab), 8, 0);
+    allowLayingWiresAnew = new QCheckBox(allowLayingWiresAnew);
+    appSettingsGrid->addWidget(allowLayingWiresAnew, 8, 1);
+
     t->addTab(appSettingsTab, tr("Settings"));
 
     // ...........................................................
@@ -510,6 +518,8 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     undoNumEdit->setText(QString::number(QucsSettings.maxUndo));
     editorEdit->setText(QucsSettings.Editor);
     checkWiring->setChecked(QucsSettings.NodeWiring);
+    allowFlexibleWires->setChecked(_settings::Get().item<bool>("AllowFlexibleWires"));
+    allowLayingWiresAnew->setChecked(_settings::Get().item<bool>("AllowLayingWiresAnew"));
 
     for(int z=LanguageCombo->count()-1; z>=0; z--)
         if(LanguageCombo->itemText(z).section('(',1,1).remove(')') == QucsSettings.Language)
@@ -731,6 +741,9 @@ void QucsSettingsDialog::slotApply()
         changed = true;
     }
 
+    _settings::Get().setItem("AllowFlexibleWires", allowFlexibleWires->isChecked());
+    _settings::Get().setItem("AllowLayingWiresAnew", allowLayingWiresAnew->isChecked());
+
     QucsSettings.FileTypes.clear();
     for (int row=0; row < fileTypesTableWidget->rowCount(); row++)
     {
@@ -926,6 +939,8 @@ void QucsSettingsDialog::slotDefaultValues()
     undoNumEdit->setText("20");
     editorEdit->setText(QucsSettings.BinDir + "qucs");
     checkWiring->setChecked(false);
+    allowFlexibleWires->setChecked(_settings::Get().itemDefault<bool>("AllowFlexibleWires"));
+    allowLayingWiresAnew->setChecked(_settings::Get().itemDefault<bool>("AllowLayingWiresAnew"));
     checkLoadFromFutureVersions->setChecked(false);
     checkAntiAliasing->setChecked(false);
     checkTextAntiAliasing->setChecked(true);

--- a/qucs/dialogs/qucssettingsdialog.h
+++ b/qucs/dialogs/qucssettingsdialog.h
@@ -86,6 +86,7 @@ public:
     QFont AppFont;
     QFont TextFont;
     QCheckBox *checkWiring, *checkLoadFromFutureVersions,
+              *allowFlexibleWires, *allowLayingWiresAnew,
               *checkAntiAliasing, *checkTextAntiAliasing,
               *checkFullTraceNames;
     QComboBox *LanguageCombo,

--- a/qucs/healer.cpp
+++ b/qucs/healer.cpp
@@ -95,30 +95,6 @@ public:
 // GenericPort
 // --------------------------------------------------------------------------------------
 
-template<>
-Wire* GenericPort::host() const
-{
-    return (isOfWire() ? m_wire : nullptr);
-}
-
-
-template<>
-Component* GenericPort::host() const
-{
-    return (isOfComponent() ? m_comp : nullptr);
-}
-
-
-template<>
-Element* GenericPort::host() const
-{
-    if (isOfComponent()) {
-        return m_comp;
-    }
-    return m_wire;
-}
-
-
 QPoint GenericPort::center() const
 {
     switch (m_portType) {
@@ -186,7 +162,7 @@ Node* GenericPort::replaceNodeWith(Node* new_node)
 void GenericPort::moveCenterTo(const QPoint& coords)
 {
     assert(isOfWire());
-    auto* wire = host<Wire>();
+    auto* wire = hostWire();
 
     switch (m_portType) {
     case (PortType::WireOne):
@@ -309,7 +285,7 @@ bool isSpecialCase(const JointStateAssessor& jsa)
 
     if (jsa.onlyWirePortsAt(*other_loc)) return false;
 
-    Wire* single_wire = jsa.portLocations().lower_bound(*single_wire_port_loc)->second->host<Wire>();
+    Wire* single_wire = jsa.portLocations().lower_bound(*single_wire_port_loc)->second->hostWire();
     assert(single_wire != nullptr);
 
     const QPoint p1 = single_wire->P1();
@@ -458,7 +434,7 @@ vector<Healer::HealingAction> Healer::HealerImpl::processRelayingCase(Node* node
 
         assert(port->isOfWire());
 
-        auto [stable_node, obsolete_wires] = findStableNode(node, port->host<Wire>());
+        auto [stable_node, obsolete_wires] = findStableNode(node, port->hostWire());
 
         std::vector<WireLabel*> labels;
         for (auto* wire : obsolete_wires) {

--- a/qucs/healer.cpp
+++ b/qucs/healer.cpp
@@ -179,6 +179,19 @@ void GenericPort::moveCenterTo(const QPoint& coords)
 }
 
 
+Node* GenericPort::node() const
+{
+    switch (m_portType) {
+    case PortType::WireOne:
+      return m_wire->Port1;
+    case PortType::WireTwo:
+      return m_wire->Port2;
+    case PortType::Component:
+      return m_port->Connection;
+    }
+}
+
+
 // Utils
 // --------------------------------------------------------------------------------------
 

--- a/qucs/healer.h
+++ b/qucs/healer.h
@@ -67,8 +67,9 @@ public:
     bool isOfWire() const { return m_portType != PortType::Component; }
     bool isOfComponent() const { return !isOfWire(); }
 
-    template<typename T>
-    T* host() const { static_assert(!std::is_same<T,T>::value); }
+    Wire* hostWire() const { return m_wire; }
+    Component* hostComponent() const { return m_comp; }
+
     Node* node() const;
     QPoint center() const;
     Node* replaceNodeWith(Node* new_node);

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -2489,6 +2489,11 @@ public:
         sch->showEphemeralWire(a, b);
     }
 
+    void movePort(qucs_s::GenericPort* port, const QPoint& p) override {
+        Wire* host = port->hostWire();
+        Node* other = host->Port1 == port->node() ? host->Port2 : host->Port1;
+        sch->PostPaintEvent(_Line, p.x(), p.y(), other->x(), other->y());
+    }
 };
 
 

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -22,6 +22,7 @@
 #include "healer.h"
 #include "portsymbol.h"
 #include "schematic.h"
+#include "settings.h"
 
 #include <ranges>
 #include <set>
@@ -33,12 +34,19 @@ struct Schematic::HealingParams
     qucs_s::wire::Planner::PlanType m_wire_plan = qucs_s::wire::Planner::PlanType::Straight;
 };
 
-constexpr Schematic::HealingParams mousyMutationParams{
-    .m_healer_params = {.allowWireReshaping = false, .allowWireRelaying = false, .wireRelayingDepth = 3}
+const Schematic::HealingParams mousyMutationParams{
+    .m_healer_params = {
+        .allowWireReshaping = _settings::Get().item<bool>("AllowFlexibleWires"),
+        .allowWireRelaying = _settings::Get().item<bool>("AllowLayingWiresAnew"),
+        .wireRelayingDepth = 2
+    }
 };
 
-constexpr Schematic::HealingParams keyboardMutationParams{
-    .m_healer_params = {.allowWireReshaping = false, .allowWireRelaying = false}
+const Schematic::HealingParams keyboardMutationParams{
+    .m_healer_params = {
+        .allowWireReshaping = _settings::Get().item<bool>("AllowFlexibleWires"),
+        .allowWireRelaying = false
+    }
 };
 
 constexpr Schematic::HealingParams noninteractiveMutationParams{

--- a/qucs/settings.cpp
+++ b/qucs/settings.cpp
@@ -79,6 +79,8 @@ void settingsManager::initDefaults()
     m_Defaults["TextAntiAliasing"] = false;
     m_Defaults["fullTraceName"] = false;
     m_Defaults["NgspiceCompatMode"] = spicecompat::NgspDefault;
+    m_Defaults["AllowFlexibleWires"] = false;
+    m_Defaults["AllowLayingWiresAnew"] = false;
 }
 
 void settingsManager::initAliases()


### PR DESCRIPTION
Hi! This PR adds two checkboxes to application settings which control wire behaviour when elements of schematic are being moved.

![image](https://github.com/user-attachments/assets/d6eb2304-f26e-4265-b6d7-8b510cb946b3)

I'm not sure about the wording though, it's definitely not the best as I'm not a native speaker.
