### PR TITLE
Feature: Open recent project

### DIFF
--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -147,6 +147,7 @@ bool loadSettings()
     QucsSettings.GraphAntiAliasing = _settings::Get().item<bool>("GraphAntiAliasing");
     QucsSettings.TextAntiAliasing = _settings::Get().item<bool>("TextAntiAliasing");
     QucsSettings.fullTraceName = _settings::Get().item<bool>("fullTraceName");
+    QucsSettings.RecentProjects = _settings::Get().item<QString>("RecentProjects").split("*", Qt::SkipEmptyParts);
     QucsSettings.RecentDocs = _settings::Get().item<QString>("RecentDocs").split("*", Qt::SkipEmptyParts);
     QucsSettings.numRecentDocs = QucsSettings.RecentDocs.count();
     QucsSettings.spiceExtensions << "*.sp" << "*.cir" << "*.spc" << "*.spi";

--- a/qucs/main.h
+++ b/qucs/main.h
@@ -98,6 +98,8 @@ struct tQucsSettings {
   unsigned int numRecentDocs;
   QStringList RecentDocs;
 
+  QStringList RecentProjects;
+
   bool IgnoreFutureVersion;
   bool GraphAntiAliasing;
   bool TextAntiAliasing;

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -3444,6 +3444,14 @@ void QucsApp::updateRecentFilesList(QString s)
   slotUpdateRecentFiles();
 }
 
+void QucsApp::updateRecentProjectsList()
+{
+  QSettings* settings = new QSettings("qucs","qucs_s");
+  settings->setValue("RecentProjects",QucsSettings.RecentProjects.join("*"));
+  delete settings;
+  slotUpdateRecentProjects();
+}
+
 void QucsApp::updateRecentProjectsList(QString pathToProj)
 {
   QSettings* settings = new QSettings("qucs","qucs_s");

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -140,6 +140,7 @@ QucsApp::QucsApp(bool netlist2Console) :
   viewBrowseDock->setChecked(true);
   slotViewOctaveDock(false);
   slotUpdateRecentFiles();
+  slotUpdateRecentProjects();
   initCursorMenu();
   //Module::registerModules ();
 

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -1434,6 +1434,9 @@ void QucsApp::slotButtonProjNew()
 // Opens an existing project.
 void QucsApp::openProject(const QString& Path)
 {
+  // this will also remove the path from recent projects if the directory doesn't exist.
+  updateRecentProjectsList(Path);
+
   slotHideEdit(); // disable text edit of component property
 
   QDir ProjDir(QDir::cleanPath(Path)); // the full path
@@ -3451,6 +3454,7 @@ void QucsApp::updateRecentProjectsList(QString pathToProj)
   }
   settings->setValue("RecentProjects",QucsSettings.RecentProjects.join("*"));
   delete settings;
+  slotUpdateRecentProjects();
 }
 
 void QucsApp::slotSaveDiagramToGraphicsFile()

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -3440,6 +3440,18 @@ void QucsApp::updateRecentFilesList(QString s)
   slotUpdateRecentFiles();
 }
 
+void QucsApp::updateRecentProjectsList(QString pathToProj)
+{
+  QSettings* settings = new QSettings("qucs","qucs_s");
+  QucsSettings.RecentProjects.removeAll(pathToProj);
+  QucsSettings.RecentProjects.prepend(pathToProj);
+  if (QucsSettings.RecentProjects.size() > MaxRecentFiles) {
+    QucsSettings.RecentProjects.removeLast();
+  }
+  settings->setValue("RecentProjects",QucsSettings.RecentProjects.join("*"));
+  delete settings;
+}
+
 void QucsApp::slotSaveDiagramToGraphicsFile()
 {
   slotSaveSchematicToGraphicsFile(true);

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -421,6 +421,7 @@ public slots:
   void slotAddToProject();
   void slotApplyCompText();
   void slotOpenRecentFile();
+  void slotOpenRecentProject();
   void slotSaveDiagramToGraphicsFile();
   void slotSaveSchematicToGraphicsFile(bool diagram = false);
 

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -417,7 +417,7 @@ public slots:
   void slotChangeProps();
   void slotAddToProject();
   void slotApplyCompText();
-  void slotOpenRecent();
+  void slotOpenRecentFile();
   void slotSaveDiagramToGraphicsFile();
   void slotSaveSchematicToGraphicsFile(bool diagram = false);
 

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -278,6 +278,7 @@ private:
 
   void updateRecentFilesList(QString s);
   void updateRecentProjectsList(QString pathToProj);
+  void updateRecentProjectsList();
   void successExportMessages(bool ok);
   void fillLibrariesTreeView (void);
   bool populateLibTreeFromDir(const QString &LibDirPath, QList<QTreeWidgetItem *> &topitems, bool relpath = false);

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -435,6 +435,7 @@ private slots:
   void slotExportGraphAsCsv();
   void slotUpdateRecentFiles();
   void slotClearRecentFiles();
+  void slotUpdateRecentProjects();
   void slotLoadModule();
   void slotBuildModule();
 

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -321,7 +321,7 @@ private:
 
   // menus contain the items of their menubar
   enum { MaxRecentFiles = 8 };
-  QMenu *fileMenu, *editMenu, *insMenu, *projMenu, *simMenu, *viewMenu,
+  QMenu *fileMenu, *editMenu, *insMenu, *projMenu, *recentProjMenu, *simMenu, *viewMenu,
              *helpMenu, *alignMenu, *toolMenu, *recentFilesMenu, *cmMenu;
   QAction *fileRecentAction[MaxRecentFiles];
   QAction *fileClearRecent;

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -439,6 +439,7 @@ private slots:
   void slotUpdateRecentFiles();
   void slotClearRecentFiles();
   void slotUpdateRecentProjects();
+  void slotClearRecentProjects();
   void slotLoadModule();
   void slotBuildModule();
 

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -328,6 +328,7 @@ private:
   QAction *fileClearRecent;
 
   QAction *projRecentActions[MaxRecentProjects];
+  QAction *projClearRecent;
 
   // submenus for the PDF documents
   QMenu *helpTechnical, *helpReport, *helpTutorial;

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -277,6 +277,7 @@ private:
   void closeFile(int);
 
   void updateRecentFilesList(QString s);
+  void updateRecentProjectsList(QString pathToProj);
   void successExportMessages(bool ok);
   void fillLibrariesTreeView (void);
   bool populateLibTreeFromDir(const QString &LibDirPath, QList<QTreeWidgetItem *> &topitems, bool relpath = false);

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -320,11 +320,13 @@ private:
           *viewBrowseDock, *viewOctaveDock;
 
   // menus contain the items of their menubar
-  enum { MaxRecentFiles = 8 };
+  enum { MaxRecentFiles = 8, MaxRecentProjects = 8 };
   QMenu *fileMenu, *editMenu, *insMenu, *projMenu, *recentProjMenu, *simMenu, *viewMenu,
              *helpMenu, *alignMenu, *toolMenu, *recentFilesMenu, *cmMenu;
   QAction *fileRecentAction[MaxRecentFiles];
   QAction *fileClearRecent;
+
+  QAction *projRecentActions[MaxRecentProjects];
 
   // submenus for the PDF documents
   QMenu *helpTechnical, *helpReport, *helpTutorial;

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -1501,7 +1501,6 @@ void QucsApp::slotOpenRecentProject()
   QAction *recentProjAction = qobject_cast<QAction *>(sender());
   if (recentProjAction) {
     openProject(recentProjAction->data().toString());
-    updateRecentProjectsList(recentProjAction->data().toString());
   }
 }
 

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -1496,6 +1496,15 @@ void QucsApp::slotClearRecentFiles()
   slotUpdateRecentFiles();
 }
 
+void QucsApp::slotOpenRecentProject()
+{
+  QAction *recentProjAction = qobject_cast<QAction *>(sender());
+  if (recentProjAction) {
+    openProject(recentProjAction->data().toString());
+    updateRecentProjectsList(recentProjAction->data().toString());
+  }
+}
+
 void QucsApp::slotUpdateRecentProjects()
 {
   QMutableStringListIterator it(QucsSettings.RecentProjects);

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -1461,7 +1461,7 @@ void QucsApp::slotExportGraphAsCsv()
 }
 
 
-void QucsApp::slotOpenRecent()
+void QucsApp::slotOpenRecentFile()
 {
   QAction *action = qobject_cast<QAction *>(sender());
   if (action) {

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -1496,6 +1496,28 @@ void QucsApp::slotClearRecentFiles()
   slotUpdateRecentFiles();
 }
 
+void QucsApp::slotUpdateRecentProjects()
+{
+  QMutableStringListIterator it(QucsSettings.RecentProjects);
+  QDir projDir;
+  while(it.hasNext()) {
+    // QDir::cd returns false if directory doesn't exist.
+    if (!projDir.cd(it.next())) {
+        it.remove();
+    }
+  }
+
+  for (int i = 0; i < MaxRecentProjects; ++i) {
+    if (i < QucsSettings.RecentProjects.size()) {
+      projRecentActions[i]->setText(QucsSettings.RecentProjects[i]);
+      projRecentActions[i]->setData(QucsSettings.RecentProjects[i]);
+      projRecentActions[i]->setVisible(true);
+    } else {
+      projRecentActions[i]->setVisible(false);
+    }
+  }
+}
+
 /*!
  * \brief QucsApp::slotLoadModule launches the dialog to select dynamic modueles
  */

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -1526,6 +1526,12 @@ void QucsApp::slotUpdateRecentProjects()
   }
 }
 
+void QucsApp::slotClearRecentProjects()
+{
+  QucsSettings.RecentProjects.clear();
+  updateRecentProjectsList();
+}
+
 /*!
  * \brief QucsApp::slotLoadModule launches the dialog to select dynamic modueles
  */

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -310,6 +310,13 @@ void QucsApp::initActions()
   projOpen->setWhatsThis(tr("Open Project\n\nOpens an existing project"));
   connect(projOpen, SIGNAL(triggered()), SLOT(slotMenuProjOpen()));
 
+  // initialise recent project actions
+  for (auto &action : projRecentActions) {
+    action = new QAction(this);
+    action->setVisible(false);
+    //connect(i, SIGNAL(triggered()), SLOT(slotOpenRecentProject()));
+  }
+
   projDel = new QAction(tr("&Delete Project..."), this);
   projDel->setShortcut(tr("Ctrl+Shift+D"));
   projDel->setStatusTip(tr("Deletes an existing project"));
@@ -760,6 +767,11 @@ void QucsApp::initMenuBar()
 
   recentProjMenu = new QMenu(tr("Open Recent"), projMenu);
   projMenu->addMenu(recentProjMenu);
+
+  // Add recent project actions to recent project submenu
+  for (auto &action : projRecentActions) {
+    recentProjMenu->addAction(action);
+  }
 
   projMenu->addAction(addToProj);
   projMenu->addAction(projClose);

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -757,6 +757,10 @@ void QucsApp::initMenuBar()
   projMenu = new QMenu(tr("&Project"));  // menuBar entry projMenu
   projMenu->addAction(projNew);
   projMenu->addAction(projOpen);
+
+  recentProjMenu = new QMenu(tr("Open Recent"), projMenu);
+  projMenu->addMenu(recentProjMenu);
+
   projMenu->addAction(addToProj);
   projMenu->addAction(projClose);
   projMenu->addAction(projDel);

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -318,6 +318,7 @@ void QucsApp::initActions()
   }
 
   projClearRecent = new QAction(tr("Clear recent"), this);
+  connect(projClearRecent, SIGNAL(triggered()), SLOT(slotClearRecentProjects()));
 
   projDel = new QAction(tr("&Delete Project..."), this);
   projDel->setShortcut(tr("Ctrl+Shift+D"));

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -314,7 +314,7 @@ void QucsApp::initActions()
   for (auto &action : projRecentActions) {
     action = new QAction(this);
     action->setVisible(false);
-    //connect(i, SIGNAL(triggered()), SLOT(slotOpenRecentProject()));
+    connect(action, SIGNAL(triggered()), SLOT(slotOpenRecentProject()));
   }
 
   projDel = new QAction(tr("&Delete Project..."), this);

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -317,6 +317,8 @@ void QucsApp::initActions()
     connect(action, SIGNAL(triggered()), SLOT(slotOpenRecentProject()));
   }
 
+  projClearRecent = new QAction(tr("Clear recent"), this);
+
   projDel = new QAction(tr("&Delete Project..."), this);
   projDel->setShortcut(tr("Ctrl+Shift+D"));
   projDel->setStatusTip(tr("Deletes an existing project"));
@@ -772,6 +774,8 @@ void QucsApp::initMenuBar()
   for (auto &action : projRecentActions) {
     recentProjMenu->addAction(action);
   }
+  recentProjMenu->addSeparator();
+  recentProjMenu->addAction(projClearRecent);
 
   projMenu->addAction(addToProj);
   projMenu->addAction(projClose);

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -98,7 +98,7 @@ void QucsApp::initActions()
   for (auto & i : fileRecentAction) {
     i = new QAction(this);
     i->setVisible(false);
-    connect(i, SIGNAL(triggered()), SLOT(slotOpenRecent()));
+    connect(i, SIGNAL(triggered()), SLOT(slotOpenRecentFile()));
   }
 
   fileClearRecent = new QAction(tr("Clear Recent"), this);


### PR DESCRIPTION
I followed pretty much the same implementation as opening a recent file does, which was written like 10 years ago, but no deprecated qt api was used or so.

Also I noticed that after pressing "Clear Recent" in the File menu, it just hides the recent files and calls `QucsSettings.RecentDocs.clear()`
But the new empty RecentDocs is never written to the settings file.
Thus, after restarting the recent files remain in the menu.
I don't think that's desired behavior for the "clear recent" action,
So in my implementation I made it actually clear the recent projects. It would be easily fixed for recent files also.
Also being careful I don't break anything, I split this into many commits.

https://github.com/user-attachments/assets/4d2754a3-f37f-4422-bf9f-cc2b99545c72

