### PR TITLE
Reduce the number of includes in schematic.h

### DIFF
--- a/qucs/components/ampere_noise.cpp
+++ b/qucs/components/ampere_noise.cpp
@@ -18,6 +18,7 @@
 #include "ampere_noise.h"
 #include "extsimkernels/verilogawriter.h"
 #include "extsimkernels/spicecompat.h"
+#include "node.h"
 
 
 Ampere_noise::Ampere_noise()

--- a/qucs/components/capacitor.cpp
+++ b/qucs/components/capacitor.cpp
@@ -18,6 +18,7 @@
 #include "capacitor.h"
 #include "extsimkernels/spicecompat.h"
 #include "extsimkernels/verilogawriter.h"
+#include "node.h"
 
 
 Capacitor::Capacitor()

--- a/qucs/components/cccs.cpp
+++ b/qucs/components/cccs.cpp
@@ -18,6 +18,7 @@
 #include "cccs.h"
 #include "extsimkernels/spicecompat.h"
 #include "extsimkernels/verilogawriter.h"
+#include "node.h"
 
 
 CCCS::CCCS()

--- a/qucs/components/ccvs.cpp
+++ b/qucs/components/ccvs.cpp
@@ -18,6 +18,7 @@
 #include "ccvs.h"
 #include "extsimkernels/spicecompat.h"
 #include "extsimkernels/verilogawriter.h"
+#include "node.h"
 
 CCVS::CCVS()
 {

--- a/qucs/components/comp_1bit.cpp
+++ b/qucs/components/comp_1bit.cpp
@@ -18,6 +18,7 @@
 #include "comp_1bit.h"
 #include "node.h"
 #include "misc.h"
+#include "node.h"
 
 comp_1bit::comp_1bit()
 {

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -26,6 +26,7 @@
 #include "main.h"
 #include "schematic.h"
 #include "module.h"
+#include "node.h"
 #include "misc.h"
 
 #include <QPen>

--- a/qucs/components/eqndefined.cpp
+++ b/qucs/components/eqndefined.cpp
@@ -18,6 +18,7 @@
 #include "main.h"
 #include "extsimkernels/spicecompat.h"
 #include "extsimkernels/verilogawriter.h"
+#include "node.h"
 
 #include <QString>
 #include <QStringList>

--- a/qucs/components/equation.cpp
+++ b/qucs/components/equation.cpp
@@ -21,6 +21,7 @@
 
 #include <QFontInfo>
 #include <QFontMetrics>
+#include <QRegularExpression>
 
 Equation::Equation()
 {

--- a/qucs/components/gyrator.cpp
+++ b/qucs/components/gyrator.cpp
@@ -18,6 +18,7 @@
 #include "gyrator.h"
 #include "node.h"
 #include "extsimkernels/spicecompat.h"
+#include "node.h"
 
 
 Gyrator::Gyrator()

--- a/qucs/components/inductor.cpp
+++ b/qucs/components/inductor.cpp
@@ -18,6 +18,7 @@
 #include "inductor.h"
 #include "extsimkernels/spicecompat.h"
 #include "extsimkernels/verilogawriter.h"
+#include "node.h"
 
 
 Inductor::Inductor()

--- a/qucs/components/jk_flipflop.cpp
+++ b/qucs/components/jk_flipflop.cpp
@@ -17,6 +17,8 @@
 #include "jk_flipflop.h"
 #include "node.h"
 #include "misc.h"
+#include "node.h"
+
 
 JK_FlipFlop::JK_FlipFlop()
 {

--- a/qucs/components/resistor.cpp
+++ b/qucs/components/resistor.cpp
@@ -17,6 +17,7 @@
 #include "resistor.h"
 #include "extsimkernels/spicecompat.h"
 #include "extsimkernels/verilogawriter.h"
+#include "node.h"
 
 
 Resistor::Resistor(bool european)

--- a/qucs/components/subcircuit.cpp
+++ b/qucs/components/subcircuit.cpp
@@ -20,6 +20,7 @@
 #include "main.h"
 #include "misc.h"
 #include "schematic.h"
+#include "node.h"
 
 #include <QFileInfo>
 #include <QMutex>

--- a/qucs/components/vccs.cpp
+++ b/qucs/components/vccs.cpp
@@ -18,6 +18,7 @@
 #include "vccs.h"
 #include "extsimkernels/spicecompat.h"
 #include "extsimkernels/verilogawriter.h"
+#include "node.h"
 
 VCCS::VCCS()
 {

--- a/qucs/components/vcvs.cpp
+++ b/qucs/components/vcvs.cpp
@@ -18,6 +18,7 @@
 #include "vcvs.h"
 #include "extsimkernels/spicecompat.h"
 #include "extsimkernels/verilogawriter.h"
+#include "node.h"
 
 
 VCVS::VCVS()

--- a/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/diagrams/diagramdialog.cpp
@@ -26,6 +26,7 @@
 #include "main.h"
 #include "misc.h"
 #include "settings.h"
+#include "extsimkernels/spicecompat.h"
 
 #include <cmath>
 #include <assert.h>

--- a/qucs/dialogs/librarydialog.cpp
+++ b/qucs/dialogs/librarydialog.cpp
@@ -41,14 +41,13 @@
 #include <QHBoxLayout>
 #include <QStackedWidget>
 #include <QGroupBox>
-#include <QDebug>
 #include <QStringList>
 
 #include "librarydialog.h"
 #include "main.h"
-#include "schematic.h"
+#include "painting.h"
 #include "extsimkernels/abstractspicekernel.h"
-//#include "extsimkernels/xspice_cmbuilder.h"
+#include "extsimkernels/spicecompat.h"
 
 extern SubMap FileList;
 

--- a/qucs/dialogs/sweepdialog.cpp
+++ b/qucs/dialogs/sweepdialog.cpp
@@ -22,12 +22,14 @@
 #include "main.h"
 #include "../diagrams/graph.h"
 #include "misc.h"
+#include "component.h"
+#include "wire.h"
+
 
 #include <QLabel>
 #include <QLineEdit>
 #include <QValidator>
 #include <QPushButton>
-#include <QDebug>
 
 // SpinBoxes are used to show the calculated bias points at the given set of sweep points
 mySpinBox::mySpinBox(int Min, int Max, int Step, double *Val, QWidget *Parent)

--- a/qucs/extsimkernels/CdlNetlistWriter.cpp
+++ b/qucs/extsimkernels/CdlNetlistWriter.cpp
@@ -22,6 +22,7 @@
 #include "abstractspicekernel.h"
 
 #include "schematic.h"
+#include "component.h"
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -28,6 +28,7 @@
 #include "../paintings/id_text.h"
 #include "dialogs/sweepdialog.h"
 #include "components/subcircuit.h"
+#include "wire.h"
 
 
 #include <QPlainTextEdit>

--- a/qucs/extsimkernels/abstractspicekernel.h
+++ b/qucs/extsimkernels/abstractspicekernel.h
@@ -28,6 +28,7 @@
 #include <QProcess>
 
 #include "schematic.h"
+#include "extsimkernels/spicecompat.h"
 
 class QPlainTextEdit;
 

--- a/qucs/extsimkernels/customsimdialog.cpp
+++ b/qucs/extsimkernels/customsimdialog.cpp
@@ -20,6 +20,7 @@
 #include "main.h"
 #include "customsimdialog.h"
 #include "node.h"
+#include "wire.h"
 
 /*!
   \file customsimdialog.cpp

--- a/qucs/extsimkernels/externsimdialog.cpp
+++ b/qucs/extsimkernels/externsimdialog.cpp
@@ -21,9 +21,7 @@
 
 #include "settings.h"
 #include "externsimdialog.h"
-#include "simsettingsdialog.h"
 #include "main.h"
-#include "qucs.h"
 
 ExternSimDialog::ExternSimDialog(Schematic* sch, bool netlist2Console, bool netlist_mode) :
     QDialog(sch),

--- a/qucs/extsimkernels/externsimdialog.h
+++ b/qucs/extsimkernels/externsimdialog.h
@@ -20,10 +20,10 @@
 
 #include <QtGui>
 
-#include "schematic.h"
 #include "ngspice.h"
 #include "xyce.h"
-#include "spicecompat.h"
+
+class Schematic;
 
 class ExternSimDialog : public QDialog
 {

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -28,6 +28,8 @@
 #include "misc.h"
 #include "qucs.h"
 #include "settings.h"
+#include "node.h"
+#include "wire.h"
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/qucs/extsimkernels/verilogawriter.cpp
+++ b/qucs/extsimkernels/verilogawriter.cpp
@@ -24,6 +24,9 @@
 #include "verilogawriter.h"
 #include <QPlainTextEdit>
 #include "paintings/id_text.h"
+#include "component.h"
+#include "node.h"
+#include "schematic.h"
 
 /*!
   \file verilogawriter.cpp

--- a/qucs/extsimkernels/verilogawriter.h
+++ b/qucs/extsimkernels/verilogawriter.h
@@ -26,8 +26,8 @@
 #include <QString>
 #include <QStringList>
 #include <QTextStream>
-#include <schematic.h>
-#include <QRegularExpression>
+
+class Schematic;
 
 /*!
   \file verilogawriter.h

--- a/qucs/extsimkernels/xyce.cpp
+++ b/qucs/extsimkernels/xyce.cpp
@@ -20,6 +20,8 @@
 #include "components/equation.h"
 #include "main.h"
 #include "misc.h"
+#include "node.h"
+#include "wire.h"
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -36,6 +36,8 @@
 #include "main.h"
 #include "module.h"
 #include "node.h"
+#include "painting.h"
+#include "wire.h"
 #include "qucs.h"
 #include "schematic.h"
 #include "spicecomponents/sp_customsim.h"

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -73,8 +73,6 @@
 #include "dialogs/simmessage.h"
 #include "dialogs/exportdialog.h"
 #include "dialogs/displaydialog.h"
-//#include "dialogs/vtabwidget.h"
-//#include "dialogs/vtabbeddockwidget.h"
 #include "extsimkernels/externsimdialog.h"
 #include "dialogs/tuner.h"
 #include "octave_window.h"
@@ -85,8 +83,8 @@
 #include "extsimkernels/verilogawriter.h"
 #include "extsimkernels/CdlNetlistWriter.h"
 #include "extsimkernels/simsettingsdialog.h"
-//#include "extsimkernels/codemodelgen.h"
 #include "symbolwidget.h"
+#include "diagram.h"
 
 QucsApp::QucsApp(bool netlist2Console) :
   a_netlist2Console(netlist2Console)

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -59,6 +59,10 @@
 #include "dialogs/importdialog.h"
 #include "dialogs/aboutdialog.h"
 #include "module.h"
+#include "diagram.h"
+#include "node.h"
+#include "wirelabel.h"
+#include "wire.h"
 
 #include "extsimkernels/xyce.h"
 

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -52,6 +52,7 @@
 #include "main.h"
 #include "mouseactions.h"
 #include "node.h"
+#include "wire.h"
 #include "paintings/paintings.h"
 #include "schematic.h"
 #include "settings.h"

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -27,18 +27,12 @@
 #  define prechecked_cast dynamic_cast
 #endif
 
-#include "wire.h"
-#include "node.h"
 #include "qucsdoc.h"
-#include "diagrams/diagram.h"
-#include "paintings/painting.h"
-#include "components/component.h"
 #include "wire_planner.h"
 
 #include "qt3_compat/q3scrollview.h"
 #include <QVector>
 #include <QStringList>
-#include <QFileInfo>
 
 class QTextStream;
 class QTextEdit;
@@ -50,6 +44,16 @@ class QWheelEvent;
 class QMouseEvent;
 class QDragEnterEvent;
 class QPainter;
+
+class Element;
+class Component;
+class Conductor;
+class Diagram;
+class Marker;
+class Node;
+class Painting;
+class Wire;
+class WireLabel;
 
 // digital signal data
 struct DigSignal {

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -23,6 +23,10 @@
 #include "portsymbol.h"
 #include "schematic.h"
 #include "settings.h"
+#include "component.h"
+#include "diagram.h"
+#include "node.h"
+#include "wire.h"
 
 #include <ranges>
 #include <set>

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -31,6 +31,7 @@
 
 #include "main.h"
 #include "node.h"
+#include "wire.h"
 #include "schematic.h"
 #include "diagrams/diagrams.h"
 #include "paintings/paintings.h"

--- a/qucs/spicecomponents/S4Q_Ieqndef.cpp
+++ b/qucs/spicecomponents/S4Q_Ieqndef.cpp
@@ -18,6 +18,7 @@
 #include "S4Q_Ieqndef.h"
 #include "extsimkernels/spicecompat.h"
 #include "extsimkernels/verilogawriter.h"
+#include "node.h"
 
 
 S4Q_Ieqndef::S4Q_Ieqndef()

--- a/qucs/spicecomponents/src_eqndef.cpp
+++ b/qucs/spicecomponents/src_eqndef.cpp
@@ -1,6 +1,7 @@
 #include "src_eqndef.h"
 #include "extsimkernels/spicecompat.h"
 #include "extsimkernels/verilogawriter.h"
+#include "node.h"
 
 
 Src_eqndef::Src_eqndef()

--- a/qucs/wire.cpp
+++ b/qucs/wire.cpp
@@ -18,6 +18,7 @@
 #include "multi_point.h"
 #include "one_point.h"
 #include "schematic.h"
+#include "node.h"
 
 #include <QPainter>
 


### PR DESCRIPTION
Hi! `schematic.h` is included in many places, so I decided to clean up a bit its own includes to reduce the number of cases when other files are recompiled due to changes in "transitive" includes made via `schematic.h`