### PR TITLE
Fix for issues 1223 regarding CDL netlisting

### DIFF
--- a/qucs/dialogs/librarydialog.cpp
+++ b/qucs/dialogs/librarydialog.cpp
@@ -509,7 +509,7 @@ void LibraryDialog::slotSave()
                                 "Check these components: %2 \n")
                     .arg(Doc->getDocName()).arg(err_lst.join("; ")));
         }
-        kern->createSubNetlsit(ts,true);
+        kern->createSubNetlist(ts,true);
         intoStream(Stream, tmp, "Spice");
 
         QStringList libs = kern->collectSpiceLibraryFiles(Doc);

--- a/qucs/extsimkernels/CMakeLists.txt
+++ b/qucs/extsimkernels/CMakeLists.txt
@@ -20,6 +20,7 @@ s2spice.h
 spicelibcompdialog.h
 #xspice_cmbuilder.h
 #codemodelgen.h
+CdlSettingsDialog.h
 )
 
 SET(EXTSIMKERNELS_SRCS
@@ -37,6 +38,7 @@ s2spice.cpp
 spicelibcompdialog.cpp
 #xspice_cmbuilder.cpp
 #codemodelgen.cpp
+CdlSettingsDialog.cpp
 )
 
 SET(EXTSIMKERNELS_MOC_HDRS
@@ -47,6 +49,7 @@ xyce.h
 customsimdialog.h
 simsettingsdialog.h
 spicelibcompdialog.h
+CdlSettingsDialog.h
 )
 
 QT6_WRAP_CPP( EXTSIMKERNELS_MOC_SRCS ${EXTSIMKERNELS_MOC_HDRS} )

--- a/qucs/extsimkernels/CdlNetlistWriter.h
+++ b/qucs/extsimkernels/CdlNetlistWriter.h
@@ -21,13 +21,16 @@
 #ifndef CDL_NETLIST_WRITER_H
 #define CDL_NETLIST_WRITER_H
 
-class QTextStream;
+#include <QMap>
+#include <QStringList>
+#include <QTextStream>
+
 class Schematic;
 
 class CdlNetlistWriter
 {
 public:
-    CdlNetlistWriter(QTextStream& netlistStream, Schematic* schematic);
+    CdlNetlistWriter(QTextStream& netlistStream, Schematic* schematic, bool resolveSpicePrefix);
     ~CdlNetlistWriter() {};
 
     bool write();
@@ -35,9 +38,15 @@ public:
 private:
     int prepareNetlist();
     void startNetlist();
+    void resolveNetListContinuation(QStringList& netList);
+    void resolveSpicePrefix();
 
     QTextStream& a_netlistStream;
     Schematic* a_schematic;
+    const bool a_resolveSpicePrefix;
+    QString a_netListString;
+    QTextStream a_netListStringStream;
+    QTextStream& a_effectiveNetlistStream;
 };
 
 #endif // CDL_NETLIST_WRITER_H

--- a/qucs/extsimkernels/CdlSettingsDialog.cpp
+++ b/qucs/extsimkernels/CdlSettingsDialog.cpp
@@ -1,0 +1,76 @@
+/*
+ * CdlSettingsDialog.cpp - Settings for the CDL netlisting
+ *
+ * This file is part of Qucs-s
+ *
+ * Qucs is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Qucs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include "CdlSettingsDialog.h"
+#include "main.h"
+#include "settings.h"
+
+CdlSettingsDialog::CdlSettingsDialog(QWidget *parent) :
+    QDialog(parent),
+    a_btnOK(new QPushButton(tr("Apply changes"))),
+    a_btnCancel(new QPushButton(tr("Cancel"))),
+    a_chkResolveSpicePrefix(new QCheckBox(tr("Resolve spice prefix")))
+{
+    a_chkResolveSpicePrefix->setChecked(_settings::Get().item<bool>("ResolveSpicePrefix"));
+
+    connect(a_btnOK,SIGNAL(clicked()),this,SLOT(slotApply()));
+    connect(a_btnCancel,SIGNAL(clicked()),this,SLOT(reject()));
+
+    QVBoxLayout *top = new QVBoxLayout;
+
+    QGroupBox *gbp = new QGroupBox(this);
+    gbp->setTitle(tr("CDL netlist settings"));
+    QVBoxLayout *top2 = new QVBoxLayout;
+    QHBoxLayout *h1 = new QHBoxLayout;
+    h1->addWidget(a_chkResolveSpicePrefix);
+    top2->addLayout(h1);
+
+    gbp->setLayout(top2);
+    top->addWidget(gbp);
+
+    QHBoxLayout *h2 = new QHBoxLayout;
+    h2->addWidget(a_btnOK);
+    h2->addWidget(a_btnCancel);
+    h2->addStretch(2);
+    top->addLayout(h2);
+
+    this->setLayout(top);
+    this->setFixedWidth(500);
+    this->setWindowTitle(tr("CDL Settings"));
+}
+
+void CdlSettingsDialog::slotApply()
+{
+    QucsSettings.ResolveSpicePrefix = a_chkResolveSpicePrefix->isChecked();
+    settingsManager& qs = _settings::Get();
+    qs.setItem<bool>("ResolveSpicePrefix", a_chkResolveSpicePrefix->isChecked());
+    accept();
+    saveApplSettings();
+}
+
+void CdlSettingsDialog::slotCancel()
+{
+    reject();
+}
+

--- a/qucs/extsimkernels/CdlSettingsDialog.h
+++ b/qucs/extsimkernels/CdlSettingsDialog.h
@@ -1,0 +1,45 @@
+/*
+ * CdlSettingsDialog.h - Settings for the CDL netlisting
+ *
+ * This file is part of Qucs-s
+ *
+ * Qucs is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Qucs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CDL_SETTINGS_DIALOG_H
+#define CDL_SETTINGS_DIALOG_H
+
+#include <QtGui>
+#include <QtWidgets>
+
+class CdlSettingsDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit CdlSettingsDialog(QWidget *parent = 0);
+
+private:
+    QPushButton *a_btnOK;
+    QPushButton *a_btnCancel;
+
+    QCheckBox *a_chkResolveSpicePrefix;
+
+private slots:
+    void slotApply();
+    void slotCancel();
+};
+
+#endif // CDL_SETTINGS_DIALOG_H

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -271,13 +271,13 @@ void AbstractSpiceKernel::createNetlist(QTextStream&, int ,QStringList&,
 }
 
 /*!
- * \brief AbstractSpiceKernel::createSubNetlsit Output Netlist with
+ * \brief AbstractSpiceKernel::createSubNetlist Output Netlist with
  *        Subcircuit header .SUBCKT
  * \param stream QTextStream that associated with spice netlist file
  * \param xyce Default is false. Should be set in true if netlist is
  *        prepared for Xyce simulator. For Ngspice should be false.
  */
-void AbstractSpiceKernel::createSubNetlsit(QTextStream &stream, bool lib)
+void AbstractSpiceKernel::createSubNetlist(QTextStream &stream, bool lib)
 {
     QString header;
     QString f = misc::properFileName(a_schematic->getDocName());

--- a/qucs/extsimkernels/abstractspicekernel.h
+++ b/qucs/extsimkernels/abstractspicekernel.h
@@ -91,7 +91,7 @@ public:
     ~AbstractSpiceKernel();
 
     bool checkSchematic(QStringList &incompat);
-    virtual void createSubNetlsit(QTextStream& stream, bool lib = false);
+    virtual void createSubNetlist(QTextStream& stream, bool lib = false);
 
     void parseNgSpiceSimOutput(QString ngspice_file,
                                QList< QList<double> > &sim_points,

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -457,7 +457,11 @@ int doNgspiceNetlist(QString schematicFileName, QString netlistFileName, bool ne
     return 0;
 }
 
-int doCdlNetlist(QString schematicFileName, QString netlistFileName, bool netlist2Console)
+int doCdlNetlist(
+        QString schematicFileName,
+        QString netlistFileName,
+        bool netlist2Console,
+        bool resolveSpicePrefix)
 {
     QucsSettings.DefaultSimulator = spicecompat::simNgspice;
     Module::registerModules();
@@ -501,7 +505,7 @@ int doCdlNetlist(QString schematicFileName, QString netlistFileName, bool netlis
         }
     }
 
-    CdlNetlistWriter cdlWriter(*netlistStream, schematic.get());
+    CdlNetlistWriter cdlWriter(*netlistStream, schematic.get(), resolveSpicePrefix);
     if (!cdlWriter.write())
     {
         QMessageBox::critical(
@@ -1075,6 +1079,7 @@ int main(int argc, char *argv[])
         },
         {"list-entries", QCoreApplication::translate("main", "list component entry formats for schematic and netlist")},
         {{"c", "netlist2Console"}, QCoreApplication::translate("main", "write netlist to console")},
+        {{"x", "spiceprefix"}, QCoreApplication::translate("main", "resolve spice prefix during netlist CDL")},
     });
 
     parser.process(cmdArgs);
@@ -1116,6 +1121,7 @@ int main(int argc, char *argv[])
     const bool xyce_flag(parser.isSet("xyce"));
     const bool run_flag(parser.isSet("run"));
     const bool netlist2Console(parser.isSet("netlist2Console"));
+    const bool spiceprefix(parser.isSet("spiceprefix"));
 
 #if 0
     std::cout << "Current cli values:" << std::endl;
@@ -1132,6 +1138,7 @@ int main(int argc, char *argv[])
     std::cout << "xyce_flag: " << xyce_flag << std::endl;
     std::cout << "run_flag: " << run_flag << std::endl;
     std::cout << "netlist2Console: " << netlist2Console << std::endl;
+    std::cout << "spiceprefix: " << spiceprefix << std::endl;
     std::cout << "icons: " << parser.isSet("icons") << std::endl;
     std::cout << "doc: " << parser.isSet("doc") << std::endl;
     std::cout << "list-entries: " << parser.isSet("list-entries") << std::endl;
@@ -1196,7 +1203,7 @@ int main(int argc, char *argv[])
                 }
                 else if (cdl_flag)
                 {
-                    return doCdlNetlist(inputfile, outputfile, netlist2Console);
+                    return doCdlNetlist(inputfile, outputfile, netlist2Console, spiceprefix);
                 }
                 else if (xyce_flag)
                 {

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -138,6 +138,7 @@ bool loadSettings()
     QucsSettings.OpenVAFExecutable = _settings::Get().item<QString>("OpenVAFExecutable");
 
     QucsSettings.RFLayoutExecutable = _settings::Get().item<QString>("RFLayoutExecutable");
+    QucsSettings.ResolveSpicePrefix = _settings::Get().item<bool>("ResolveSpicePrefix");
 
     QucsSettings.qucsWorkspaceDir.setPath(_settings::Get().item<QString>("QucsHomeDir"));
     QucsSettings.QucsWorkDir = QucsSettings.qucsWorkspaceDir;

--- a/qucs/main.h
+++ b/qucs/main.h
@@ -88,6 +88,7 @@ struct tQucsSettings {
   QString OctaveExecutable; // OctaveExecutable location
   QString QucsOctave; // OUCS_OCTAVE variable
   QString RFLayoutExecutable;
+  bool ResolveSpicePrefix;
 
   // registered filename extensions with program to open the file
   QStringList FileTypes;

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -85,10 +85,10 @@
 #include "extsimkernels/simsettingsdialog.h"
 #include "symbolwidget.h"
 #include "diagram.h"
+#include "extsimkernels/CdlSettingsDialog.h"
 
 QucsApp::QucsApp(bool netlist2Console) :
-  a_netlist2Console(netlist2Console),
-  a_resolveSpicePrefix(false)
+  a_netlist2Console(netlist2Console)
 {
   windowTitle = misc::getWindowTitle();
   setWindowTitle(windowTitle);
@@ -3590,9 +3590,10 @@ void QucsApp::slotSaveNetlist()
     }
 }
 
-void QucsApp::slotResolveSpicePrefixToggled(bool checked)
+void QucsApp::slotCdlSettings()
 {
-    a_resolveSpicePrefix = checked;
+    std::unique_ptr<CdlSettingsDialog> dlg(new CdlSettingsDialog(this));
+    dlg->exec();
 }
 
 void QucsApp::slotSaveCdlNetlist()
@@ -3607,7 +3608,7 @@ void QucsApp::slotSaveCdlNetlist()
             QString netlistString;
             {
                 QTextStream netlistStream(&netlistString);
-                CdlNetlistWriter cdlWriter(netlistStream, schematic, a_resolveSpicePrefix);
+                CdlNetlistWriter cdlWriter(netlistStream, schematic, QucsSettings.ResolveSpicePrefix);
                 if (!cdlWriter.write())
                 {
                     QMessageBox::critical(
@@ -3638,7 +3639,7 @@ void QucsApp::slotSaveCdlNetlist()
             if (netlistFile.open(QIODevice::WriteOnly))
             {
                 QTextStream netlistStream(&netlistFile);
-                CdlNetlistWriter cdlWriter(netlistStream, schematic, a_resolveSpicePrefix);
+                CdlNetlistWriter cdlWriter(netlistStream, schematic, QucsSettings.ResolveSpicePrefix);
                 if (!cdlWriter.write())
                 {
                     QMessageBox::critical(

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -87,7 +87,8 @@
 #include "diagram.h"
 
 QucsApp::QucsApp(bool netlist2Console) :
-  a_netlist2Console(netlist2Console)
+  a_netlist2Console(netlist2Console),
+  a_resolveSpicePrefix(false)
 {
   windowTitle = misc::getWindowTitle();
   setWindowTitle(windowTitle);
@@ -3589,6 +3590,11 @@ void QucsApp::slotSaveNetlist()
     }
 }
 
+void QucsApp::slotResolveSpicePrefixToggled(bool checked)
+{
+    a_resolveSpicePrefix = checked;
+}
+
 void QucsApp::slotSaveCdlNetlist()
 {
     if (!isTextDocument(DocumentTab->currentWidget()))
@@ -3601,7 +3607,7 @@ void QucsApp::slotSaveCdlNetlist()
             QString netlistString;
             {
                 QTextStream netlistStream(&netlistString);
-                CdlNetlistWriter cdlWriter(netlistStream, schematic);
+                CdlNetlistWriter cdlWriter(netlistStream, schematic, a_resolveSpicePrefix);
                 if (!cdlWriter.write())
                 {
                     QMessageBox::critical(
@@ -3632,7 +3638,7 @@ void QucsApp::slotSaveCdlNetlist()
             if (netlistFile.open(QIODevice::WriteOnly))
             {
                 QTextStream netlistStream(&netlistFile);
-                CdlNetlistWriter cdlWriter(netlistStream, schematic);
+                CdlNetlistWriter cdlWriter(netlistStream, schematic, a_resolveSpicePrefix);
                 if (!cdlWriter.write())
                 {
                     QMessageBox::critical(

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -192,6 +192,7 @@ private slots:
   void slotSimSettings();
   void slotSaveNetlist();
   void slotSaveCdlNetlist();
+  void slotResolveSpicePrefixToggled(bool checked);
   void slotAfterSpiceSimulation(ExternSimDialog *SimDlg);
   void slotBuildVAModule();
   /*void slotBuildXSPICEIfs(int mode = 0);
@@ -225,7 +226,7 @@ public:
           *projNew, *projOpen, *projDel, *projClose, *applSettings, *refreshSchPath,
           *editCut, *editCopy, *magAll, *magSel, *magOne, *magMinus, *filePrintFit, *tune,
           *symEdit, *intoH, *popH, *simulate, *save_netlist, *dpl_sch, *undo, *redo, *dcbias,
-          *saveCdlNetlist;
+          *saveCdlNetlist, *resolveSpicePrefix;
 
   QAction *exportAsImage;
 
@@ -449,7 +450,9 @@ private:
   void launchTool(const QString&, const QString&,
                   const QStringList& = QStringList(),bool qucs_tool = false); // tool, description and args
   friend class SaveDialog;
+
   QString lastExportFilename;
+  bool a_resolveSpicePrefix;
 };
 
 /** \brief Provide a template to declare singleton classes.

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -192,7 +192,7 @@ private slots:
   void slotSimSettings();
   void slotSaveNetlist();
   void slotSaveCdlNetlist();
-  void slotResolveSpicePrefixToggled(bool checked);
+  void slotCdlSettings();
   void slotAfterSpiceSimulation(ExternSimDialog *SimDlg);
   void slotBuildVAModule();
   /*void slotBuildXSPICEIfs(int mode = 0);
@@ -226,7 +226,7 @@ public:
           *projNew, *projOpen, *projDel, *projClose, *applSettings, *refreshSchPath,
           *editCut, *editCopy, *magAll, *magSel, *magOne, *magMinus, *filePrintFit, *tune,
           *symEdit, *intoH, *popH, *simulate, *save_netlist, *dpl_sch, *undo, *redo, *dcbias,
-          *saveCdlNetlist, *resolveSpicePrefix;
+          *saveCdlNetlist, *cdlSettings;
 
   QAction *exportAsImage;
 
@@ -452,7 +452,6 @@ private:
   friend class SaveDialog;
 
   QString lastExportFilename;
-  bool a_resolveSpicePrefix;
 };
 
 /** \brief Provide a template to declare singleton classes.

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -592,11 +592,10 @@ void QucsApp::initActions()
   saveCdlNetlist->setWhatsThis(tr(QString::fromUtf8("Save CDL netlist to %1").arg(a_netlist2Console ? "console" : "file").toLatin1().constData()));
   connect(saveCdlNetlist, SIGNAL(triggered()), SLOT(slotSaveCdlNetlist()));
 
-  resolveSpicePrefix = new QAction(tr("Resolve spice prefix"), this);
-  resolveSpicePrefix->setStatusTip(tr("Resolve spice prefix"));
-  resolveSpicePrefix->setWhatsThis(tr(QString::fromUtf8("Resolve spice prefix during netlist CDL").toLatin1().constData()));
-  resolveSpicePrefix->setCheckable(true);
-  connect(resolveSpicePrefix, SIGNAL(toggled(bool)), SLOT(slotResolveSpicePrefixToggled(bool)));
+  cdlSettings = new QAction(tr("CDL Settings..."), this);
+  cdlSettings->setStatusTip(tr("CDL Settings"));
+  cdlSettings->setWhatsThis(tr(QString::fromUtf8("CDL Settings").toLatin1().constData()));
+  connect(cdlSettings, SIGNAL(triggered()), SLOT(slotCdlSettings()));
 
   setMarker = new QAction(QIcon((":/bitmaps/svg/marker.svg")),	tr("Set Marker on Graph"), this);
   setMarker->setShortcut(Qt::CTRL|Qt::Key_B);
@@ -830,7 +829,7 @@ void QucsApp::initMenuBar()
   simMenu->addAction(save_netlist);
   simMenu->addSeparator();
   simMenu->addAction(saveCdlNetlist);
-  simMenu->addAction(resolveSpicePrefix);
+  simMenu->addAction(cdlSettings);
   simMenu->addSeparator();
   simMenu->addAction(simSettings);
 

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -592,6 +592,12 @@ void QucsApp::initActions()
   saveCdlNetlist->setWhatsThis(tr(QString::fromUtf8("Save CDL netlist to %1").arg(a_netlist2Console ? "console" : "file").toLatin1().constData()));
   connect(saveCdlNetlist, SIGNAL(triggered()), SLOT(slotSaveCdlNetlist()));
 
+  resolveSpicePrefix = new QAction(tr("Resolve spice prefix"), this);
+  resolveSpicePrefix->setStatusTip(tr("Resolve spice prefix"));
+  resolveSpicePrefix->setWhatsThis(tr(QString::fromUtf8("Resolve spice prefix during netlist CDL").toLatin1().constData()));
+  resolveSpicePrefix->setCheckable(true);
+  connect(resolveSpicePrefix, SIGNAL(toggled(bool)), SLOT(slotResolveSpicePrefixToggled(bool)));
+
   setMarker = new QAction(QIcon((":/bitmaps/svg/marker.svg")),	tr("Set Marker on Graph"), this);
   setMarker->setShortcut(Qt::CTRL|Qt::Key_B);
   setMarker->setStatusTip(tr("Sets a marker on a diagram's graph"));
@@ -822,7 +828,10 @@ void QucsApp::initMenuBar()
   simMenu->addAction(showMsg);
   simMenu->addAction(showNet);
   simMenu->addAction(save_netlist);
+  simMenu->addSeparator();
   simMenu->addAction(saveCdlNetlist);
+  simMenu->addAction(resolveSpicePrefix);
+  simMenu->addSeparator();
   simMenu->addAction(simSettings);
 
 

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -2035,7 +2035,7 @@ bool Schematic::createSubNetlist(QTextStream *stream, int& countInit,
           ErrText->insertPlainText(s);
           return false;
       }
-      kern->createSubNetlsit(*stream);
+      kern->createSubNetlist(*stream);
 
       delete kern;
   }


### PR DESCRIPTION
-Fixed unresolved subcircuit instance model name in CDL netlisting:
 As an optional post-processing step during CDL netlist export:

 1. Found all subcircuit instances in the current schematic.
 2. For every instance from 1. check whether the referenced subcircuit with the same number of pins exists in the current 
 schematic.
 4. For every instance from 2. where the subcircuit don’t exist do: a. Check whether the second letter of the instance name refer a CDL primitive device (R, C, L, M, Q, ...) c. If a. holds remove the first letter from the instance name for the CDL-netlisted instance name.

-Introduced command-line parameter and CDL settings dialog for resolve spice prefix parameter

-Fixed misleading function name