### PR TITLE
S-parameter viewer: Fixes

### DIFF
--- a/qucs-s-spar-viewer/polarplotwidget.cpp
+++ b/qucs-s-spar-viewer/polarplotwidget.cpp
@@ -611,3 +611,34 @@ double PolarPlotWidget::getFrequencyMultiplier() const {
   }
 }
 
+
+// Send settings to the main program
+PolarPlotWidget::AxisSettings PolarPlotWidget::getSettings() const {
+  AxisSettings settings;
+  settings.freqMin = fMinSpinBox->value();
+  settings.freqMax = fMaxSpinBox->value();
+  settings.freqUnit = fUnitComboBox->currentText();
+
+  settings.radius_min = rAxisMin->value();
+  settings.radius_max = rAxisMax->value();
+  settings.radius_div = rAxisDiv->value();
+
+  settings.marker_format = displayModeCombo->currentText();
+
+  return settings;
+}
+
+// Get settings from the main program
+void PolarPlotWidget::setSettings(const AxisSettings& settings) {
+  fMinSpinBox->setValue(settings.freqMin);
+  fMaxSpinBox->setValue(settings.freqMax);
+  fUnitComboBox->setCurrentText(settings.freqUnit);
+
+  rAxisMin->setValue(settings.radius_min);
+  rAxisMax->setValue(settings.radius_max);
+  rAxisDiv->setValue(settings.radius_div);
+
+  displayModeCombo->setCurrentText(settings.marker_format);
+
+  update();
+}

--- a/qucs-s-spar-viewer/polarplotwidget.h
+++ b/qucs-s-spar-viewer/polarplotwidget.h
@@ -37,6 +37,22 @@ public:
     QPen pen;
   };
 
+  struct AxisSettings {
+    double freqMax;
+    double freqMin;
+    QString freqUnit;
+
+    double radius_min;
+    double radius_max;
+    double radius_div;
+
+    QString marker_format;
+
+  };
+
+  void setSettings(const AxisSettings& settings);
+  PolarPlotWidget::AxisSettings getSettings() const;
+
   explicit PolarPlotWidget(QWidget *parent = nullptr);
   ~PolarPlotWidget();
 

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -159,6 +159,7 @@ void Qucs_S_SPAR_Viewer::CreateRightPanel(){
   // Notes
   Notes_Widget = new CodeEditor();
   dockNotes = new QDockWidget("Notes", this);
+  dockNotes->setObjectName("dockNotes");
   dockNotes->setWidget(Notes_Widget);
 
   // Disable dock closing
@@ -195,6 +196,8 @@ void Qucs_S_SPAR_Viewer::CreateRightPanel(){
 void Qucs_S_SPAR_Viewer::setFileManagementDock(){
 
   dockFiles = new QDockWidget("S-parameter files", this);
+  dockFiles->setObjectName("dockFiles");
+
 
   QScrollArea *scrollArea_Files = new QScrollArea();
   FileList_Widget = new QWidget();
@@ -253,6 +256,7 @@ void Qucs_S_SPAR_Viewer::setFileManagementDock(){
 void Qucs_S_SPAR_Viewer::setTraceManagementDock(){
 
   dockTracesList = new QDockWidget("Traces List", this);
+  dockTracesList->setObjectName("TracesDock");
 
   QWidget * TracesGroup = new QWidget();
   QVBoxLayout *Traces_VBox = new QVBoxLayout(TracesGroup);
@@ -462,6 +466,7 @@ void Qucs_S_SPAR_Viewer::setTraceManagementDock(){
 void Qucs_S_SPAR_Viewer::setMarkerManagementDock() {
   // Markers dock
   dockMarkers = new QDockWidget("Markers", this);
+  dockMarkers->setObjectName("dockMarkers");
 
   QWidget* MarkersGroup = new QWidget();
   QVBoxLayout* Markers_VBox = new QVBoxLayout(MarkersGroup);
@@ -552,6 +557,8 @@ void Qucs_S_SPAR_Viewer::setMarkerManagementDock() {
 void Qucs_S_SPAR_Viewer::setLimitManagementDock(){
   // Limits dock
   dockLimits = new QDockWidget("Limits", this);
+  dockLimits->setObjectName("dockLimits");
+
 
   QWidget * LimitsGroup = new QWidget();
   QVBoxLayout *Limits_VBox = new QVBoxLayout(LimitsGroup);
@@ -636,6 +643,7 @@ void Qucs_S_SPAR_Viewer::CreateDisplayWidgets(){
   dockChart = new QDockWidget("Magnitude / Phase", this);
   dockChart->setWidget(Magnitude_PhaseChart);
   dockChart->setAllowedAreas(Qt::AllDockWidgetAreas);
+  dockChart->setObjectName("dockChart");
   addDockWidget(Qt::LeftDockWidgetArea, dockChart);
 
   // Smith Chart
@@ -644,6 +652,7 @@ void Qucs_S_SPAR_Viewer::CreateDisplayWidgets(){
   dockSmithChart = new QDockWidget("Smith", this);
   dockSmithChart->setWidget(smithChart);
   dockSmithChart->setAllowedAreas(Qt::AllDockWidgetAreas);
+  dockSmithChart->setObjectName("dockSmithChart");
   addDockWidget(Qt::LeftDockWidgetArea, dockSmithChart);
 
   // Polar Chart
@@ -652,6 +661,7 @@ void Qucs_S_SPAR_Viewer::CreateDisplayWidgets(){
   dockPolarChart = new QDockWidget("Polar", this);
   dockPolarChart->setWidget(polarChart);
   dockPolarChart->setAllowedAreas(Qt::AllDockWidgetAreas);
+  dockPolarChart->setObjectName("dockPolarChart");
   addDockWidget(Qt::LeftDockWidgetArea, dockPolarChart);
 
   // Port impedance chart settings
@@ -659,6 +669,7 @@ void Qucs_S_SPAR_Viewer::CreateDisplayWidgets(){
   dockImpedanceChart = new QDockWidget("Port Impedance", this);
   dockImpedanceChart->setWidget(impedanceChart);
   dockImpedanceChart->setAllowedAreas(Qt::AllDockWidgetAreas);
+  dockImpedanceChart->setObjectName("dockImpedanceChart");
   addDockWidget(Qt::LeftDockWidgetArea, dockImpedanceChart);
   impedanceChart->change_Y_axis_title(QString("Resistance (Ω)")); // Remove default labels
   impedanceChart->change_Y_axis_units(QString("Ω"));
@@ -670,6 +681,7 @@ void Qucs_S_SPAR_Viewer::CreateDisplayWidgets(){
   dockStabilityChart = new QDockWidget("Stability", this);
   dockStabilityChart->setWidget(stabilityChart);
   dockStabilityChart->setAllowedAreas(Qt::AllDockWidgetAreas);
+  dockStabilityChart->setObjectName("dockStabilityChart");
   addDockWidget(Qt::LeftDockWidgetArea, dockStabilityChart);
   stabilityChart->set_y_autoscale(false);
   stabilityChart->setRightYAxisEnabled(false); // Hide right y-axis
@@ -688,6 +700,7 @@ void Qucs_S_SPAR_Viewer::CreateDisplayWidgets(){
   dockVSWRChart = new QDockWidget("VSWR", this);
   dockVSWRChart->setWidget(VSWRChart);
   dockVSWRChart->setAllowedAreas(Qt::AllDockWidgetAreas);
+  dockVSWRChart->setObjectName("dockVSWRChart");
   addDockWidget(Qt::LeftDockWidgetArea, dockVSWRChart);
   VSWRChart->set_y_autoscale(false);
   VSWRChart->setRightYAxisEnabled(false); // Hide right y-axis
@@ -704,6 +717,7 @@ void Qucs_S_SPAR_Viewer::CreateDisplayWidgets(){
   dockGroupDelayChart = new QDockWidget("Group Delay", this);
   dockGroupDelayChart->setWidget(GroupDelayChart);
   dockGroupDelayChart->setAllowedAreas(Qt::AllDockWidgetAreas);
+  dockGroupDelayChart->setObjectName("dockGroupDelayChart");
   addDockWidget(Qt::LeftDockWidgetArea, dockGroupDelayChart);
   GroupDelayChart->change_Y_axis_title(QString("Time (ns)")); // Remove default labels
   GroupDelayChart->change_Y_axis_units(QString("ns"));
@@ -3732,7 +3746,6 @@ void Qucs_S_SPAR_Viewer::slotLoadSession()
                                                   tr("Open S-parameter Viewer Session"),
                                                   QDir::homePath(),
                                                   tr("Qucs-S snp viewer session (*.spar)"));
-
 
   loadSession(fileName);
 }

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -4511,7 +4511,7 @@ void Qucs_S_SPAR_Viewer::directoryChanged(const QString &path) {
   QStringList paths;
   for(const QString& file : newFiles) {
     const QString fullPath = dir.absoluteFilePath(file);
-    if(!filePaths.contains(fullPath)) {
+    if(!filePaths.contains(file)) {
       paths.append(fullPath);
     }
   }

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -3731,7 +3731,8 @@ void Qucs_S_SPAR_Viewer::slotLoadSession()
   QString fileName = QFileDialog::getOpenFileName(this,
                                                   tr("Open S-parameter Viewer Session"),
                                                   QDir::homePath(),
-                                                  tr("Qucs-S snp viewer session (*.spar);"));
+                                                  tr("Qucs-S snp viewer session (*.spar)"));
+
 
   loadSession(fileName);
 }
@@ -3862,6 +3863,7 @@ bool Qucs_S_SPAR_Viewer::save() {
   saveRectangularPlotSettings(xml, GroupDelayChart, "GroupDelayChartSettings");
 
   saveSmithPlotSettings(xml, smithChart, "SmithChartSettings");
+  savePolarPlotSettings(xml, polarChart, "PolarChartSettings");
 
   xml.writeEndElement(); // session
   xml.writeEndDocument();
@@ -4009,6 +4011,8 @@ void Qucs_S_SPAR_Viewer::loadSession(QString session_file) {
         loadRectangularPlotSettings(xml, GroupDelayChart, "GroupDelayChartSettings");
       } else if (xml.name() == QStringLiteral("SmithChartSettings")) {
         loadSmithPlotSettings(xml, smithChart, "SmithChartSettings");
+      } else if (xml.name() == QStringLiteral("PolarChartSettings")) {
+        loadPolarPlotSettings(xml, polarChart, "PolarChartSettings");
       }
 
     }
@@ -4934,6 +4938,74 @@ void Qucs_S_SPAR_Viewer::loadSmithPlotSettings(QXmlStreamReader &xml,
         settings.y_chart = (text == "true");
       } else if (name == QStringView(u"z_chart")) {
         settings.z_chart = (text == "true");
+      }
+    }
+    xml.readNext();
+  }
+
+  widget->setSettings(settings);
+  xml.readNext();
+}
+
+
+void Qucs_S_SPAR_Viewer::savePolarPlotSettings(QXmlStreamWriter &xml,
+                                               PolarPlotWidget *widget,
+                                               const QString &elementName)
+{
+  if (!widget) return;
+
+  auto settings = widget->getSettings();
+
+  xml.writeStartElement(elementName);
+
+  xml.writeTextElement("freqMin", QString::number(settings.freqMin));
+  xml.writeTextElement("freqMax", QString::number(settings.freqMax));
+  xml.writeTextElement("freqUnit", settings.freqUnit);
+
+  xml.writeTextElement("radius_min", QString::number(settings.radius_min));
+  xml.writeTextElement("radius_max", QString::number(settings.radius_max));
+  xml.writeTextElement("radius_div", QString::number(settings.radius_div));
+
+
+  xml.writeTextElement("marker_format", settings.marker_format);
+
+  xml.writeEndElement(); // elementName
+}
+
+
+void Qucs_S_SPAR_Viewer::loadPolarPlotSettings(QXmlStreamReader &xml,
+                                               PolarPlotWidget *widget,
+                                               const QString &elementName)
+{
+  if (!widget) return;
+
+  if (!(xml.isStartElement() && xml.name() == elementName)) {
+    // Not positioned at the correct start element, return early
+    return;
+  }
+  xml.readNext();
+  PolarPlotWidget::AxisSettings settings;
+
+         // Read inside the element until the corresponding end element
+  while (!(xml.tokenType() == QXmlStreamReader::EndElement)) {
+    if (xml.tokenType() == QXmlStreamReader::StartElement) {
+      QStringView name = xml.name();
+      QString text = xml.readElementText();
+
+      if (name == QStringView(u"freqMin")) {
+        settings.freqMin = text.toDouble();
+      } else if (name == QStringView(u"freqMax")) {
+        settings.freqMax = text.toDouble();
+      }  else if (name == QStringView(u"freqUnit")) {
+        settings.freqUnit = text;
+      }  else if (name == QStringView(u"radius_min")) {
+        settings.radius_min = text.toDouble();
+      } else if (name == QStringView(u"radius_max")) {
+        settings.radius_max = text.toDouble();
+      } else if (name == QStringView(u"radius_div")) {
+        settings.radius_div = text.toDouble();
+      } else if (name == QStringView(u"marker_format")) {
+        settings.marker_format = text;
       }
     }
     xml.readNext();

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -3861,6 +3861,7 @@ bool Qucs_S_SPAR_Viewer::save() {
   saveRectangularPlotSettings(xml, VSWRChart, "VSWRChartSettings");
   saveRectangularPlotSettings(xml, GroupDelayChart, "GroupDelayChartSettings");
 
+  saveSmithPlotSettings(xml, smithChart, "SmithChartSettings");
 
   xml.writeEndElement(); // session
   xml.writeEndDocument();
@@ -4006,6 +4007,8 @@ void Qucs_S_SPAR_Viewer::loadSession(QString session_file) {
         loadRectangularPlotSettings(xml, VSWRChart, "VSWRChartSettings");
       } else if (xml.name() == QStringLiteral("GroupDelayChartSettings")) {
         loadRectangularPlotSettings(xml, GroupDelayChart, "GroupDelayChartSettings");
+      } else if (xml.name() == QStringLiteral("SmithChartSettings")) {
+        loadSmithPlotSettings(xml, smithChart, "SmithChartSettings");
       }
 
     }
@@ -4867,6 +4870,70 @@ void Qucs_S_SPAR_Viewer::loadRectangularPlotSettings(QXmlStreamReader &xml,
         settings.showValues = (text == "true");
       } else if (name == QStringView(u"lockAxis")) {
         settings.lockAxis = (text == "true");
+      }
+    }
+    xml.readNext();
+  }
+
+  widget->setSettings(settings);
+  xml.readNext();
+}
+
+
+void Qucs_S_SPAR_Viewer::saveSmithPlotSettings(QXmlStreamWriter &xml,
+                                                     SmithChartWidget *widget,
+                                                     const QString &elementName)
+{
+  if (!widget) return;
+
+  auto settings = widget->getSettings();
+
+  xml.writeStartElement(elementName);
+
+  xml.writeTextElement("Z0", settings.Z0);
+  xml.writeTextElement("freqMin", QString::number(settings.freqMin));
+  xml.writeTextElement("freqMax", QString::number(settings.freqMax));
+  xml.writeTextElement("freqUnit", settings.freqUnit);
+
+
+  xml.writeTextElement("z_chart", settings.z_chart ? "true" : "false");
+  xml.writeTextElement("y_chart", settings.y_chart ? "true" : "false");
+
+  xml.writeEndElement(); // elementName
+}
+
+
+void Qucs_S_SPAR_Viewer::loadSmithPlotSettings(QXmlStreamReader &xml,
+                                                     SmithChartWidget *widget,
+                                                     const QString &elementName)
+{
+  if (!widget) return;
+
+  if (!(xml.isStartElement() && xml.name() == elementName)) {
+    // Not positioned at the correct start element, return early
+    return;
+  }
+  xml.readNext();
+  SmithChartWidget::AxisSettings settings;
+
+         // Read inside the element until the corresponding end element
+  while (!(xml.tokenType() == QXmlStreamReader::EndElement)) {
+    if (xml.tokenType() == QXmlStreamReader::StartElement) {
+      QStringView name = xml.name();
+      QString text = xml.readElementText();
+
+      if (name == QStringView(u"freqMin")) {
+        settings.freqMin = text.toDouble();
+      } else if (name == QStringView(u"freqMax")) {
+        settings.freqMax = text.toDouble();
+      }  else if (name == QStringView(u"freqUnit")) {
+        settings.freqUnit = text;
+      } else if (name == QStringView(u"Z0")) {
+        settings.Z0 = text;
+      } else if (name == QStringView(u"y_chart")) {
+        settings.y_chart = (text == "true");
+      } else if (name == QStringView(u"z_chart")) {
+        settings.z_chart = (text == "true");
       }
     }
     xml.readNext();

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.h
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.h
@@ -325,6 +325,9 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   void saveRectangularPlotSettings(QXmlStreamWriter &xml, RectangularPlotWidget *widget, const QString &elementName);
   void loadRectangularPlotSettings(QXmlStreamReader &xml, RectangularPlotWidget *widget, const QString &elementName);
 
+  void saveSmithPlotSettings(QXmlStreamWriter &xml, SmithChartWidget *widget, const QString &elementName);
+  void loadSmithPlotSettings(QXmlStreamReader &xml, SmithChartWidget *widget, const QString &elementName);
+
 
   // Notes
   QDockWidget *dockNotes;

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.h
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.h
@@ -328,6 +328,9 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   void saveSmithPlotSettings(QXmlStreamWriter &xml, SmithChartWidget *widget, const QString &elementName);
   void loadSmithPlotSettings(QXmlStreamReader &xml, SmithChartWidget *widget, const QString &elementName);
 
+  void savePolarPlotSettings(QXmlStreamWriter &xml, PolarPlotWidget *widget, const QString &elementName);
+  void loadPolarPlotSettings(QXmlStreamReader &xml, PolarPlotWidget *widget, const QString &elementName);
+
 
   // Notes
   QDockWidget *dockNotes;

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.h
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.h
@@ -321,6 +321,11 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   bool save();
   void loadSession(QString);
 
+  // Save rectangular plot settings
+  void saveRectangularPlotSettings(QXmlStreamWriter &xml, RectangularPlotWidget *widget, const QString &elementName);
+  void loadRectangularPlotSettings(QXmlStreamReader &xml, RectangularPlotWidget *widget, const QString &elementName);
+
+
   // Notes
   QDockWidget *dockNotes;
   CodeEditor *Notes_Widget;

--- a/qucs-s-spar-viewer/rectangularplotwidget.cpp
+++ b/qucs-s-spar-viewer/rectangularplotwidget.cpp
@@ -986,3 +986,54 @@ bool RectangularPlotWidget::areAxisSettingsLocked() const
 void RectangularPlotWidget::set_y_autoscale(bool value){
   y_autoscale = value;
 }
+
+
+// Send settings to the main program
+RectangularPlotWidget::AxisSettings RectangularPlotWidget::getSettings() const {
+  AxisSettings settings;
+  settings.xAxisMin = xAxisMin->value();
+  settings.xAxisMax = xAxisMax->value();
+  settings.xAxisDiv = xAxisDiv->value();
+  settings.xAxisUnits = xAxisUnits->currentText();
+
+  settings.yAxisMin = yAxisMin->value();
+  settings.yAxisMax = yAxisMax->value();
+  settings.yAxisDiv = yAxisDiv->value();
+
+  settings.y2AxisMin = y2AxisMin->value();
+  settings.y2AxisMax = y2AxisMax->value();
+  settings.y2AxisDiv = y2AxisDiv->value();
+
+  settings.showValues = showValuesCheckbox->isChecked();
+  settings.lockAxis = lockAxisCheckbox->isChecked();
+
+  return settings;
+}
+
+// Get settings from the main program
+void RectangularPlotWidget::setSettings(const AxisSettings& settings) {
+  xAxisMin->setValue(settings.xAxisMin);
+  xAxisMax->setValue(settings.xAxisMax);
+  xAxisDiv->setValue(settings.xAxisDiv);
+  int index = xAxisUnits->findText(settings.xAxisUnits);
+  if (index != -1) {
+    xAxisUnits->setCurrentIndex(index);
+  }
+
+  yAxisMin->setValue(settings.yAxisMin);
+  yAxisMax->setValue(settings.yAxisMax);
+  yAxisDiv->setValue(settings.yAxisDiv);
+
+  y2AxisMin->setValue(settings.y2AxisMin);
+  y2AxisMax->setValue(settings.y2AxisMax);
+  y2AxisDiv->setValue(settings.y2AxisDiv);
+
+  showValuesCheckbox->setChecked(settings.showValues);
+  lockAxisCheckbox->setChecked(settings.lockAxis);
+
+         // Update axes to reflect new settings
+  updateXAxis();
+  updateYAxis();
+  updateY2Axis();
+  updatePlot();
+}

--- a/qucs-s-spar-viewer/rectangularplotwidget.cpp
+++ b/qucs-s-spar-viewer/rectangularplotwidget.cpp
@@ -119,7 +119,7 @@ void RectangularPlotWidget::addTrace(const QString& name, const Trace& trace)
         yAxisMin->setValue(y_min);
         yAxisMax->setValue(y_max);
         double y_step = round((y_max - y_min)/10);
-        y_step = floor(y_step / 5) * 5; // round to 5
+        y_step = ceil(y_step / 5) * 5; // round to 5
         yAxisDiv->setValue(y_step);
 
       }
@@ -492,7 +492,7 @@ void RectangularPlotWidget::updateYAxis()
   double yMax = yAxisMax->value();
   double yDiv = yAxisDiv->value();
 
-  double min_step = (yMax-yMin)/10;
+  double min_step = (yMax-yMin)/20;
 
   if (yDiv < min_step) {
     // Avoid excessive ticking

--- a/qucs-s-spar-viewer/rectangularplotwidget.h
+++ b/qucs-s-spar-viewer/rectangularplotwidget.h
@@ -17,6 +17,10 @@
 #include <complex>
 #include <limits>
 
+
+
+
+
 class RectangularPlotWidget : public QWidget
 {
   Q_OBJECT
@@ -45,6 +49,25 @@ public:
     double y2; // End y
     int y_axis; // 0: Left y-axis; 1: Right y-axis
     QPen pen;
+  };
+
+  // Struct to exchange the widget settings with the main program
+  struct AxisSettings {
+    double xAxisMin;
+    double xAxisMax;
+    double xAxisDiv;
+    QString xAxisUnits;
+
+    double yAxisMin;
+    double yAxisMax;
+    double yAxisDiv;
+
+    double y2AxisMin;
+    double y2AxisMax;
+    double y2AxisDiv;
+
+    bool showValues;
+    bool lockAxis;
   };
 
   explicit RectangularPlotWidget(QWidget *parent = nullptr);
@@ -107,6 +130,10 @@ public:
   bool updateLimit(const QString& limitId, const Limit& limit);
 
   QChart *chart() const { return ChartWidget; }
+
+  // Exchange the settings with the main program
+  AxisSettings getSettings() const;
+  void setSettings(const AxisSettings& settings);
 
 private slots:
   void updateXAxis();

--- a/qucs-s-spar-viewer/smithchartwidget.cpp
+++ b/qucs-s-spar-viewer/smithchartwidget.cpp
@@ -907,6 +907,9 @@ void SmithChartWidget::onMinFreqChanged(double value)
   double minFreq = m_minFreqSpinBox->value();
   double maxFreq = m_maxFreqSpinBox->value();
 
+  m_maxFreqSpinBox->setMinimum(minFreq); // Update the minimum of the maximum freq
+
+
   if (minFreq > maxFreq) {
     m_minFreqSpinBox->blockSignals(true);
     m_minFreqSpinBox->setValue(maxFreq);
@@ -925,6 +928,8 @@ void SmithChartWidget::onMaxFreqChanged(double value)
   // Make sure max is greater than min
   double minFreq = m_minFreqSpinBox->value();
   double maxFreq = m_maxFreqSpinBox->value();
+
+  m_minFreqSpinBox->setMaximum(maxFreq); // Update the maximum of the minimum freq
   if (maxFreq < minFreq) {
     m_maxFreqSpinBox->blockSignals(true);
     m_maxFreqSpinBox->setValue(minFreq);
@@ -1057,4 +1062,30 @@ bool SmithChartWidget::updateMarkerFrequency(const QString& markerId, double new
   // Trigger repaint
   update();
   return true;
+}
+
+
+// Send settings to the main program
+SmithChartWidget::AxisSettings SmithChartWidget::getSettings() const {
+  AxisSettings settings;
+  settings.Z0 = m_Z0ComboBox->currentText();
+  settings.freqMin = m_minFreqSpinBox->value();
+  settings.freqMax = m_maxFreqSpinBox->value();
+  settings.freqUnit = m_freqUnitComboBox->currentText();
+
+  settings.z_chart = m_ShowConstantCurvesCheckBox->isChecked();
+  settings.y_chart = m_ShowAdmittanceChartCheckBox->isChecked();
+
+  return settings;
+}
+
+// Get settings from the main program
+void SmithChartWidget::setSettings(const AxisSettings& settings) {
+  m_Z0ComboBox->setCurrentText(settings.Z0);
+  m_minFreqSpinBox->setValue(settings.freqMin);
+  m_maxFreqSpinBox->setValue(settings.freqMax);
+  m_freqUnitComboBox->setCurrentText(settings.freqUnit);
+  m_ShowConstantCurvesCheckBox->setChecked(settings.z_chart);
+  m_ShowAdmittanceChartCheckBox->setChecked(settings.y_chart);
+  update();
 }

--- a/qucs-s-spar-viewer/smithchartwidget.h
+++ b/qucs-s-spar-viewer/smithchartwidget.h
@@ -54,6 +54,20 @@ public:
     QPen pen;
   };
 
+  struct AxisSettings {
+    QString Z0;
+
+    double freqMax;
+    double freqMin;
+    QString freqUnit;
+
+    bool y_chart;
+    bool z_chart;
+  };
+
+  SmithChartWidget::AxisSettings getSettings() const;
+  void setSettings(const AxisSettings& settings);
+
   SmithChartWidget(QWidget *parent = nullptr);
   ~SmithChartWidget() override;
 


### PR DESCRIPTION
This PR addresses some issues detected after merging PR #1309:

- Fix save / load feature
- When the user removes a file, ensure that the dataset is removed.
- Fix Rectangular plot y-axis autoscale
- Fix duplicate addition when a file was created in the directory the program is watching
- Add import / export functions to the chart widgets to save/load the specific settings of each viewer in/from the .xml file
- Assign object names to the docks in order to avoid warnings when saving the tool state.