### PR TITLE
Avoid double-layering wires in certain conditions

### DIFF
--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -347,7 +347,6 @@ Node* Schematic::provideNode(int x, int y)
         if (qucs_s::geom::is_between(new_node, wire->P1(), wire->P2())) {
             // split the wire into two wires
             splitWire(wire, new_node);
-            return new_node;
         }
     }
 


### PR DESCRIPTION
Hi! This is a tiny fix of behaviour displayed in the video:


https://github.com/user-attachments/assets/60b473f6-d48f-4c42-84c0-8e83a545d0a2

The algorithm for providing a node at location is designed in a way that if a newly created node lies above one or more wires, only one of the wires is split by the node. In some conditions this can lead to double-layering of wires.

This PR removes "early exit" after the first splitting of a wire and makes all wires be considered for splitting.

But I'm in doubt: though described wire configuration looks confusing, it's nevertheless correct. I personally think it's better to go with this patch to avoid such cases at all.