### PR TITLE
Project view: Open files with the system default program

### DIFF
--- a/qucs-s-spar-viewer/main.cpp
+++ b/qucs-s-spar-viewer/main.cpp
@@ -104,11 +104,22 @@ int main( int argc, char ** argv )
 
   Qucs_S_SPAR_Viewer *qucs = new Qucs_S_SPAR_Viewer();
 
-  if (argc > 1) { // File directory to watch
+  if (argc > 1) { // File or directory path to watch
     QString path = QString(argv[1]);
-    qucs->addPathToWatcher(path);
-  }
+    QFileInfo fileInfo(path);
 
+    if (fileInfo.exists()) {
+      if (fileInfo.isDir()) {
+        // It's a directory
+        qucs->addPathToWatcher(path);
+      } else if (fileInfo.isFile()) {
+        // It's a file
+        qucs->addFile(fileInfo);
+      }
+    } else {
+      QMessageBox::warning(qucs, "Path Error", "The specified path does not exist.");
+    }
+  }
   qucs->raise();
   qucs->move(QucsSettings.x, QucsSettings.y);  // position before "show" !!!
   qucs->show();

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -5027,3 +5027,19 @@ void Qucs_S_SPAR_Viewer::loadPolarPlotSettings(QXmlStreamReader &xml,
   widget->setSettings(settings);
   xml.readNext();
 }
+
+
+       // Wrapper of void "Qucs_S_SPAR_Viewer::addFiles(QStringList fileNames)". It is needed to open a Touchstone file from command line
+void Qucs_S_SPAR_Viewer::addFile(const QFileInfo& fileInfo) {
+  if (fileInfo.exists()) {
+    QStringList fileNames;
+    fileNames.append(fileInfo.absoluteFilePath());
+    addFiles(fileNames);
+  } else {
+    QMessageBox::warning(
+        this,
+        tr("Error"),
+        tr("The file or directory does not exist.")
+        );
+  }
+}

--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.h
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.h
@@ -122,6 +122,7 @@ class Qucs_S_SPAR_Viewer : public QMainWindow
   Qucs_S_SPAR_Viewer();
   ~Qucs_S_SPAR_Viewer();
   void addPathToWatcher(const QString &path); // It's needed to pass the directory to watch from the main program
+  void addFile(const QFileInfo& fileInfo); // The main qucs program uses this function to open a Touchstone file from the Project View
 
  private slots:
   void slotHelpIntro();

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -2864,6 +2864,17 @@ void QucsApp::slotOpenContent(const QModelIndex &idx)
     it++;
   }
 
+  // If no appropriate program was found, open in system default program.
+  QUrl fileUrl = QUrl::fromLocalFile(Info.absoluteFilePath());
+  if (QDesktopServices::openUrl(fileUrl)) {
+    // Success
+    return;
+  } else {
+    // If opening fails, optionally show an error message
+    QMessageBox::critical(this, tr("Error"),
+                          tr("Cannot open \"%1\" with the system default program!").arg(Info.absoluteFilePath()));
+  }
+
   // If no appropriate program was found, open as text file.
   editFile(Info.absoluteFilePath());  // open datasets with text editor
 }

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -2864,15 +2864,23 @@ void QucsApp::slotOpenContent(const QModelIndex &idx)
     it++;
   }
 
-  // If no appropriate program was found, open in system default program.
-  QUrl fileUrl = QUrl::fromLocalFile(Info.absoluteFilePath());
-  if (QDesktopServices::openUrl(fileUrl)) {
-    // Success
+  // If no appropriate program was found, open in system default program or, if it is a Touchstone file, open it in the S-parameter viewer.
+  if (extName == "s2p" || extName == "s3p" || extName == "s4p") {
+    QString file_path = Info.absoluteFilePath();
+    QStringList args;
+    args.append(file_path);
+    launchTool(QUCS_NAME "spar-viewer", "s-parameter viewer", args);
     return;
   } else {
-    // If opening fails, optionally show an error message
-    QMessageBox::critical(this, tr("Error"),
-                          tr("Cannot open \"%1\" with the system default program!").arg(Info.absoluteFilePath()));
+    QUrl fileUrl = QUrl::fromLocalFile(Info.absoluteFilePath());
+    if (QDesktopServices::openUrl(fileUrl)) {
+      // Success
+      return;
+    } else {
+      // If opening fails, optionally show an error message
+      QMessageBox::critical(this, tr("Error"),
+                            tr("Cannot open \"%1\" with the system default program!").arg(Info.absoluteFilePath()));
+    }
   }
 
   // If no appropriate program was found, open as text file.

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -2809,7 +2809,7 @@ void QucsApp::slotOpenContent(const QModelIndex &idx)
 
   if (extName == "sch" || extName == "dpl" || extName == "vhdl" ||
       extName == "vhd" || extName == "v" || extName == "va" ||
-      extName == "m" || extName == "oct") {
+      extName == "m" || extName == "oct" || extName == "net") {
     gotoPage(Info.absoluteFilePath());
     updateRecentFilesList(Info.absoluteFilePath());
     slotUpdateRecentFiles();

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -2868,7 +2868,7 @@ void QucsApp::slotOpenContent(const QModelIndex &idx)
   if (extName == "s2p" || extName == "s3p" || extName == "s4p") {
     QString file_path = Info.absoluteFilePath();
     QStringList args;
-    args.append(file_path);
+    args << file_path;
     launchTool(QUCS_NAME "spar-viewer", "s-parameter viewer", args);
     return;
   } else {


### PR DESCRIPTION
I've found that if a user double-clicks a file in the "Others" section of the Project View, Qucs-S loads the file as a text file.

As far as I know, Qucs-S tries to find a suitable program by inspecting QucsSettings (see: https://github.com/ra3xdh/qucs_s/blob/current/qucs/qucs.cpp#L2840). If it doesn't find a suitable application, it opens the file as a text file.

In this PR, I've added code to use QDesktopServices if the previous method fails. Additionally, Touchstone files are now opened with the Qucs-S S-parameter viewer.

**Before this PR**

https://github.com/user-attachments/assets/478a21e4-6b74-4e2c-b9d6-fbab5019abdb

**After this PR**

https://github.com/user-attachments/assets/8d4b21e2-b671-45ff-8126-e340c6081da0




