### PR TITLE
Fix crash when deleting label after wire merge

### DIFF
--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -437,11 +437,16 @@ Wire* merge_wires_at_node(Node* node) {
     // First of all, let's deal with labels. Label of node, if present, has
     // priority over wire labels.
     auto* preserved_label = node->Label;
-    node->Label = nullptr;
+
     if (preserved_label == nullptr) {
         // Node has no label, choose label of one of the wires
         preserved_label = extended_wire->Label == nullptr ? dissapearing_wire->Label : extended_wire->Label;
-        dissapearing_wire->Label = nullptr;
+    }
+
+    // Isolate preserved label completely
+    if (preserved_label != nullptr) {
+        preserved_label->pOwner->Label = nullptr;
+        preserved_label->pOwner = nullptr;
     }
 
     auto* extend_to = dissapearing_wire->Port1 == node
@@ -468,9 +473,10 @@ Wire* merge_wires_at_node(Node* node) {
     extended_wire->setP1(extended_wire->Port1->center());
     extended_wire->setP2(extended_wire->Port2->center());
 
-    if (preserved_label != extended_wire->Label) {
+    if (preserved_label != nullptr) {
         delete extended_wire->Label;
         extended_wire->Label = preserved_label;
+        preserved_label->pOwner = extended_wire;
     }
 
     return dissapearing_wire;

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -436,11 +436,11 @@ Wire* merge_wires_at_node(Node* node) {
 
     // First of all, let's deal with labels. Label of node, if present, has
     // priority over wire labels.
-    auto* label = node->Label;
+    auto* preserved_label = node->Label;
     node->Label = nullptr;
-    if (label == nullptr) {
+    if (preserved_label == nullptr) {
         // Node has no label, choose label of one of the wires
-        label = extended_wire->Label == nullptr ? dissapearing_wire->Label : extended_wire->Label;
+        preserved_label = extended_wire->Label == nullptr ? dissapearing_wire->Label : extended_wire->Label;
         dissapearing_wire->Label = nullptr;
     }
 
@@ -468,9 +468,9 @@ Wire* merge_wires_at_node(Node* node) {
     extended_wire->setP1(extended_wire->Port1->center());
     extended_wire->setP2(extended_wire->Port2->center());
 
-    if (label != extended_wire->Label) {
+    if (preserved_label != extended_wire->Label) {
         delete extended_wire->Label;
-        extended_wire->Label = label;
+        extended_wire->Label = preserved_label;
     }
 
     return dissapearing_wire;


### PR DESCRIPTION
How to reproduce the crash:
1. Draw a straight wire and attach a label to it
2. Draw another straight wire over the first one so it covers the first one completely
3. Select and delete the label
4. See crash 