### PR TITLE
Fix incorrect default diode model parameters in .MODEL Section component

### DIFF
--- a/qucs/spicecomponents/sp_model.cpp
+++ b/qucs/spicecomponents/sp_model.cpp
@@ -51,7 +51,7 @@ S4Q_Model::S4Q_Model()
   Name  = "SpiceModel";
   SpiceModel = ".MODEL";
 
-  Props.append(new Property("Line_1", ".MODEL DIODE1 D(BF=50 Is=1e-13 Vbf = 50)", true,"Model statement"));
+  Props.append(new Property("Line_1", ".MODEL DIODE1 D(BV=50 Is=1e-13 N = 1.5)", true,"Model statement"));
   Props.append(new Property("Line_2", "", false,"+ continuation line 1"));
   Props.append(new Property("Line_3", "", false,"+ continuation line 2"));
   Props.append(new Property("Line_4", "", false,"+ continuation line 3"));


### PR DESCRIPTION
The default diode model parameters in the `.MODEL Section` component contained ngspice-incompatible parameters 'BF' and 'Vbf' . This caused warnings during simulation:

![изображение](https://github.com/user-attachments/assets/d48d2e14-1f70-43f2-8a16-52e97a94800c)


This commit replaces:
- 'bf' with 'bv' parameter (Reverse breakdown voltage)
- 'vbf' with 'n' parameter (Emission coefficient)

The new default model is:
.model DIODE1 D (bv=50 is=1e-13 n=1.5)