### PR TITLE
Fix BJT and MOSFET qucsator netlist generation

### DIFF
--- a/qucs/components/bjt.cpp
+++ b/qucs/components/bjt.cpp
@@ -145,8 +145,12 @@ QString BJT::netlist()
   s += " "+Ports.at(1)->Connection->Name;  // connect substrate to collector
 
   // output all properties
-  for(const auto& p2 : Props)
+  for(const auto& p2 : Props) {
+    if (p2->Name == QString("UseGlobTemp")) {
+      continue;
+    }
     s += " "+p2->Name+"=\""+p2->Value+"\"";
+  }
 
   return s + '\n';
 }

--- a/qucs/components/mosfet.cpp
+++ b/qucs/components/mosfet.cpp
@@ -134,9 +134,12 @@ QString MOSFET::netlist()
   s += " "+Ports.at(2)->Connection->Name;  // connect substrate to source
 
   // output all properties
-  for(Property *p2 : Props)
+  for(Property *p2 : Props) {
+    if (p2->Name == QString("UseGlobTemp")) {
+      continue;
+    }
     s += " "+p2->Name+"=\""+p2->Value+"\"";
-
+  }
   return s + '\n';
 }
 


### PR DESCRIPTION
I've noticed that the Qucs-S examples with BJT and MOSFET devices do not work in qucsator.

I'm aware that one shouldn't use qucsator for these devices... Anyway, I fixed the netlist generation to skip the "UseGlobTemp" which qucsator seems not to understand and crashes.

**Steps to reproduce**

1) Open "examples/qucsator/single_balanced.sch" (MOSFET) or "examples/qucsator/classic_osci.sch" (BJT)

![Selection_021](https://github.com/user-attachments/assets/6a9cce3a-709f-43ad-b540-27c4b82b9bd6)

![Selection_022](https://github.com/user-attachments/assets/a8b5ec9e-742b-470e-8a45-f8a3bb5bf369)

