### PR TITLE
Add a context menu to documents tabs

### DIFF
--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -3837,6 +3837,33 @@ void QucsApp::slotSearchLibClear()
     slotSearchLibComponent("");
 }
 
+// Close all documents except the current one
+void QucsApp::slotFileCloseOthers()
+{
+  closeAllFiles(DocumentTab->currentIndex());
+}
+
+// Close all documents to the left of the current one
+void QucsApp::slotFileCloseAllLeft()
+{
+  closeAllLeft(DocumentTab->currentIndex());
+}
+
+// Close all documents to the right of the current one
+void QucsApp::slotFileCloseAllRight()
+{
+  closeAllRight(DocumentTab->currentIndex());
+}
+
+// Close all documents
+void QucsApp::slotFileCloseAll()
+{
+  // close all tabs
+  closeAllFiles();
+  // create empty schematic
+  slotFileNew();
+}
+
 QVariant QucsFileSystemModel::data( const QModelIndex& index, int role ) const
 {
     if (role == Qt::DecorationRole) { // it's an icon
@@ -3957,10 +3984,7 @@ void ContextMenuTabWidget::slotCxMenuCloseRight()
 
 void ContextMenuTabWidget::slotCxMenuCloseAll()
 {
-  // close all tabs
-  App->closeAllFiles();
-  // create empty schematic
-  App->slotFileNew();
+  App->slotFileCloseAll();
 }
 
 void ContextMenuTabWidget::slotCxMenuCopyPath()

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -3922,6 +3922,9 @@ void ContextMenuTabWidget::showContextMenu(const QPoint& point)
     APPEND_MENU(ActionCxMenuCloseOthers, slotCxMenuCloseLeft, "Close all to the left")
     APPEND_MENU(ActionCxMenuCloseOthers, slotCxMenuCloseRight, "Close all to the right")
     APPEND_MENU(ActionCxMenuCloseAll, slotCxMenuCloseAll, "Close all")
+    menu.addSeparator();
+    APPEND_MENU(ActionCxMenuCopyPath, slotCxMenuCopyPath, "Copy full path")
+    APPEND_MENU(ActionCxMenuOpenFolder, slotCxMenuOpenFolder, "Open containing folder")
 #undef APPEND_MENU
 
     menu.exec(tabBar()->mapToGlobal(point));
@@ -3958,4 +3961,25 @@ void ContextMenuTabWidget::slotCxMenuCloseAll()
   App->closeAllFiles();
   // create empty schematic
   App->slotFileNew();
+}
+
+void ContextMenuTabWidget::slotCxMenuCopyPath()
+{
+  // get the document where the context menu was opened
+  QucsDoc *d = App->getDoc(contextTabIndex);
+  // copy the document full path to the clipboard
+  QClipboard *cb = QApplication::clipboard();
+  cb->setText(d->getDocName());
+}
+
+void ContextMenuTabWidget::slotCxMenuOpenFolder()
+{
+  // get the document where the context menu was opened
+  QucsDoc *d = App->getDoc(contextTabIndex);
+  QString dName = d->getDocName();
+  // a not-yet-saved document does not have a DocName
+  if (!dName.isEmpty()) {
+    QFileInfo Info(dName);
+    QDesktopServices::openUrl(QUrl::fromLocalFile(Info.canonicalPath()));
+  }
 }

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -2021,6 +2021,19 @@ void QucsApp::closeFile(int index)
  */
 bool QucsApp::closeAllFiles(int exceptTab)
 {
+  return closeTabsRange(0, DocumentTab->count()-1, exceptTab);
+}
+
+/**
+ * @brief close Tabs in a specified range, optionally skipping a specified one
+ * @param startTab first tab to be closed
+ * @param stoptTab last tab to be closed
+ * @param exceptTab tab to leave open, none if not specified
+ */
+bool QucsApp::closeTabsRange(int startTab, int stopTab, int exceptTab)
+{
+  if (stopTab < startTab)
+    return false;
   // document to keep open, if any
   QucsDoc *docToKeep = 0;
   if (exceptTab >= 0) {
@@ -2029,33 +2042,55 @@ bool QucsApp::closeAllFiles(int exceptTab)
 
   SaveDialog *sd = new SaveDialog(this);
   sd->setApp(this);
-  for(int i=0; i < DocumentTab->count(); ++i) {
+  Q_ASSERT(startTab >= 0);
+  Q_ASSERT(stopTab < DocumentTab->count());
+
+  for(int i=startTab; i <= stopTab; ++i) {
     QucsDoc *doc = getDoc(i);
     if ((doc->getDocChanged()) && (doc != docToKeep))
       sd->addUnsavedDoc(doc);
   }
   int Result = SaveDialog::DontSave;
   if(!sd->isEmpty())
-     Result = sd->exec();
+    Result = sd->exec();
   delete sd;
   if(Result == SaveDialog::AbortClosing)
     return false;
-  QucsDoc *doc = 0;
-
   // remove documents
+  QucsDoc *doc = 0;
+  QucsDoc *stopDoc = getDoc(stopTab);
   int i = 0;
-  while (i < DocumentTab->count()) {
-    if ((doc=getDoc(i)) == docToKeep) {
+  do {
+    doc = getDoc(startTab+i);
+    if (doc == docToKeep) {
       i++; // skip to next doc
     } else {
       delete doc;
     }
-  }
-
+  } while (doc != stopDoc);
 
   //switchEditMode(true);   // set schematic edit mode
   return true;
 }
+
+/**
+ * @brief close all documents to the left of the specified one
+ * @param index reference tab
+ */
+bool QucsApp::closeAllLeft(int index)
+{
+  return closeTabsRange(0, index-1);
+}
+
+/**
+ * @brief close all documents to the right of the specified one
+ * @param index reference tab
+ */
+bool QucsApp::closeAllRight(int index)
+{
+  return closeTabsRange(index+1, DocumentTab->count()-1);
+}
+
 
 void QucsApp::slotFileExamples() {
   statusBar()->showMessage(tr("Open example…"));
@@ -3883,7 +3918,9 @@ void ContextMenuTabWidget::showContextMenu(const QPoint& point)
     }
 
     APPEND_MENU(ActionCxMenuClose, slotCxMenuClose, "Close")
-    APPEND_MENU(ActionCxMenuCloseOthers, slotCxMenuCloseOthers, "Close other Tabs")
+    APPEND_MENU(ActionCxMenuCloseOthers, slotCxMenuCloseOthers, "Close all but this")
+    APPEND_MENU(ActionCxMenuCloseOthers, slotCxMenuCloseLeft, "Close all to the left")
+    APPEND_MENU(ActionCxMenuCloseOthers, slotCxMenuCloseRight, "Close all to the right")
     APPEND_MENU(ActionCxMenuCloseAll, slotCxMenuCloseAll, "Close all")
 #undef APPEND_MENU
 
@@ -3901,6 +3938,18 @@ void ContextMenuTabWidget::slotCxMenuCloseOthers()
 {
   // close all tabs, except the one where the context menu was opened
   App->closeAllFiles(contextTabIndex);
+}
+
+void ContextMenuTabWidget::slotCxMenuCloseLeft()
+{
+  // close all tabs to the left of the current one
+  App->closeAllLeft(contextTabIndex);
+}
+
+void ContextMenuTabWidget::slotCxMenuCloseRight()
+{
+  // close all tabs to the right of the current one
+  App->closeAllRight(contextTabIndex);
 }
 
 void ContextMenuTabWidget::slotCxMenuCloseAll()

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -286,7 +286,7 @@ void QucsApp::initView()
   setStyleSheet("QToolButton { padding: 0px; }");
 #endif
 
-  DocumentTab = new QTabWidget(this);
+  DocumentTab = new ContextMenuTabWidget(this);
 #if __APPLE__
   DocumentTab->setDocumentMode(true);
 #endif
@@ -2015,14 +2015,23 @@ void QucsApp::closeFile(int index)
 }
 
 
-// --------------------------------------------------------------
-bool QucsApp::closeAllFiles()
+/**
+ * @brief close all open documents - except a specified one, optionally
+ * @param exceptTab tab to leave open, none if not specified
+ */
+bool QucsApp::closeAllFiles(int exceptTab)
 {
+  // document to keep open, if any
+  QucsDoc *docToKeep = 0;
+  if (exceptTab >= 0) {
+    docToKeep = getDoc(exceptTab);
+  }
+
   SaveDialog *sd = new SaveDialog(this);
   sd->setApp(this);
   for(int i=0; i < DocumentTab->count(); ++i) {
     QucsDoc *doc = getDoc(i);
-    if(doc->getDocChanged())
+    if ((doc->getDocChanged()) && (doc != docToKeep))
       sd->addUnsavedDoc(doc);
   }
   int Result = SaveDialog::DontSave;
@@ -2032,8 +2041,16 @@ bool QucsApp::closeAllFiles()
   if(Result == SaveDialog::AbortClosing)
     return false;
   QucsDoc *doc = 0;
-  while((doc = getDoc()) != 0)
-  delete doc;
+
+  // remove documents
+  int i = 0;
+  while (i < DocumentTab->count()) {
+    if ((doc=getDoc(i)) == docToKeep) {
+      i++; // skip to next doc
+    } else {
+      delete doc;
+    }
+  }
 
 
   //switchEditMode(true);   // set schematic edit mode
@@ -3837,4 +3854,59 @@ bool QucsSortFilterProxyModel::lessThan(const QModelIndex &left, const QModelInd
     }
 
     return QSortFilterProxyModel::lessThan(left, right);
+}
+
+ContextMenuTabWidget::ContextMenuTabWidget(QucsApp *parent) : QTabWidget(parent)
+{
+  App = parent;
+  setContextMenuPolicy(Qt::CustomContextMenu);
+  connect(this, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(showContextMenu(const QPoint&)));
+}
+
+void ContextMenuTabWidget::showContextMenu(const QPoint& point)
+{
+  if (point.isNull()) {
+    qDebug() << "ContextMenuTabWidget::showContextMenu() : point is null!";
+    return;
+  }
+
+  contextTabIndex = tabBar()->tabAt(point);
+  qDebug() << "contextTabIndex =" << contextTabIndex;
+  if (contextTabIndex >= 0) { // clicked over a tab
+    QMenu menu(this);
+
+#define APPEND_MENU(action, slot, text)         \
+    {                                           \
+          QAction *action = new QAction(tr(text), &menu);    \
+          connect(action, SIGNAL(triggered()), SLOT(slot())); \
+          menu.addAction(action); \
+    }
+
+    APPEND_MENU(ActionCxMenuClose, slotCxMenuClose, "Close")
+    APPEND_MENU(ActionCxMenuCloseOthers, slotCxMenuCloseOthers, "Close other Tabs")
+    APPEND_MENU(ActionCxMenuCloseAll, slotCxMenuCloseAll, "Close all")
+#undef APPEND_MENU
+
+    menu.exec(tabBar()->mapToGlobal(point));
+  }
+}
+
+void ContextMenuTabWidget::slotCxMenuClose()
+{
+  // close tab where the context menu was opened
+  App->slotFileClose(contextTabIndex);
+}
+
+void ContextMenuTabWidget::slotCxMenuCloseOthers()
+{
+  // close all tabs, except the one where the context menu was opened
+  App->closeAllFiles(contextTabIndex);
+}
+
+void ContextMenuTabWidget::slotCxMenuCloseAll()
+{
+  // close all tabs
+  App->closeAllFiles();
+  // create empty schematic
+  App->slotFileNew();
 }

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -37,6 +37,7 @@ class SearchDialog;
 class OctaveWindow;
 class MessageDock;
 class ProjectView;
+class ContextMenuTabWidget;
 class TunerDialog;
 class tunerElement;
 class ExternSimDialog;
@@ -90,7 +91,7 @@ class QucsApp : public QMainWindow {
 public:
   QucsApp(bool netlist2Console);
  ~QucsApp();
-  bool closeAllFiles();
+  bool closeAllFiles(int exceptTab = -1);
   bool gotoPage(const QString&);   // to load a document
   QucsDoc *getDoc(int No=-1);
   QucsDoc* findDoc (QString, int * Pos = 0);
@@ -207,7 +208,7 @@ signals:
 
 public:
   MouseActions *view;
-  QTabWidget *DocumentTab;
+  ContextMenuTabWidget *DocumentTab;
   QListWidget *CompComps;
   QTreeWidget *libTreeWidget;
   QTextEdit *CompDescr;
@@ -481,6 +482,22 @@ private:
   QucsSingleton& operator=(const QucsSingleton&) = delete;
   QucsSingleton(QucsSingleton&&) = delete;
   QucsSingleton& operator=(QucsSingleton&&) = delete;
+};
+
+class ContextMenuTabWidget : public QTabWidget
+{
+  Q_OBJECT
+public:
+  ContextMenuTabWidget(QucsApp *parent = 0);
+public slots:
+  void showContextMenu(const QPoint& point);
+private:
+  int contextTabIndex; // index of tab where context menu was opened
+  QucsApp *App; // the main application - parent widget
+private slots:
+  void slotCxMenuClose();
+  void slotCxMenuCloseOthers();
+  void slotCxMenuCloseAll();
 };
 
 #endif /* QUCS_H */

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -503,6 +503,8 @@ private slots:
   void slotCxMenuCloseAll();
   void slotCxMenuCloseRight();
   void slotCxMenuCloseLeft();
+  void slotCxMenuCopyPath();
+  void slotCxMenuOpenFolder();
 };
 
 #endif /* QUCS_H */

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -128,6 +128,10 @@ public slots:
   void slotFileSaveAs();  // save a document under a different filename
   void slotFileSaveAll(); // save all open documents
   void slotFileClose();   // close the actual file
+  void slotFileCloseOthers();   // close all documents except the current one
+  void slotFileCloseAllLeft();  // close all documents to the left of the current one
+  void slotFileCloseAllRight(); // close all documents to the right of the current one
+  void slotFileCloseAll();      //  close all documents
   void slotFileExamples();   // show the examples in a file browser
   void slotHelpTutorial();   // Open a pdf tutorial
   void slotHelpReport();   // Open a pdf report
@@ -226,7 +230,8 @@ public:
   QAction *ActionCMenuOpen, *ActionCMenuCopy, *ActionCMenuRename, *ActionCMenuDelete, *ActionCMenuInsert;
 
   QAction *fileNew, *textNew, *symNew, *fileNewDpl, *fileOpen, *fileSave, *fileSaveAs,
-          *fileSaveAll, *fileClose, *fileExamples, *fileSettings, *filePrint, *fileQuit,
+          *fileSaveAll, *fileClose, *fileCloseOthers, *fileCloseAllLeft, *fileCloseAllRight,
+          *fileCloseAll, *fileExamples, *fileSettings, *filePrint, *fileQuit,
           *projNew, *projOpen, *projDel, *projClose, *applSettings, *refreshSchPath,
           *editCut, *editCopy, *magAll, *magSel, *magOne, *magMinus, *filePrintFit, *tune,
           *symEdit, *intoH, *popH, *simulate, *save_netlist, *dpl_sch, *undo, *redo, *dcbias,

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -91,7 +91,10 @@ class QucsApp : public QMainWindow {
 public:
   QucsApp(bool netlist2Console);
  ~QucsApp();
+  bool closeTabsRange(int startTab, int stopTab, int exceptTab = -1);
   bool closeAllFiles(int exceptTab = -1);
+  bool closeAllLeft(int);
+  bool closeAllRight(int);
   bool gotoPage(const QString&);   // to load a document
   QucsDoc *getDoc(int No=-1);
   QucsDoc* findDoc (QString, int * Pos = 0);
@@ -498,6 +501,8 @@ private slots:
   void slotCxMenuClose();
   void slotCxMenuCloseOthers();
   void slotCxMenuCloseAll();
+  void slotCxMenuCloseRight();
+  void slotCxMenuCloseLeft();
 };
 
 #endif /* QUCS_H */

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -95,6 +95,26 @@ void QucsApp::initActions()
   fileClose->setWhatsThis(tr("Close File\n\nCloses the current document"));
   connect(fileClose, SIGNAL(triggered()), SLOT(slotFileClose()));
 
+  fileCloseOthers = new QAction(QIcon((":/bitmaps/fileclose.png")), tr("Close all but current"), this);
+  fileCloseOthers->setStatusTip(tr("Closes all documents except the current one"));
+  fileCloseOthers->setWhatsThis(tr("Close all but current\n\nCloses all documents except the current one"));
+  connect(fileCloseOthers, SIGNAL(triggered()), SLOT(slotFileCloseOthers()));
+
+  fileCloseAllLeft = new QAction(QIcon((":/bitmaps/fileclose.png")), tr("Close all left"), this);
+  fileCloseAllLeft->setStatusTip(tr("Closes all documents to the left of the current one"));
+  fileCloseAllLeft->setWhatsThis(tr("Close all left\n\nCloses all documents to the left of the current one"));
+  connect(fileCloseAllLeft, SIGNAL(triggered()), SLOT(slotFileCloseAllLeft()));
+
+  fileCloseAllRight = new QAction(QIcon((":/bitmaps/fileclose.png")), tr("Close all right"), this);
+  fileCloseAllRight->setStatusTip(tr("Closes all documents to the right of the current one"));
+  fileCloseAllRight->setWhatsThis(tr("Close all right\n\nCloses all documents to the right of the current one"));
+  connect(fileCloseAllRight, SIGNAL(triggered()), SLOT(slotFileCloseAllRight()));
+
+  fileCloseAll = new QAction(QIcon((":/bitmaps/fileclose.png")), tr("Close &All"), this);
+  fileCloseAll->setStatusTip(tr("Closes all documents"));
+  fileCloseAll->setWhatsThis(tr("Close All\n\nCloses all documents"));
+  connect(fileCloseAll, SIGNAL(triggered()), SLOT(slotFileCloseAll()));
+
   for (auto & i : fileRecentAction) {
     i = new QAction(this);
     i->setVisible(false);
@@ -690,7 +710,14 @@ void QucsApp::initMenuBar()
   fileMenu->addAction(textNew);
   fileMenu->addAction(symNew);
   fileMenu->addAction(fileOpen);
-  fileMenu->addAction(fileClose);
+
+  QMenu *closeFileMenu = new QMenu(tr("Close"), fileMenu);
+  closeFileMenu->addAction(fileClose);
+  closeFileMenu->addAction(fileCloseOthers);
+  closeFileMenu->addAction(fileCloseAllLeft);
+  closeFileMenu->addAction(fileCloseAllRight);
+  closeFileMenu->addAction(fileCloseAll);
+  fileMenu->addMenu(closeFileMenu);
 
   recentFilesMenu = new QMenu(tr("Open Recent"),fileMenu);
   fileMenu->addMenu(recentFilesMenu);


### PR DESCRIPTION
This PR adds a context menu for closing document tabs.

![image](https://github.com/user-attachments/assets/09e8a574-943d-4e11-a7fa-0f865c9c68c9)


This feature was present in [Qucs/qucs](https://github.com/Qucs/qucs) (developed in [PR#708](https://github.com/Qucs/qucs/pull/708)) and, honestly, I missed it so much here in Qucs-S.

Credits to @in3otd. I just ported his commits and made minor adjustments.