### PR TITLE
Fix scalars plotting

### DIFF
--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -760,7 +760,8 @@ void AbstractSpiceKernel::parseDC_OPoutputXY(QString xyce_file)
  */
 void AbstractSpiceKernel::parseSTEPOutput(QString ngspice_file,
                      QList< QList<double> > &sim_points,
-                     QStringList &var_list, bool &isComplex)
+                     QStringList &var_list, bool &isComplex,
+                     QStringList &digital_vars, QList<int> &dig_vars_dims)
 {
     isComplex = false;
     bool isBinary = false;
@@ -809,6 +810,11 @@ void AbstractSpiceKernel::parseSTEPOutput(QString ngspice_file,
                     lin = ngsp_data.readLine();
                     QString dep_var = lin.section(sep,1,1,QString::SectionSkipEmpty);
                     var_list.append(dep_var);
+                    if (lin.contains("dims=")) {
+                      digital_vars.append(dep_var); // XSPICE digital node
+                      QString tail = lin.section("dims=",1,1,QString::SectionSkipEmpty);
+                      dig_vars_dims.append(tail.toInt());
+                    }
                 }
                 header_parsed = true;
                 continue;
@@ -1250,7 +1256,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
                                                     + "spice4qucs." + dataset_prefix + ".cir.res");
             parseResFile(res_file,swp_var,swp_var_val);
 
-            parseSTEPOutput(full_outfile,sim_points,var_list,isComplex);
+            parseSTEPOutput(full_outfile,sim_points,var_list,isComplex, digital_vars, dig_vars_dims);
         } else {
             int OutType = checkRawOutupt(full_outfile,swp_var_val);
             bool hasSwp = false;
@@ -1258,7 +1264,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             case spiceRawSwp:
                 hasParSweep = true;
                 swp_var = "Number";
-                parseSTEPOutput(full_outfile,sim_points,var_list,isComplex);
+                parseSTEPOutput(full_outfile,sim_points,var_list,isComplex, digital_vars, dig_vars_dims);
                 break;
             case spiceRaw:
                 parseNgSpiceSimOutput(full_outfile, sim_points, var_list, isComplex, digital_vars, dig_vars_dims);
@@ -1349,8 +1355,13 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
                   ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var).arg(var2);
                 } else {
                   // it is scalar
-                  ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(var).arg(dig_vars_dims.at(dig_var_idx));
-                  is_scalar = true;
+                  if (hasParSweep) {
+                    ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var).arg(swp_var);
+                  } else {
+                    ds_stream<<QStringLiteral("<indep %1 %2>\n")
+                                     .arg(var).arg(dig_vars_dims.at(dig_var_idx));
+                    is_scalar = true;
+                  }
                 }
               } else if (is_digital_var && var.endsWith("_steps") && // indep XSPICE digital var
                          !var.contains("(") && !var.contains(")")) {
@@ -1360,9 +1371,22 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
                 ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var_list.at(i)).arg(indep);
               }
             }
-            int count = 0;
-            for (auto& sim_point : sim_points) {
-                if (is_digital_var && count > dig_vars_dims.at(dig_var_idx)) break;
+
+            int count  = 0;
+            for (int idx = 0; idx < sim_points.count(); idx++) {
+                auto sim_point = sim_points.at(idx);
+                if (hasParSweep) {
+                  int dig_var_length = dig_vars_dims.at(dig_var_idx);
+                  if (is_digital_var && count >= dig_var_length) {
+                    // forward variables with dim= suffix
+                    int indep_cnt = sim_points.count()/swp_var_val.count();
+                    idx = idx + (indep_cnt - dig_var_length - 1);
+                    count = 0;
+                    continue;
+                  }
+                } else {
+                  if (is_digital_var && idx >= dig_vars_dims.at(dig_var_idx)) break;
+                }
                 if (isComplex) {
                     double re=sim_point.at(2*(i-1)+1);
                     double im = sim_point.at(2*i);

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -343,7 +343,7 @@ void AbstractSpiceKernel::slotSimulate()
  */
 void AbstractSpiceKernel::parseNgSpiceSimOutput(QString ngspice_file, QList< QList<double> > &sim_points,
                                                 QStringList &var_list, bool &isComplex,
-                                                QStringList &digital_vars, QList<int> &dig_vars_dims)
+                                                QStringList &extra_vars, QList<int> &extra_vars_dims)
 {
     isComplex = false;
     bool isBinary = false;
@@ -388,9 +388,9 @@ void AbstractSpiceKernel::parseNgSpiceSimOutput(QString ngspice_file, QList< QLi
                 QString dep_var = lin.section(sep,1,1,QString::SectionSkipEmpty);
                 var_list.append(dep_var);
                 if (lin.contains("dims=")) {
-                  digital_vars.append(dep_var); // XSPICE digital node
+                  extra_vars.append(dep_var); // XSPICE digital node or scalar
                   QString tail = lin.section("dims=",1,1,QString::SectionSkipEmpty);
-                  dig_vars_dims.append(tail.toInt());
+                  extra_vars_dims.append(tail.toInt());
                 }
             }
             continue;
@@ -761,7 +761,7 @@ void AbstractSpiceKernel::parseDC_OPoutputXY(QString xyce_file)
 void AbstractSpiceKernel::parseSTEPOutput(QString ngspice_file,
                      QList< QList<double> > &sim_points,
                      QStringList &var_list, bool &isComplex,
-                     QStringList &digital_vars, QList<int> &dig_vars_dims)
+                     QStringList &extra_vars, QList<int> &extra_vars_dims)
 {
     isComplex = false;
     bool isBinary = false;
@@ -811,9 +811,9 @@ void AbstractSpiceKernel::parseSTEPOutput(QString ngspice_file,
                     QString dep_var = lin.section(sep,1,1,QString::SectionSkipEmpty);
                     var_list.append(dep_var);
                     if (lin.contains("dims=")) {
-                      digital_vars.append(dep_var); // XSPICE digital node
+                      extra_vars.append(dep_var); // XSPICE digital node or scalar
                       QString tail = lin.section("dims=",1,1,QString::SectionSkipEmpty);
-                      dig_vars_dims.append(tail.toInt());
+                      extra_vars_dims.append(tail.toInt());
                     }
                 }
                 header_parsed = true;
@@ -1177,13 +1177,13 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
 
     for (const QString& ngspice_output_filename : a_output_files) { // For every simulation convert results to Qucs dataset
         QList< QList<double> > sim_points;
-        QStringList var_list, digital_vars;
+        QStringList var_list, extra_vars;
         QString swp_var,swp_var2;
         QStringList swp_var_val,swp_var2_val;
         bool isComplex = false;
         bool hasParSweep = false;
         bool hasDblParSweep = false;
-        QList<int> dig_vars_dims;
+        QList<int> extra_vars_dims;
 
         QString dataset_prefix;
         bool isCustomPrefix = false;
@@ -1256,7 +1256,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
                                                     + "spice4qucs." + dataset_prefix + ".cir.res");
             parseResFile(res_file,swp_var,swp_var_val);
 
-            parseSTEPOutput(full_outfile,sim_points,var_list,isComplex, digital_vars, dig_vars_dims);
+            parseSTEPOutput(full_outfile,sim_points,var_list,isComplex, extra_vars, extra_vars_dims);
         } else {
             int OutType = checkRawOutupt(full_outfile,swp_var_val);
             bool hasSwp = false;
@@ -1264,10 +1264,10 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             case spiceRawSwp:
                 hasParSweep = true;
                 swp_var = "Number";
-                parseSTEPOutput(full_outfile,sim_points,var_list,isComplex, digital_vars, dig_vars_dims);
+                parseSTEPOutput(full_outfile,sim_points,var_list,isComplex, extra_vars, extra_vars_dims);
                 break;
             case spiceRaw:
-                parseNgSpiceSimOutput(full_outfile, sim_points, var_list, isComplex, digital_vars, dig_vars_dims);
+                parseNgSpiceSimOutput(full_outfile, sim_points, var_list, isComplex, extra_vars, extra_vars_dims);
                 break;
             case xyceSTD:
                 parseXYCESTDOutput(full_outfile,sim_points,var_list,isComplex,hasSwp);
@@ -1286,8 +1286,8 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
         }
         if (var_list.isEmpty()) continue; // nothing to convert
         normalizeVarsNames(var_list, dataset_prefix, isCustomPrefix);
-        digital_vars.prepend(var_list.first());
-        normalizeVarsNames(digital_vars, dataset_prefix, isCustomPrefix);
+        extra_vars.prepend(var_list.first());
+        normalizeVarsNames(extra_vars, dataset_prefix, isCustomPrefix);
 
         QString indep = var_list.first();
         //QList<double> sim_point;
@@ -1330,17 +1330,17 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             ds_stream<<"</indep>\n";
         }
 
-        int dig_var_idx = 0;
+        int var_idx = 0;
         for(int i=1;i<var_list.count();i++) { // output dep var
-            bool is_digital_var = false;
-            bool digital_indep = false;
+            bool is_extra_var = false;
+            bool extra_indep = false; // For XSPICE digital vars or scalar
             bool is_scalar = false;
             if (indep.isEmpty()) {
               ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(var_list.at(i)).arg(sim_points.count());
             } else {
               QString var = var_list.at(i);
-              is_digital_var = digital_vars.contains(var);
-              if (is_digital_var && !var.endsWith("_steps")) { // XSPICE digital node
+              is_extra_var = extra_vars.contains(var);
+              if (is_extra_var && !var.endsWith("_steps")) { // XSPICE digital node
                 // requires another X-variable; not time
                 QString var2 = var + "_steps";
                 var2.remove("v(");
@@ -1359,14 +1359,14 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
                     ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var).arg(swp_var);
                   } else {
                     ds_stream<<QStringLiteral("<indep %1 %2>\n")
-                                     .arg(var).arg(dig_vars_dims.at(dig_var_idx));
+                                     .arg(var).arg(extra_vars_dims.at(var_idx));
                     is_scalar = true;
                   }
                 }
-              } else if (is_digital_var && var.endsWith("_steps") && // indep XSPICE digital var
+              } else if (is_extra_var && var.endsWith("_steps") && // indep XSPICE digital var
                          !var.contains("(") && !var.contains(")")) {
-                digital_indep = true;
-                ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(var).arg(dig_vars_dims.at(dig_var_idx));
+                extra_indep = true;
+                ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(var).arg(extra_vars_dims.at(var_idx));
               } else {
                 ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var_list.at(i)).arg(indep);
               }
@@ -1376,16 +1376,16 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             for (int idx = 0; idx < sim_points.count(); idx++) {
                 auto sim_point = sim_points.at(idx);
                 if (hasParSweep) {
-                  int dig_var_length = dig_vars_dims.at(dig_var_idx);
-                  if (is_digital_var && count >= dig_var_length) {
+                  int var_length = extra_vars_dims.at(var_idx);
+                  if (is_extra_var && count >= var_length) {
                     // forward variables with dim= suffix
                     int indep_cnt = sim_points.count()/swp_var_val.count();
-                    idx = idx + (indep_cnt - dig_var_length - 1);
+                    idx = idx + (indep_cnt - var_length - 1);
                     count = 0;
                     continue;
                   }
                 } else {
-                  if (is_digital_var && idx >= dig_vars_dims.at(dig_var_idx)) break;
+                  if (is_extra_var && idx >= extra_vars_dims.at(var_idx)) break;
                 }
                 if (isComplex) {
                     double re=sim_point.at(2*(i-1)+1);
@@ -1401,12 +1401,12 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
                 }
                 count++;
             }
-            if (indep.isEmpty() || digital_indep || is_scalar) {
+            if (indep.isEmpty() || extra_indep || is_scalar) {
               ds_stream<<"</indep>\n";
             } else {
               ds_stream<<"</dep>\n";
             }
-            if (is_digital_var) dig_var_idx++;
+            if (is_extra_var) var_idx++;
         }
     }
 

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -1328,6 +1328,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
         for(int i=1;i<var_list.count();i++) { // output dep var
             bool is_digital_var = false;
             bool digital_indep = false;
+            bool is_scalar = false;
             if (indep.isEmpty()) {
               ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(var_list.at(i)).arg(sim_points.count());
             } else {
@@ -1343,7 +1344,14 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
                   var2 += " " + swp_var;
                   if (hasDblParSweep) var += " " + swp_var2;
                 }
-                ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var).arg(var2);
+                if (var_list.contains(var2)) {
+                  // it is digtial variable
+                  ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var).arg(var2);
+                } else {
+                  // it is scalar
+                  ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(var).arg(dig_vars_dims.at(dig_var_idx));
+                  is_scalar = true;
+                }
               } else if (is_digital_var && var.endsWith("_steps") && // indep XSPICE digital var
                          !var.contains("(") && !var.contains(")")) {
                 digital_indep = true;
@@ -1369,7 +1377,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
                 }
                 count++;
             }
-            if (indep.isEmpty() || digital_indep) {
+            if (indep.isEmpty() || digital_indep || is_scalar) {
               ds_stream<<"</indep>\n";
             } else {
               ds_stream<<"</dep>\n";

--- a/qucs/extsimkernels/abstractspicekernel.h
+++ b/qucs/extsimkernels/abstractspicekernel.h
@@ -111,7 +111,8 @@ public:
     void parseDC_OPoutputXY(QString xyce_file);
     void parseSTEPOutput(QString ngspice_file,
                          QList< QList<double> > &sim_points,
-                         QStringList &var_list, bool &isComplex);
+                         QStringList &var_list, bool &isComplex,
+                         QStringList &digital_vars, QList<int> &dig_vars_dims);
     void parsePrnOutput(const QString &ngspice_file,
                         QList< QList<double> > &sim_points,
                         QStringList &var_list,

--- a/qucs/extsimkernels/abstractspicekernel.h
+++ b/qucs/extsimkernels/abstractspicekernel.h
@@ -96,7 +96,7 @@ public:
     void parseNgSpiceSimOutput(QString ngspice_file,
                                QList< QList<double> > &sim_points,
                                QStringList &var_list, bool &isComplex,
-                               QStringList &digital_vars, QList<int> &dig_vars_dims);
+                               QStringList &extra_vars, QList<int> &extra_vars_dims);
     void parseHBOutput(QString ngspice_file, QList< QList<double> > &sim_points,
                        QStringList &var_list, bool &hasParSweep);
     void parseFourierOutput(QString ngspice_file, QList< QList<double> > &sim_points,
@@ -112,7 +112,7 @@ public:
     void parseSTEPOutput(QString ngspice_file,
                          QList< QList<double> > &sim_points,
                          QStringList &var_list, bool &isComplex,
-                         QStringList &digital_vars, QList<int> &dig_vars_dims);
+                         QStringList &extra_vars, QList<int> &extra_vars_dims);
     void parsePrnOutput(const QString &ngspice_file,
                         QList< QList<double> > &sim_points,
                         QStringList &var_list,


### PR DESCRIPTION
This PR fixes scalar plotting bug reported in #1369 The screenshot illustrates how to use the scalar plotting. The example is provided for `mean` function. 

![image](https://github.com/user-attachments/assets/314625b8-0bb4-4dbb-ad18-76198ee3cafb)
