### PR TITLE
Refactor Schematic::activateCompsWithinRect

### DIFF
--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -75,14 +75,6 @@ Component *Component::newOne() {
 }
 
 // -------------------------------------------------------
-void Component::Bounding(int &_x1, int &_y1, int &_x2, int &_y2) {
-    _x1 = x1 + cx;
-    _y1 = y1 + cy;
-    _x2 = x2 + cx;
-    _y2 = y2 + cy;
-}
-
-// -------------------------------------------------------
 // Size of component text.
 int Component::textSize(int &textPropertyMaxWidth, int &totalTextPropertiesHeight) const {
     // get size of text using the screen-compatible metric
@@ -111,20 +103,6 @@ int Component::textSize(int &textPropertyMaxWidth, int &totalTextPropertiesHeigh
         textPropertiesCount++;
     }
     return textPropertiesCount;
-}
-
-// -------------------------------------------------------
-// Boundings including the component text.
-void Component::entireBounds(int& boundingRectLeft, int& boundingRectTop,
-                             int& boundingRectRight, int& boundingRectBottom) {
-    boundingRectLeft = std::min(x1, tx) + cx;
-    boundingRectTop  = std::min(y1, ty) + cy;
-
-    int textPropertyMaxWidth, totalTextPropertiesHeight;
-    textSize(textPropertyMaxWidth, totalTextPropertiesHeight);
-
-    boundingRectRight  = std::max(tx + textPropertyMaxWidth, x2) + cx;
-    boundingRectBottom = std::max(ty + totalTextPropertiesHeight, y2) + cy;
 }
 
 QRect Component::boundingRect() const noexcept {

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -205,19 +205,6 @@ int Component::getTextSelected(int point_x, int point_y) {
     return -1;
 }
 
-// -------------------------------------------------------
-bool Component::getSelected(int x_, int y_) {
-    x_ -= cx;
-    y_ -= cy;
-    if (x_ >= x1)
-        if (x_ <= x2)
-            if (y_ >= y1)
-                if (y_ <= y2)
-                    return true;
-
-    return false;
-}
-
 void Component::paint(QPainter *p) {
     p->save();
     p->translate(cx, cy);

--- a/qucs/components/component.h
+++ b/qucs/components/component.h
@@ -63,7 +63,7 @@ public:
   int     textSize(int&, int&) const;
   QRect   boundingRect() const noexcept override;
   QRect   boundingRectIncludingProperties() const noexcept;
-  bool    getSelected(int, int);
+  bool    getSelected(int x, int y) const { return boundingRect().contains(x, y); }
   int     getTextSelected(int, int);
   bool    rotate() noexcept override;
   bool    mirrorX() noexcept override;

--- a/qucs/components/component.h
+++ b/qucs/components/component.h
@@ -61,8 +61,6 @@ public:
   void    paint(QPainter* painter);
   void    paintScheme(Schematic*) override;
   int     textSize(int&, int&) const;
-  void    Bounding(int&, int&, int&, int&);
-  void    entireBounds(int&, int&, int&, int&);
   QRect   boundingRect() const noexcept override;
   QRect   boundingRectIncludingProperties() const noexcept;
   bool    getSelected(int, int);

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -465,7 +465,6 @@ public:
   bool       activateSelectedComponents();
   Component* selectCompText(int, int, int&, int&) const;
   Component* searchSelSubcircuit();
-  Component* selectedComponent(int, int);
   void       deleteComp(Component*);
   void       detachComp(Component*);
   Component* getComponentByName(const QString& compname) const;

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -2045,18 +2045,6 @@ Component* Schematic::searchSelSubcircuit()
     return sub;
 }
 
-
-// ---------------------------------------------------
-Component* Schematic::selectedComponent(int x, int y)
-{
-    // test all components
-    for(Component* pc : *a_Components)
-        if(pc->getSelected(x, y))
-            return pc;
-
-    return 0;
-}
-
 // Disconnect component and remove it from the list of schematic components.
 // Component is not deleted, pointer remains valid after call. It is responsibility
 // of the caller to handle it by deleting, reinstalling, etc.

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -1917,40 +1917,28 @@ void Schematic::insertComponent(Component *c)
 void Schematic::activateCompsWithinRect(int x1, int y1, int x2, int y2)
 {
     bool changed = false;
-    int  cx1, cy1, cx2, cy2, a;
-    // exchange rectangle coordinates to obtain x1 < x2 and y1 < y2
-    cx1 = (x1 < x2) ? x1 : x2;
-    cx2 = (x1 > x2) ? x1 : x2;
-    cy1 = (y1 < y2) ? y1 : y2;
-    cy2 = (y1 > y2) ? y1 : y2;
-    x1 = cx1;
-    x2 = cx2;
-    y1 = cy1;
-    y2 = cy2;
+    const auto rect = QRect{x1, y1, x2 - x1, y2 - y1}.normalized();
+    int a;
 
+    for (Component *pc : *a_Components) {
+      if (!(rect.contains(pc->boundingRect()))) {
+        continue;
+      }
 
-    for(Component *pc : *a_Components)
-    {
-        pc->Bounding(cx1, cy1, cx2, cy2);
-        if(cx1 >= x1) if(cx2 <= x2) if(cy1 >= y1) if(cy2 <= y2)
-                    {
-                        a = pc->isActive - 1;
+      a = pc->isActive - 1;
 
-                        if(pc->Ports.count() > 1)
-                        {
-                            if(a < 0)  a = 2;
-                            pc->isActive = a;    // change "active status"
-                        }
-                        else
-                        {
-                            a &= 1;
-                            pc->isActive = a;    // change "active status"
-                            if(a == COMP_IS_ACTIVE)  // only for active (not shorten)
-                                if(pc->Model == "GND")  // if existing, delete label on wire line
-                                    oneLabel(pc->Ports.first()->Connection);
-                        }
-                        changed = true;
-                    }
+      if (pc->Ports.count() > 1) {
+          if(a < 0)  a = 2;
+          pc->isActive = a;    // change "active status"
+      }
+      else {
+          a &= 1;
+          pc->isActive = a;    // change "active status"
+          if(a == COMP_IS_ACTIVE)  // only for active (not shorten)
+            if(pc->Model == "GND")  // if existing, delete label on wire line
+              oneLabel(pc->Ports.first()->Connection);
+      }
+      changed = true;
     }
 
     if(changed)  setChanged(true, true);


### PR DESCRIPTION
Hi!

This is an implementation of #1292 and a couple of other tiny changes. Mostly code cleanup.

<hr>

Also something not related to this issue: it seems (to me at least) that three-step wire planners (#1232) and "lay wires anew" feature (#1329) are actually not so useful. The latter I'd even call controversial. So I thought as the next release time is getting closer maybe these features should be removed and not included in the release? What do you think?