### PR TITLE
Stop forcing LEVEL=2 into Xyce diode conversions

### DIFF
--- a/qucs/components/diode.cpp
+++ b/qucs/components/diode.cpp
@@ -151,11 +151,7 @@ QString Diode::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
 
     if (dialect != spicecompat::CDL)
     {
-        if (dialect == spicecompat::SPICEXyce) {
-            s += QStringLiteral(".MODEL DMOD_%1 D (LEVEL = 2 %2)\n").arg(Name).arg(par_str);
-        } else {
-            s += QStringLiteral(".MODEL DMOD_%1 D (%2)\n").arg(Name).arg(par_str);
-        }
+      s += QStringLiteral(".MODEL DMOD_%1 D (%2)\n").arg(Name).arg(par_str);
     }
 
     return s;

--- a/qucs/extsimkernels/qucs2spice.cpp
+++ b/qucs/extsimkernels/qucs2spice.cpp
@@ -160,8 +160,7 @@ QString qucs2spice::convert_diode(QString line,bool xyce)
     s += QStringLiteral("D%1 %2 %3 DMOD_%4 \n").arg(name).arg(A).arg(K).arg(name);
     QString mod_params = lst.join(" ");
     mod_params.remove('\"');
-    if (xyce) s += QStringLiteral(".MODEL DMOD_%1 D(LEVEL=2 %2) \n").arg(name).arg(mod_params);
-    else  s += QStringLiteral(".MODEL DMOD_%1 D(%2) \n").arg(name).arg(mod_params);
+    s += QStringLiteral(".MODEL DMOD_%1 D(%2) \n").arg(name).arg(mod_params);
     return s;
 }
 


### PR DESCRIPTION
Qucs diode models use some parameters that the Xyce level 1 diode did not support prior to 2022, and the "PSpice-compatible" level 2 diode did have those parameters.

Xyce's level 1 diode has been reworked to include those parameters and more, and most of the differences between level 1 and level 2 are gone.  In fact, the only differences that remain are in the computation of junction voltage and junction capacitance, and it is believed that they are incorrect anyway.

This commit removes the code that forces LEVEL=2 into diode models converted from Qucs models to Xyce netlists.

Closes GH-1372