### PR TITLE
SPICE models for Qucsator devices

### DIFF
--- a/library/spicelibrary/coax.cir
+++ b/library/spicelibrary/coax.cir
@@ -1,0 +1,19 @@
+* Coax cable
+
+.SUBCKT COAX in n2 out n4 De=2.95e-3 Di=0.9e-3 L=1.500 er=2.29 
++ mur=1.0 tand=4e-4 rho=0.022e-6
+.PARAM m_pi = 4*atan(1)
+.PARAM mu0 = 4*m_pi*1e-7
+.PARAM e0 = 8.854e-12
+.PARAM L1 = (mu0*mur)/(2*m_pi)*log(De/Di)
+.PARAM C1 = 2*m_pi*er*e0/log(De/Di)
+.PARAM G1 = 4*m_pi*m_pi*e0*er*tand/log(De/Di)
+.PARAM Rdc = rho/(m_pi*Di*Di/4)
+RS1 in  n1 R='1e-12+0.5*L*sqrt(hertz*mu0/m_pi)*(sqrt(mur*rho)*(1/De+1/Di))' 
+RS2 out n3 R='1e-12+0.5*L*sqrt(hertz*mu0/m_pi)*(sqrt(mur*rho)*(1/De+1/Di))' 
+* Ngspice doesn't support R!=0 and G!=0 for LTRA 
+R1 n1 n2 R='2/(L*G1*(hertz+1e-12))'
+R2 n3 n4 R='2/(L*G1*(hertz+1e-12))'
+O1 n1 n2 n3 n4 COAX_MOD
+.MODEL COAX_MOD LTRA( G=0  R={Rdc} L={L1} C={C1} LEN={L} )
+.ENDS

--- a/qucs/components/coaxialline.cpp
+++ b/qucs/components/coaxialline.cpp
@@ -16,13 +16,14 @@
  ***************************************************************************/
 
 #include "coaxialline.h"
+#include "node.h"
 #include "extsimkernels/spicecompat.h"
 
 
 CoaxialLine::CoaxialLine()
 {
   Description = QObject::tr("coaxial transmission line");
-  Simulator = spicecompat::simQucsator;
+  Simulator = spicecompat::simAll;
 
   Arcs.append(new qucs::Arc(-20, -9, 8, 18,     0, 16*360,QPen(Qt::darkBlue,2)));
   Arcs.append(new qucs::Arc( 11, -9, 8, 18,16*270, 16*180,QPen(Qt::darkBlue,2)));
@@ -42,6 +43,7 @@ CoaxialLine::CoaxialLine()
   ty = y2+4;
   Model = "COAX";
   Name  = "Line";
+  SpiceModel ="X";
 
   Props.append(new Property("er", "2.29", true,
 		QObject::tr("relative permittivity of dielectric")));
@@ -77,4 +79,35 @@ Element* CoaxialLine::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
   if(getNewOne)  return new CoaxialLine();
   return 0;
+}
+
+QString CoaxialLine::spice_netlist(spicecompat::SpiceDialect dialect)
+{
+  Q_UNUSED(dialect);
+  QString s;
+
+  QString p1 = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
+  QString p2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
+
+  QString D = spicecompat::normalize_value(getProperty("D")->Value);
+  QString d = spicecompat::normalize_value(getProperty("d")->Value);
+  QString er = spicecompat::normalize_value(getProperty("er")->Value);
+  QString mur = spicecompat::normalize_value(getProperty("mur")->Value);
+  QString L = spicecompat::normalize_value(getProperty("L")->Value);
+  QString rho = spicecompat::normalize_value(getProperty("rho")->Value);
+  QString tand = spicecompat::normalize_value(getProperty("tand")->Value);
+
+  s = QString("X%1 %2 0 %3 0 COAX De=%4 Di=%5 L=%6 er=%7 mur=%8 rho=%9 tand=%10\n")
+          .arg(Name).arg(p1).arg(p2)
+          .arg(D).arg(d).arg(L).arg(er).arg(mur).arg(rho).arg(tand);
+
+  return s;
+}
+
+
+QString CoaxialLine::getSpiceLibrary()
+{
+  QString f = spicecompat::getSpiceLibPath("coax.cir");
+  QString s = QString (".INCLUDE \"%1\"\n").arg(f);
+  return s;
 }

--- a/qucs/components/coaxialline.h
+++ b/qucs/components/coaxialline.h
@@ -27,6 +27,10 @@ public:
  ~CoaxialLine();
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
+protected:
+  QString spice_netlist(spicecompat::SpiceDialect dialect);
+  QString getSpiceLibrary();
+
 };
 
 #endif

--- a/qucs/components/gyrator.cpp
+++ b/qucs/components/gyrator.cpp
@@ -24,7 +24,7 @@
 Gyrator::Gyrator()
 {
   Description = QObject::tr("gyrator (impedance inverter)");
-  Simulator = spicecompat::simQucsator;
+  Simulator = spicecompat::simAll;
 
   Arcs.append(new qucs::Arc(  3, -9, 18, 18, 16*90, 16*180,QPen(Qt::darkBlue,2)));
   Arcs.append(new qucs::Arc(-21, -9, 18, 18,16*270, 16*180,QPen(Qt::darkBlue,2)));
@@ -54,7 +54,7 @@ Gyrator::Gyrator()
   ty = y2+4;
   Model = "Gyrator";
   Name  = "X";
-  SpiceModel = "*";
+  SpiceModel = "X";
 
   Props.append(new Property("R", "50 Ohm", true,
 		QObject::tr("gyrator ratio")));

--- a/qucs/components/tline.cpp
+++ b/qucs/components/tline.cpp
@@ -16,13 +16,14 @@
  ***************************************************************************/
 
 #include "tline.h"
+#include "node.h"
 #include "extsimkernels/spicecompat.h"
 
 
 TLine::TLine()
 {
   Description = QObject::tr("ideal transmission line");
-  Simulator = spicecompat::simQucsator;
+  Simulator = spicecompat::simAll;
 
   Lines.append(new qucs::Line(-30,  0, 30,  0,QPen(Qt::darkBlue,2)));
   Lines.append(new qucs::Line(-28,  7, 28,  7,QPen(Qt::darkBlue,2)));
@@ -46,6 +47,7 @@ TLine::TLine()
   ty = y2+4;
   Model = "TLIN";
   Name  = "Line";
+  SpiceModel = "T";
 
   Props.append(new Property("Z", "50 Ohm", true,
 		QObject::tr("characteristic impedance")));
@@ -73,4 +75,25 @@ Element* TLine::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
   if(getNewOne)  return new TLine();
   return 0;
+}
+
+
+QString TLine::spice_netlist(spicecompat::SpiceDialect dialect)
+{
+  Q_UNUSED(dialect);
+
+  QString c0 = "299792458.0"; // light speed
+  QString p1 = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
+  QString p2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
+
+  QString zw = spicecompat::normalize_value(getProperty("Z")->Value);
+  QString l = spicecompat::normalize_value(getProperty("L")->Value);
+
+  QString s = QString("T%1 %2 0 %3 0 Z0=%4 TD={%5/%6}\n")
+                  .arg(Name)
+                  .arg(p1).arg(p2)
+                  .arg(zw).arg(l).arg(c0);
+
+  return s;
+
 }

--- a/qucs/components/tline.h
+++ b/qucs/components/tline.h
@@ -27,6 +27,8 @@ public:
   ~TLine();
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
+protected:
+  QString spice_netlist(spicecompat::SpiceDialect dialect);
 };
 
 #endif

--- a/qucs/components/tline_4port.cpp
+++ b/qucs/components/tline_4port.cpp
@@ -16,13 +16,14 @@
  ***************************************************************************/
 
 #include "tline_4port.h"
+#include "node.h"
 #include "extsimkernels/spicecompat.h"
 
 
 TLine_4Port::TLine_4Port()
 {
   Description = QObject::tr("ideal 4-terminal transmission line");
-  Simulator = spicecompat::simQucsator;
+  Simulator = spicecompat::simAll;
 
   Arcs.append(new qucs::Arc(-28,-40, 18, 38,16*232, 16*33,QPen(Qt::darkBlue,1)));
   Arcs.append(new qucs::Arc(-28,  2, 18, 38, 16*95, 16*33,QPen(Qt::darkBlue,1)));
@@ -50,6 +51,7 @@ TLine_4Port::TLine_4Port()
   ty = y2+4;
   Model = "TLIN4P";
   Name  = "Line";
+  SpiceModel ="T";
 
   Props.append(new Property("Z", "50 Ohm", true,
 		QObject::tr("characteristic impedance")));
@@ -77,4 +79,27 @@ Element* TLine_4Port::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
   if(getNewOne)  return new TLine_4Port();
   return 0;
+}
+
+
+QString TLine_4Port::spice_netlist(spicecompat::SpiceDialect dialect)
+{
+  Q_UNUSED(dialect);
+
+  QString c0 = "299792458.0"; // light speed
+  QString p1 = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
+  QString p2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
+  QString p3 = spicecompat::normalize_node_name(Ports.at(2)->Connection->Name);
+  QString p4 = spicecompat::normalize_node_name(Ports.at(3)->Connection->Name);
+
+  QString zw = spicecompat::normalize_value(getProperty("Z")->Value);
+  QString l = spicecompat::normalize_value(getProperty("L")->Value);
+
+  QString s = QString("T%1 %2 %3 %4 %5 Z0=%6 TD={%7/%8}\n")
+                  .arg(Name)
+                  .arg(p1).arg(p3).arg(p2).arg(p4)
+                  .arg(zw).arg(l).arg(c0);
+
+  return s;
+
 }

--- a/qucs/components/tline_4port.h
+++ b/qucs/components/tline_4port.h
@@ -27,6 +27,8 @@ public:
  ~TLine_4Port();
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
+protected:
+  QString spice_netlist(spicecompat::SpiceDialect dialect);
 };
 
 #endif


### PR DESCRIPTION
This PR provides SPICE models for some Qucsator devices:

* Both 2-port and 4-port ideal TLines. These devices are mapped to SPICE T
* Enable SPICE model for Gyrator. It was disabled by mistake
* Coaxial cable. This device is mapped to SPICE LTRA

Here are some screenshots illustrating new features:

![image](https://github.com/user-attachments/assets/acd32a5d-d3d6-4a0b-be67-ab1bf8f16efe)

![image](https://github.com/user-attachments/assets/f2499f24-e2a0-414e-a699-3dbfce5679a4)
