### PR TITLE
Open multiple schematics from the Content View tab

### DIFF
--- a/qucs/projectView.cpp
+++ b/qucs/projectView.cpp
@@ -78,16 +78,16 @@ ProjectView::refresh()
   header << tr("Content of %1").arg(m_projName) << tr("Note");
   m_model->setHorizontalHeaderLabels(header);
 
-  APPEND_ROW(m_model, tr("Datasets"), QString(""));
-  APPEND_ROW(m_model, tr("Data Displays"), QString(""));
-  APPEND_ROW(m_model, tr("Verilog"), QString(""));
-  APPEND_ROW(m_model, tr("Verilog-A"), QString(""));
-  APPEND_ROW(m_model, tr("VHDL"), QString(""));
-  APPEND_ROW(m_model, tr("Octave"), QString(""));
-  APPEND_ROW(m_model, tr("Schematics"), QString(""));
-  APPEND_ROW(m_model, tr("Symbols"), QString(""));
-  APPEND_ROW(m_model, tr("SPICE"), QString(""));
-  APPEND_ROW(m_model, tr("Others"), QString(""));
+  appendRow(m_model->invisibleRootItem(), tr("Datasets"), QString(""));
+  appendRow(m_model->invisibleRootItem(), tr("Data Displays"), QString(""));
+  appendRow(m_model->invisibleRootItem(), tr("Verilog"), QString(""));
+  appendRow(m_model->invisibleRootItem(), tr("Verilog-A"), QString(""));
+  appendRow(m_model->invisibleRootItem(), tr("VHDL"), QString(""));
+  appendRow(m_model->invisibleRootItem(), tr("Octave"), QString(""));
+  appendRow(m_model->invisibleRootItem(), tr("Schematics"), QString(""));
+  appendRow(m_model->invisibleRootItem(), tr("Symbols"), QString(""));
+  appendRow(m_model->invisibleRootItem(), tr("SPICE"), QString(""));
+  appendRow(m_model->invisibleRootItem(), tr("Others"), QString(""));
 
   setExpanded(m_model->index(6, 0), true);
 
@@ -102,8 +102,6 @@ ProjectView::refresh()
   QString extName, fileName, fullExtName;
   QList<QStandardItem *> columnData;
 
-#define APPEND_CHILD(category, data) \
-  m_model->item(category, 0)->appendRow(data);
 
   for(it = files.begin(); it != files.end(); ++it) {
     fileName = (*it).toLatin1();
@@ -115,22 +113,22 @@ ProjectView::refresh()
 
     if(extName == "dat" || fullExtName == "dat.ngspice" ||
        fullExtName == "dat.xyce" || fullExtName == "dat.spopus" ) {
-      APPEND_CHILD(0, columnData);
+      appendChild(0, columnData);
     }
     else if(extName == "dpl") {
-      APPEND_CHILD(1, columnData);
+      appendChild(1, columnData);
     }
     else if(extName == "v") {
-      APPEND_CHILD(2, columnData);
+      appendChild(2, columnData);
     }
     else if(extName == "va") {
-      APPEND_CHILD(3, columnData);
+      appendChild(3, columnData);
     }
     else if((extName == "vhdl") || (extName == "vhd")) {
-      APPEND_CHILD(4, columnData);
+      appendChild(4, columnData);
     }
     else if((extName == "m") || (extName == "oct")) {
-      APPEND_CHILD(5, columnData);
+      appendChild(5, columnData);
     }
     else if(extName == "sch") {
       // test if it's a valid schematic file
@@ -139,24 +137,23 @@ ProjectView::refresh()
         if(n > 0) { // is a subcircuit
           columnData.append(new QStandardItem(QString::number(n)+tr("-port")));
         }
-        APPEND_CHILD(6, columnData);
+        appendChild(6, columnData);
       }
     } else if (extName == "sym") {
-        APPEND_CHILD(7,columnData);
+        appendChild(7,columnData);
     } else if ((extName == "cir") || (extName=="ckt") ||
              (extName=="sp")) {
-        APPEND_CHILD(8,columnData);
+        appendChild(8,columnData);
     }
     else {
-      APPEND_CHILD(9, columnData);
+      appendChild(9, columnData);
     }
   }
 
   resizeColumnToContents(0);
 }
 
-QStringList
-ProjectView::exportSchematic()
+QStringList ProjectView::exportSchematic()
 {
   QStringList list;
   QStandardItem *item = m_model->item(6, 0);

--- a/qucs/projectView.cpp
+++ b/qucs/projectView.cpp
@@ -42,6 +42,7 @@ ProjectView::ProjectView(QWidget *parent)
 
   this->setModel(m_model);
   this->setEditTriggers(QAbstractItemView::NoEditTriggers);
+  this->setSelectionMode(QAbstractItemView::ExtendedSelection); // Allow multiple selection
 }
 
 ProjectView::~ProjectView()

--- a/qucs/projectView.cpp
+++ b/qucs/projectView.cpp
@@ -78,16 +78,16 @@ ProjectView::refresh()
   header << tr("Content of %1").arg(m_projName) << tr("Note");
   m_model->setHorizontalHeaderLabels(header);
 
-  APPEND_ROW(m_model, tr("Datasets")     );
-  APPEND_ROW(m_model, tr("Data Displays"));
-  APPEND_ROW(m_model, tr("Verilog")      );
-  APPEND_ROW(m_model, tr("Verilog-A")    );
-  APPEND_ROW(m_model, tr("VHDL")         );
-  APPEND_ROW(m_model, tr("Octave")       );
-  APPEND_ROW(m_model, tr("Schematics")   );
-  APPEND_ROW(m_model, tr("Symbols")      );
-  APPEND_ROW(m_model, tr("SPICE")       );
-  APPEND_ROW(m_model, tr("Others")       );
+  APPEND_ROW(m_model, tr("Datasets"), QString(""));
+  APPEND_ROW(m_model, tr("Data Displays"), QString(""));
+  APPEND_ROW(m_model, tr("Verilog"), QString(""));
+  APPEND_ROW(m_model, tr("Verilog-A"), QString(""));
+  APPEND_ROW(m_model, tr("VHDL"), QString(""));
+  APPEND_ROW(m_model, tr("Octave"), QString(""));
+  APPEND_ROW(m_model, tr("Schematics"), QString(""));
+  APPEND_ROW(m_model, tr("Symbols"), QString(""));
+  APPEND_ROW(m_model, tr("SPICE"), QString(""));
+  APPEND_ROW(m_model, tr("Others"), QString(""));
 
   setExpanded(m_model->index(6, 0), true);
 

--- a/qucs/projectView.h
+++ b/qucs/projectView.h
@@ -35,11 +35,16 @@
 })*/
 
 
-#define APPEND_ROW(parent, data) \
+#define APPEND_ROW(parent, data0, data1) \
 if(1){ \
-    QList<QStandardItem*> c; \
-    c.append(new QStandardItem(data)); \
-    parent->appendRow(c); \
+      QList<QStandardItem*> c; \
+      QStandardItem *col0 = new QStandardItem(data0); \
+      QStandardItem *col1 = new QStandardItem(data1); \
+      col0->setFlags(col0->flags() & ~Qt::ItemIsSelectable); \
+      col1->setFlags(col1->flags() & ~Qt::ItemIsSelectable); \
+      c.append(col0); \
+      c.append(col1); \
+      parent->appendRow(c); \
 }
 
 class QStandardItemModel;

--- a/qucs/projectView.h
+++ b/qucs/projectView.h
@@ -26,26 +26,8 @@
 
 #include <QTreeView>
 #include <QString>
+#include <QStandardItem>
 
-/*#define APPEND_ROW(parent, data) \
-({ \
-  QList<QStandardItem*> c; \
-  c.append(new QStandardItem(data)); \
-  parent->appendRow(c); \
-})*/
-
-
-#define APPEND_ROW(parent, data0, data1) \
-if(1){ \
-      QList<QStandardItem*> c; \
-      QStandardItem *col0 = new QStandardItem(data0); \
-      QStandardItem *col1 = new QStandardItem(data1); \
-      col0->setFlags(col0->flags() & ~Qt::ItemIsSelectable); \
-      col1->setFlags(col1->flags() & ~Qt::ItemIsSelectable); \
-      c.append(col0); \
-      c.append(col1); \
-      parent->appendRow(c); \
-}
 
 class QStandardItemModel;
 
@@ -72,6 +54,23 @@ private:
   bool m_valid;
   QString m_projPath;
   QString m_projName;
+
+  inline void appendChild(int category, const QList<QStandardItem*>& data) {
+    if (auto *item = m_model->item(category, 0)) {
+      item->appendRow(data);
+    }
+  }
+
+  inline void appendRow(QStandardItem* parent, const QString& data0, const QString& data1) {
+    auto* col0 = new QStandardItem(data0);
+    auto* col1 = new QStandardItem(data1);
+
+    col0->setFlags(col0->flags() & ~Qt::ItemIsSelectable);
+    col1->setFlags(col1->flags() & ~Qt::ItemIsSelectable);
+
+    QList<QStandardItem*> row{ col0, col1 };
+    parent->appendRow(row);
+  }
 };
 
 #endif /* PROJECTVIEW_H_ */

--- a/qucs/projectView.h
+++ b/qucs/projectView.h
@@ -57,6 +57,10 @@ public:
   void setProjPath(const QString &);
   void refresh();
   QStringList exportSchematic();
+
+signals:
+  void filesSelected(const QStringList&);
+
 private:
   QStandardItemModel *m_model;
 

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -2856,26 +2856,70 @@ void QucsApp::slotOpenContent(const QModelIndex &idx)
 {
   editText->setHidden(true); // disable text edit of component property
 
-  //test the item is valid
-  if (!idx.isValid()) { return; }
-  if (!idx.parent().isValid()) { return; }
+  // Get the selection model
+  QItemSelectionModel *selectionModel = Content->selectionModel();
+
+  // Handle multiple selections if CTRL is pressed or from context menu
+  // OR if Shift is pressed during double click
+  if ((QApplication::keyboardModifiers() & (Qt::ControlModifier | Qt::ShiftModifier)) ||
+      (sender() == ActionCMenuOpen && selectionModel->hasSelection())) {
+
+    QModelIndexList selected = selectionModel->selectedIndexes();
+    QSet<QString> openedFiles; // To avoid opening duplicates
+
+     // We only want column 0 items (file names)
+    for (const QModelIndex &index : selected) {
+      if (index.column() == 0 && index.parent().isValid()) {
+        QString filename = index.sibling(index.row(), 0).data().toString();
+        QString note = index.sibling(index.row(), 1).data().toString();
+        QFileInfo Info(QucsSettings.QucsWorkDir.filePath(filename));
+
+        // Only open each file once
+        if (!openedFiles.contains(Info.absoluteFilePath())) {
+          openFileFromProjectView(Info, note);
+          openedFiles.insert(Info.absoluteFilePath());
+        }
+      }
+    }
+    return;
+  }
+
+  if (!idx.isValid() || !idx.parent().isValid()) {
+    return;
+  }
 
   QString filename = idx.sibling(idx.row(), 0).data().toString();
   QString note = idx.sibling(idx.row(), 1).data().toString();
   QFileInfo Info(QucsSettings.QucsWorkDir.filePath(filename));
-  QString extName = Info.suffix();
+  openFileFromProjectView(Info, note);
+}
 
+/**
+ * Opens a file from the project view based on its file type
+ * @param Info - QFileInfo object containing file information
+ * @param note - Optional note from the project view (used for subcircuits)
+ */
+void QucsApp::openFileFromProjectView(const QFileInfo &Info, const QString &note)
+{
+  QString extName = Info.suffix().toLower();
+  QString absolutePath = Info.absoluteFilePath();
+
+   // Handle Qucs document types
   if (extName == "sch" || extName == "dpl" || extName == "vhdl" ||
       extName == "vhd" || extName == "v" || extName == "va" ||
       extName == "m" || extName == "oct" || extName == "net") {
-    gotoPage(Info.absoluteFilePath());
-    updateRecentFilesList(Info.absoluteFilePath());
+
+    gotoPage(absolutePath);
+    updateRecentFilesList(absolutePath);
     slotUpdateRecentFiles();
 
-    if(note.isEmpty())     // is subcircuit ?
-      if(extName == "sch") return;
+    // Special handling for subcircuits
+    if (note.isEmpty() && extName == "sch") {
+      return;
+    }
 
-    select->blockSignals(true);  // switch on the 'select' action ...
+    // Set selection mode if not in subcircuit
+    select->blockSignals(true);
     select->setChecked(true);
     select->blockSignals(false);
 
@@ -2887,34 +2931,42 @@ void QucsApp::slotOpenContent(const QModelIndex &idx)
     return;
   }
 
-  if(extName == "dat") {
-    editFile(Info.absoluteFilePath());  // open datasets with text editor
+  // Handle data files
+  if (extName == "dat") {
+    editFile(absolutePath);
     return;
   }
 
-  // File is no Qucs file, so go through list and search a user
-  // defined program to open it.
+  // Handle S-parameter files
+  if (extName == "s1p" || extName == "s2p" || extName == "s3p" || extName == "s4p") {
+    QStringList args;
+    args << absolutePath;
+    launchTool(QUCS_NAME "spar-viewer", "s-parameter viewer", args);
+    return;
+  }
+
+  // Try to find a user-defined program for the file extension
   QStringList com;
   QStringList::const_iterator it = QucsSettings.FileTypes.constBegin();
-  while(it != QucsSettings.FileTypes.constEnd()) {
-    if(extName == (*it).section('/',0,0)) {
-      QString progName = (*it).section('/',1,1);
+  while (it != QucsSettings.FileTypes.constEnd()) {
+    if (extName == (*it).section('/', 0, 0)) {
+      QString progName = (*it).section('/', 1, 1);
       com = progName.split(" ");
-      com << Info.absoluteFilePath();
+      com << absolutePath;
 
       QProcess *Program = new QProcess();
-      //Program->setCommunication(0);
       QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-      env.insert("PATH", env.value("PATH") );
+      env.insert("PATH", env.value("PATH"));
       Program->setProcessEnvironment(env);
       QString cmd = com.at(0);
       QStringList com_args = com;
       com_args.removeAt(0);
       Program->start(cmd, com_args);
-      if(Program->state()!=QProcess::Running&&
-              Program->state()!=QProcess::Starting) {
+
+      if (Program->state() != QProcess::Running &&
+          Program->state() != QProcess::Starting) {
         QMessageBox::critical(this, tr("Error"),
-               tr("Cannot start \"%1\"!").arg(Info.absoluteFilePath()));
+                              tr("Cannot start \"%1\"!").arg(absolutePath));
         delete Program;
       }
       return;
@@ -2922,28 +2974,15 @@ void QucsApp::slotOpenContent(const QModelIndex &idx)
     it++;
   }
 
-  // If no appropriate program was found, open in system default program or, if it is a Touchstone file, open it in the S-parameter viewer.
-  if (extName == "s2p" || extName == "s3p" || extName == "s4p") {
-    QString file_path = Info.absoluteFilePath();
-    QStringList args;
-    args << file_path;
-    launchTool(QUCS_NAME "spar-viewer", "s-parameter viewer", args);
-    return;
-  } else {
-    QUrl fileUrl = QUrl::fromLocalFile(Info.absoluteFilePath());
-    if (QDesktopServices::openUrl(fileUrl)) {
-      // Success
-      return;
-    } else {
-      // If opening fails, optionally show an error message
-      QMessageBox::critical(this, tr("Error"),
-                            tr("Cannot open \"%1\" with the system default program!").arg(Info.absoluteFilePath()));
-    }
+         // Fallback to system default handler
+  QUrl fileUrl = QUrl::fromLocalFile(absolutePath);
+  if (!QDesktopServices::openUrl(fileUrl)) {
+    // If system handler fails, try opening as text file
+    editFile(absolutePath);
   }
-
-  // If no appropriate program was found, open as text file.
-  editFile(Info.absoluteFilePath());  // open datasets with text editor
 }
+
+
 
 // ---------------------------------------------------------
 // Is called when the mouse is clicked within the Content QListView.

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -1194,9 +1194,17 @@ void QucsApp::slotShowContentMenu(const QPoint& pos)
 {
   QModelIndex idx = Content->indexAt(pos);
   if (idx.isValid() && idx.parent().isValid()) {
+    QItemSelectionModel *selectionModel = Content->selectionModel();
+    bool multipleSelected = selectionModel->selectedIndexes().count() > 1;
+
     ActionCMenuInsert->setVisible(
         idx.sibling(idx.row(), 1).data().toString().contains(tr("-port"))
-    );
+        );
+
+    // Disable Duplicate and Rename when multiple files are selected
+    ActionCMenuCopy->setEnabled(!multipleSelected);
+    ActionCMenuRename->setEnabled(!multipleSelected);
+
     ContentMenu->popup(Content->mapToGlobal(pos));
   }
 }

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -1341,29 +1341,61 @@ void QucsApp::slotCMenuRename()
 
 void QucsApp::slotCMenuDelete()
 {
-  QModelIndex idx = Content->currentIndex();
+  QItemSelectionModel *selectionModel = Content->selectionModel();
+  QModelIndexList selected = selectionModel->selectedIndexes();
 
-  //test the item is valid
-  if (!idx.isValid() || !idx.parent().isValid()) { return; }
+         // We only want column 0 items (file names)
+  QSet<QString> filesToDelete; // Use QSet to avoid duplicates
+  for (const QModelIndex &index : selected) {
+    if (index.column() == 0 && index.parent().isValid()) {
+      QString filename = index.sibling(index.row(), 0).data().toString();
+      filesToDelete.insert(filename);
+    }
+  }
 
-  QString filename = idx.sibling(idx.row(), 0).data().toString();
-  QString file(QucsSettings.QucsWorkDir.filePath(filename));
-
-  if (findDoc (file)) {
-    QMessageBox::critical(this, tr("Error"), tr("Cannot delete an open file!"));
+  if (filesToDelete.isEmpty()) {
+    QMessageBox::information(this, tr("Info"), tr("No files selected for deletion!"));
     return;
   }
 
-  int No;
-  No = QMessageBox::warning(this, tr("Warning"),
-      tr("This will delete the file permanently! Continue ?"),
-      QMessageBox::No | QMessageBox::Yes);
-  if(No == QMessageBox::Yes) {
-    if(!QFile::remove(file)) {
-      QMessageBox::critical(this, tr("Error"),
-      tr("Cannot delete file: %1").arg(filename));
-      return;
+  QString message;
+  if (filesToDelete.size() > 1) {
+    message = tr("This will delete %1 files permanently! Continue?").arg(filesToDelete.size());
+  } else {
+    message = tr("This will delete the file permanently! Continue?");
+  }
+
+  int response = QMessageBox::warning(this, tr("Warning"),
+                                      message,
+                                      QMessageBox::No | QMessageBox::Yes);
+
+  if (response != QMessageBox::Yes) {
+    return;
+  }
+
+  QDir dir(QucsSettings.QucsWorkDir.path());
+  bool allDeleted = true;
+  QStringList failedFiles;
+
+  for (const QString &filename : filesToDelete) {
+    QString filePath = dir.filePath(filename);
+
+    if (findDoc(filePath)) {
+      failedFiles << filename + " (" + tr("file is open") + ")";
+      allDeleted = false;
+      continue;
     }
+
+    if (!QFile::remove(filePath)) {
+      failedFiles << filename;
+      allDeleted = false;
+    }
+  }
+
+  if (!allDeleted) {
+    QString errorMsg = tr("Could not delete the following files:\n") +
+                       failedFiles.join("\n");
+    QMessageBox::critical(this, tr("Error"), errorMsg);
   }
 
   slotUpdateTreeview();

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -328,6 +328,8 @@ private:
   void initToolBar();    // creates the toolbars
   void initStatusBar();  // setup the statusbar
 
+  void openFileFromProjectView(const QFileInfo &Info, const QString &note);
+
   QAction *helpAboutApp, *helpAboutQt,
           *viewBrowseDock, *viewOctaveDock;
 


### PR DESCRIPTION
This PR enables the ProjectView class to open multiple files in a row by holding the CTRL or SHIFT key. The context menu has also been modified to allow for the removal of multiple files. 

The 'Rename' and 'Duplicate' options are disabled when multiple files are selected.

https://github.com/user-attachments/assets/1f5d19ab-78c6-472f-9825-8de0c5153015


