### PR TITLE
Fix crash when moving a wirelabel

### DIFF
--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -383,8 +383,9 @@ void merge(Node* donor, Node* recipient) {
     }
 
     // Try to keep donor label
-    if (recipient->Label == nullptr) {
+    if (recipient->Label == nullptr && donor->Label != nullptr) {
         recipient->Label = donor->Label;
+        recipient->Label->pOwner = recipient;
         donor->Label = nullptr;
     }
 }


### PR DESCRIPTION
Hi! Let's try this out. It's a fix for #1388

There was an error in the process of merging of two nodes: after one node had been merged with anoter, wirelabel kept pointer to its old host (obsolete donor node). This inconsistency eventually led to use-after-free.

If I'm not mistaken, use-after-free is the reason why the switch reached the default case. After memory had been freed, `Type` hold a value not fitting to any of the other cases.

Fixes: #1388 