### PR TITLE
Fix wrong marker root position

### DIFF
--- a/qucs/diagrams/marker.cpp
+++ b/qucs/diagrams/marker.cpp
@@ -104,7 +104,9 @@ void Marker::initText(int n)
   Text = "";
 
   bool isCross = false;
-  int nn, nnn, m, x, y, d, dmin = INT_MAX;
+  int nn, nnn, m;
+  double dmin = std::numeric_limits<double>::max();
+  double x, y, d;
   DataX const *pD = pGraph->axis(0);
   px  = pD->Points;
   nnn = pD->count;
@@ -136,8 +138,8 @@ void Marker::initText(int n)
       py++;
       pz += 2*(pD->count-1);
     }
-    x = int(fCX+0.5) - cx;
-    y = int(fCY+0.5) - cy;
+    x = fCX+0.5 - cx;
+    y = fCY+0.5 - cy;
     d = x*x + y*y;
     if(d < dmin) {
       dmin = d;


### PR DESCRIPTION
Hi! This is fix for #1385.

This was hard to catch tbh :)

In short the bug is caused by integer overflow when calculating distance between the click and datapoint. In some configurations `x` becomes so large that its square overflows giving wrong result i.e. a datapoint appears to be closer to the click than it actually is.
```
    d = x*x + y*y;
    if(d < dmin) {
```