### PR TITLE
Conductor and labels refactoring

### DIFF
--- a/qucs/conductor.h
+++ b/qucs/conductor.h
@@ -1,17 +1,59 @@
 
 #ifndef CONDUCTOR_H
 #define CONDUCTOR_H
-#include "element.h"
 
-class WireLabel;
+#include "element.h"
+#include "wirelabel.h"
+
 
 /** \class Conductor
   * \brief label for Node and Wire classes
   *
   */
 class Conductor : public Element {
+  std::unique_ptr<WireLabel> m_label;
 public:
-  WireLabel *Label;
+  bool hasLabel() const
+  {
+    return m_label != nullptr;
+  }
+
+  void dropLabel()
+  {
+    m_label.reset();
+  }
+
+  std::unique_ptr<WireLabel> releaseLabel()
+  {
+    if (hasLabel()) {
+      m_label->pOwner = nullptr;
+      return std::move(m_label);
+    }
+    return nullptr;
+  }
+
+  void acquireLabel(std::unique_ptr<WireLabel>&& new_label)
+  {
+    if (new_label != nullptr) {
+      assert(new_label->pOwner == nullptr);
+      m_label->pOwner = this;
+    }
+    m_label = std::move(new_label);
+  }
+
+  void acquireLabel(WireLabel* new_label)
+  {
+    if (new_label != nullptr) {
+      assert(new_label->pOwner == nullptr);
+      m_label->pOwner = this;
+    }
+    m_label.reset(new_label);
+  }
+
+  WireLabel* label() const
+  {
+    return m_label.get();
+  }
 };
 
 #endif

--- a/qucs/conductor.h
+++ b/qucs/conductor.h
@@ -26,7 +26,7 @@ public:
   std::unique_ptr<WireLabel> releaseLabel()
   {
     if (hasLabel()) {
-      m_label->pOwner = nullptr;
+      m_label->setOwner(nullptr);
       return std::move(m_label);
     }
     return nullptr;
@@ -35,8 +35,8 @@ public:
   void acquireLabel(std::unique_ptr<WireLabel>&& new_label)
   {
     if (new_label != nullptr) {
-      assert(new_label->pOwner == nullptr);
-      m_label->pOwner = this;
+      assert(new_label->owner() == nullptr);
+      new_label->setOwner(this);
     }
     m_label = std::move(new_label);
   }
@@ -44,8 +44,8 @@ public:
   void acquireLabel(WireLabel* new_label)
   {
     if (new_label != nullptr) {
-      assert(new_label->pOwner == nullptr);
-      m_label->pOwner = this;
+      assert(new_label->owner() == nullptr);
+      new_label->setOwner(this);
     }
     m_label.reset(new_label);
   }

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -208,11 +208,11 @@ void AbstractSpiceKernel::startNetlist(QTextStream &stream, spicecompat::SpiceDi
         // create .IC from wire labels
         QStringList wire_labels;
         for(Wire *pw : a_schematic->a_DocWires) {
-            if (pw->Label != nullptr) {
-                QString label = pw->Label->Name;
+            if (pw->hasLabel()) {
+                QString label = pw->label()->Name;
                 if (!wire_labels.contains(label)) wire_labels.append(label);
                 else continue;
-                QString ic = pw->Label->initValue;
+                QString ic = pw->label()->initValue;
                 if (!ic.isEmpty()) {
                     QString ic_str = QStringLiteral(".IC v(%1)=%2\n").arg(label).arg(ic);
                     stream<<ic_str;
@@ -221,11 +221,11 @@ void AbstractSpiceKernel::startNetlist(QTextStream &stream, spicecompat::SpiceDi
         }
         for(Node *pn : a_schematic->a_DocNodes) {
             Conductor *pw = (Conductor*) pn;
-            if (pw->Label != nullptr) {
-                QString label = pw->Label->Name;
+            if (pw->hasLabel()) {
+                QString label = pw->label()->Name;
                 if (!wire_labels.contains(label)) wire_labels.append(label);
                 else continue;
-                QString ic = pw->Label->initValue;
+                QString ic = pw->label()->initValue;
                 if (!ic.isEmpty()) {
                     QString ic_str = QStringLiteral(".IC v(%1)=%2\n").arg(label).arg(ic);
                     stream<<ic_str;

--- a/qucs/extsimkernels/customsimdialog.cpp
+++ b/qucs/extsimkernels/customsimdialog.cpp
@@ -165,16 +165,16 @@ void CustomSimDialog::slotFindVars()
 {
     QStringList vars;
     for (Node* pn : a_schematic->a_DocNodes) {
-      if(pn->Label != 0) {
-          if (!vars.contains(pn->Label->Name)) {
-              vars.append(pn->Label->Name);
+      if(pn->hasLabel()) {
+          if (!vars.contains(pn->label()->Name)) {
+              vars.append(pn->label()->Name);
           }
       }
     }
     for (Wire* pw : a_schematic->a_DocWires) {
-      if(pw->Label != 0) {
-          if (!vars.contains(pw->Label->Name)) {
-              vars.append(pw->Label->Name);
+      if(pw->hasLabel()) {
+          if (!vars.contains(pw->label()->Name)) {
+              vars.append(pw->label()->Name);
           }
       }
     }

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -111,16 +111,16 @@ void Ngspice::createNetlist(
     // set variable names for named nodes and wires
     vars.clear();
     for(Node *pn : a_schematic->a_DocNodes) {
-      if(pn->Label != 0) {
-          if (!vars.contains(pn->Label->Name)) {
-              vars.append(pn->Label->Name);
+      if(pn->hasLabel()) {
+          if (!vars.contains(pn->label()->Name)) {
+            vars.append(pn->label()->Name);
           }
       }
     }
     for(Wire *pw : a_schematic->a_DocWires) {
-      if(pw->Label != 0) {
-          if (!vars.contains(pw->Label->Name)) {
-              vars.append(pw->Label->Name);
+      if(pw->hasLabel()) {
+          if (!vars.contains(pw->label()->Name)) {
+              vars.append(pw->label()->Name);
           }
       }
     }
@@ -503,17 +503,17 @@ bool Ngspice::checkNodeNames(QStringList &incompat)
 {
     bool result = true;
     for(Node *pn : a_schematic->a_DocNodes) {
-      if(pn->Label != 0) {
-          if (!spicecompat::check_nodename(pn->Label->Name)) {
-              incompat.append(pn->Label->Name);
+      if(pn->hasLabel()) {
+          if (!spicecompat::check_nodename(pn->label()->Name)) {
+              incompat.append(pn->label()->Name);
               result = false;
           }
       }
     }
     for(Wire *pw : a_schematic->a_DocWires) {
-      if(pw->Label != 0) {
-          if (!spicecompat::check_nodename(pw->Label->Name)) {
-              incompat.append(pw->Label->Name);
+      if(pw->hasLabel()) {
+          if (!spicecompat::check_nodename(pw->label()->Name)) {
+              incompat.append(pw->label()->Name);
               result = false;
           }
       }

--- a/qucs/extsimkernels/xyce.cpp
+++ b/qucs/extsimkernels/xyce.cpp
@@ -104,16 +104,16 @@ void Xyce::createNetlist(
     // set variable names for named nodes and wires
     vars.clear();
     for(Node *pn : a_schematic->a_DocNodes) {
-      if(pn->Label != 0) {
-          if (!vars.contains(pn->Label->Name)) {
-              vars.append(pn->Label->Name);
+      if(pn->hasLabel()) {
+          if (!vars.contains(pn->label()->Name)) {
+              vars.append(pn->label()->Name);
           }
       }
     }
     for(Wire *pw : a_schematic->a_DocWires) {
-      if(pw->Label != 0) {
-          if (!vars.contains(pw->Label->Name)) {
-              vars.append(pw->Label->Name);
+      if(pw->hasLabel()) {
+          if (!vars.contains(pw->label()->Name)) {
+              vars.append(pw->label()->Name);
           }
       }
     }

--- a/qucs/healer.cpp
+++ b/qucs/healer.cpp
@@ -449,11 +449,11 @@ vector<Healer::HealingAction> Healer::HealerImpl::processRelayingCase(Node* node
 
         auto [stable_node, obsolete_wires] = findStableNode(node, port->hostWire());
 
-        std::vector<WireLabel*> labels;
+        std::vector<std::unique_ptr<WireLabel>> labels;
         for (auto* wire : obsolete_wires) {
-            if (wire->Label != nullptr)        labels.push_back(wire->Label);
-            if (wire->Port1->Label != nullptr) labels.push_back(wire->Port1->Label);
-            if (wire->Port2->Label != nullptr) labels.push_back(wire->Port2->Label);
+            if (wire->hasLabel())        labels.emplace_back(wire->releaseLabel());
+            if (wire->Port1->hasLabel()) labels.emplace_back(wire->Port1->releaseLabel());
+            if (wire->Port2->hasLabel()) labels.emplace_back(wire->Port2->releaseLabel());
         }
 
         assert(labels.size() <= 1);
@@ -462,8 +462,8 @@ vector<Healer::HealingAction> Healer::HealerImpl::processRelayingCase(Node* node
             actions.push_back(make_unique<ReplaceNode>(port.get()));
         }
 
-        if (!labels.empty() && stable_node->Label == nullptr) {
-            actions.push_back(make_unique<ReattachLabel>(labels.front(), stable_node));
+        if (!labels.empty() && !stable_node->hasLabel()) {
+            actions.push_back(make_unique<ReattachLabel>(labels.front().release(), stable_node));
         }
 
         for (const auto& port : m_port_groups.at(node)) {

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -140,7 +140,7 @@ void MouseActions::editLabel(Schematic *Doc, WireLabel *pl)
     delete Dia;
 
     if (Name.isEmpty() && Value.isEmpty()) { // if nothing entered, delete label
-        pl->pOwner->dropLabel();               // delete name of wire
+        pl->owner()->dropLabel();               // delete name of wire
     } else {
         if (Result == 1)
             return; // nothing changed
@@ -416,7 +416,7 @@ void MouseActions::MMovePaste(Schematic *Doc, QMouseEvent *Event)
 
         // Special case: node label. Pasted node label has no host element,
         // which would move its root, thus it has to be moved explicitely.
-        if (auto* l = dynamic_cast<WireLabel*>(pe); l != nullptr && l->pOwner == nullptr) {
+        if (auto* l = dynamic_cast<WireLabel*>(pe); l != nullptr && l->owner() == nullptr) {
             l->moveRoot(diff.x(), diff.y());
         }
     }
@@ -436,7 +436,7 @@ void MouseActions::MMovePaste2(Schematic *Doc, QMouseEvent *Event)
 
         // Special case: node label. Pasted node label has no host element,
         // which would move its root, thus it has to be moved explicitely.
-        if (auto* l = dynamic_cast<WireLabel*>(pe); l != nullptr && l->pOwner == nullptr) {
+        if (auto* l = dynamic_cast<WireLabel*>(pe); l != nullptr && l->owner() == nullptr) {
             l->moveRoot(diff.x(), diff.y());
         }
     }

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -140,8 +140,7 @@ void MouseActions::editLabel(Schematic *Doc, WireLabel *pl)
     delete Dia;
 
     if (Name.isEmpty() && Value.isEmpty()) { // if nothing entered, delete label
-        pl->pOwner->Label = 0;               // delete name of wire
-        delete pl;
+        pl->pOwner->dropLabel();               // delete name of wire
     } else {
         if (Result == 1)
             return; // nothing changed
@@ -832,7 +831,7 @@ void MouseActions::MPressLabel(Schematic *Doc, QMouseEvent *, float fX, float fY
                                      QObject::tr("The ground potential cannot be labeled!"));
             return;
         }
-        pl = ((Conductor *) pe)->Label;
+        pl = ((Conductor *) pe)->label();
     }
 
     LabelDialog *Dia = new LabelDialog(pl, Doc);
@@ -845,9 +844,8 @@ void MouseActions::MPressLabel(Schematic *Doc, QMouseEvent *, float fX, float fY
 
     if (Name.isEmpty() && Value.isEmpty()) { // if nothing entered, delete name
         if (pe) {
-            if (((Conductor *) pe)->Label)
-                delete ((Conductor *) pe)->Label; // delete old name
-            ((Conductor *) pe)->Label = 0;
+            if (((Conductor *) pe)->hasLabel())
+                ((Conductor *) pe)->dropLabel(); // delete old name
         } else {
             if (pw)
                 pw->setName("", ""); // delete name of wire
@@ -856,8 +854,7 @@ void MouseActions::MPressLabel(Schematic *Doc, QMouseEvent *, float fX, float fY
         }
     } else {
         if (pe) {
-            delete ((Conductor *) pe)->Label; // delete old name
-            ((Conductor *) pe)->Label = nullptr;
+            ((Conductor *) pe)->dropLabel(); // delete old name
         }
 
         int xl = x + 30;

--- a/qucs/node.cpp
+++ b/qucs/node.cpp
@@ -22,7 +22,6 @@
 
 Node::Node(int x, int y)
 {
-  Label = nullptr;
   Type  = isNode;
   State = 0;
   DType = "";
@@ -31,17 +30,12 @@ Node::Node(int x, int y)
   cy = y;
 }
 
-Node::~Node()
-{
-  delete Label;
-}
-
 void Node::paint(QPainter* painter) const {
   painter->save();
 
   switch(connections.size()) {
     case 1:
-      if (Label) {
+      if (label()) {
         painter->fillRect(cx-2, cy-2, 4, 4, Qt::darkBlue); // open but labeled
       } else {
         painter->setPen(QPen(Qt::red,1));  // node is open
@@ -74,21 +68,19 @@ bool Node::getSelected(int x, int y)
 void Node::setName(const QString& name, const QString& value, int x, int y)
 {
   if (name.isEmpty() && value.isEmpty()) {
-    if (Label) {
-      delete Label;
-      Label = nullptr;
+    if (hasLabel()) {
+      dropLabel();
     }
     return;
   }
 
-  if (!Label) {
-    Label = new WireLabel(name, cx, cy, x, y, isNodeLabel);
+  if (!hasLabel()) {
+    acquireLabel(new WireLabel(name, cx, cy, x, y, isNodeLabel));
   }
   else {
-    Label->setName(name);
+    label()->setName(name);
   }
-  Label->pOwner = this;
-  Label->initValue = value;
+  label()->initValue = value;
 }
 
 Element* Node::other_than(Element* elem) const
@@ -102,8 +94,8 @@ Element* Node::other_than(Element* elem) const
 bool Node::moveCenter(int dx, int dy) noexcept
 {
   Element::moveCenter(dx, dy);
-  if (Label != nullptr) {
-    Label->moveRoot(dx, dy);
+  if (hasLabel()) {
+    label()->moveRoot(dx, dy);
   }
   return dx != 0 || dy != 0;
 }

--- a/qucs/node.h
+++ b/qucs/node.h
@@ -24,7 +24,6 @@
 class Node : public Conductor {
 public:
   Node(int x, int y);
- ~Node() override;
 
   void  paint(QPainter* painter) const;
   bool  getSelected(int, int);

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -459,15 +459,15 @@ void Schematic::drawElements(QPainter* painter) {
 
     for (auto* wire : *a_Wires) {
         wire->paint(painter);
-        if (wire->Label) {
-            wire->Label->paint(painter); // separate because of paintSelected
+        if (wire->hasLabel()) {
+            wire->label()->paint(painter); // separate because of paintSelected
         }
     }
 
     for (auto* node : *a_Nodes) {
         node->paint(painter);
-        if (node->Label) {
-            node->Label->paint(painter); // separate because of paintSelected
+        if (node->hasLabel()) {
+            node->label()->paint(painter); // separate because of paintSelected
         }
     }
 
@@ -817,7 +817,7 @@ void Schematic::paintSchToViewpainter(QPainter* painter, bool printAll) {
             draw_preserve_selection(wire, painter);
         }
 
-        if (auto* label = wire->Label) {
+        if (auto* label = wire->label()) {
             if (should_draw(label)) {
                 draw_preserve_selection(label, painter);
             }
@@ -832,7 +832,7 @@ void Schematic::paintSchToViewpainter(QPainter* painter, bool printAll) {
             }
         }
 
-        if (auto* label = node->Label) {
+        if (auto* label = node->label()) {
             if (should_draw(label)) {
                 draw_preserve_selection(label, painter);
             }
@@ -1137,11 +1137,11 @@ void Schematic::updateAllBoundingRect()
 
     for (auto* pw : *a_Wires) {
         internal::unite(totalBounds, pw->boundingRect());
-        if (pw->Label) internal::unite(totalBounds, pw->Label->boundingRect());
+        if (pw->hasLabel()) internal::unite(totalBounds, pw->label()->boundingRect());
     }
 
     for (auto* pn : *a_Nodes) {
-        if (pn->Label) internal::unite(totalBounds, pn->Label->boundingRect());
+        if (pn->hasLabel()) internal::unite(totalBounds, pn->label()->boundingRect());
     }
 
     for (auto* pd : *a_Diagrams) {
@@ -1179,9 +1179,9 @@ Schematic::Selection Schematic::currentSelection() const {
             internal::unite(totalBounds, pw->boundingRect());
         }
 
-        if (pw->Label != nullptr && pw->Label->isSelected) { // check position of wire label
-            selection.labels.push_back(pw->Label);
-            internal::unite(totalBounds, pw->Label->boundingRect());
+        if (pw->hasLabel() && pw->label()->isSelected) { // check position of wire label
+            selection.labels.push_back(pw->label());
+            internal::unite(totalBounds, pw->label()->boundingRect());
         }
     }
 
@@ -1190,9 +1190,9 @@ Schematic::Selection Schematic::currentSelection() const {
             selection.nodes.push_back(pn);
         }
 
-        if (pn->Label != nullptr && pn->Label->isSelected) { // check position of node label
-            selection.labels.push_back(pn->Label);
-            internal::unite(totalBounds, pn->Label->boundingRect());
+        if (pn->hasLabel() && pn->label()->isSelected) { // check position of node label
+            selection.labels.push_back(pn->label());
+            internal::unite(totalBounds, pn->label()->boundingRect());
         }
     }
 

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -383,10 +383,8 @@ void merge(Node* donor, Node* recipient) {
     }
 
     // Try to keep donor label
-    if (recipient->Label == nullptr && donor->Label != nullptr) {
-        recipient->Label = donor->Label;
-        recipient->Label->pOwner = recipient;
-        donor->Label = nullptr;
+    if (!recipient->hasLabel() && donor->hasLabel()) {
+        recipient->acquireLabel(donor->releaseLabel());
     }
 }
 
@@ -437,17 +435,15 @@ Wire* merge_wires_at_node(Node* node) {
 
     // First of all, let's deal with labels. Label of node, if present, has
     // priority over wire labels.
-    auto* preserved_label = node->Label;
-
-    if (preserved_label == nullptr) {
-        // Node has no label, choose label of one of the wires
-        preserved_label = extended_wire->Label == nullptr ? dissapearing_wire->Label : extended_wire->Label;
+    std::unique_ptr<WireLabel> preserved_label;
+    if (node->hasLabel()) {
+        preserved_label = node->releaseLabel();
     }
-
-    // Isolate preserved label completely
-    if (preserved_label != nullptr) {
-        preserved_label->pOwner->Label = nullptr;
-        preserved_label->pOwner = nullptr;
+    else {
+        // Node has no label, choose label of one of the wires
+        preserved_label = extended_wire->hasLabel()
+                        ? extended_wire->releaseLabel()
+                        : dissapearing_wire->releaseLabel();
     }
 
     auto* extend_to = dissapearing_wire->Port1 == node
@@ -475,9 +471,7 @@ Wire* merge_wires_at_node(Node* node) {
     extended_wire->setP2(extended_wire->Port2->center());
 
     if (preserved_label != nullptr) {
-        delete extended_wire->Label;
-        extended_wire->Label = preserved_label;
-        preserved_label->pOwner = extended_wire;
+        extended_wire->acquireLabel(std::move(preserved_label));
     }
 
     return dissapearing_wire;
@@ -563,12 +557,10 @@ Wire* Schematic::splitWire(Wire *source_wire, Node *splitter_node)
     source_wire->connectPort2(splitter_node);
     a_Wires->push_back(new_wire);
 
-    if(source_wire->Label)
-        if((source_wire->Label->cx > splitter_node->cx) || (source_wire->Label->cy > splitter_node->cy))
+    if(source_wire->hasLabel())
+        if((source_wire->label()->cx > splitter_node->cx) || (source_wire->label()->cy > splitter_node->cy))
         {
-            new_wire->Label = source_wire->Label;   // label goes to the new wire
-            source_wire->Label = 0;
-            new_wire->Label->pOwner = new_wire;
+            new_wire->acquireLabel(source_wire->releaseLabel());   // label goes to the new wire
         }
 
     return new_wire;
@@ -677,7 +669,7 @@ Element* Schematic::selectElement(float fX, float fY, bool flag, int *index)
             }
         }
 
-        pl = pn->Label; // Get any wire label associated with the Node
+        pl = pn->label(); // Get any wire label associated with the Node
         if(pl)
         {
             if(pl->getSelected(x, y))
@@ -739,7 +731,7 @@ Element* Schematic::selectElement(float fX, float fY, bool flag, int *index)
                 pe_sel = pw;
             }
         }
-        pl = pw->Label; // test any label associated with the wire
+        pl = pw->label(); // test any label associated with the wire
         if(pl)
         {
             if(pl->getSelected(x, y))
@@ -974,11 +966,11 @@ void Schematic::highlightWireLabels ()
     // First set highlighting for all wire and nodes labels to false
 
     for (auto* wire : *a_Wires) {
-        if (wire->Label != nullptr) wire->Label->setHighlighted(false);
+        if (wire->hasLabel()) wire->label()->setHighlighted(false);
     }
 
     for(Node* node : *a_Nodes) {
-        if (node->Label != nullptr) node->Label->setHighlighted(false);
+        if (node->hasLabel()) node->label()->setHighlighted(false);
     }
 
 
@@ -990,7 +982,7 @@ void Schematic::highlightWireLabels ()
     for (auto* pwouter : *a_Wires)
     {
         // get any label associated with the wire
-        pltestouter = pwouter->Label;
+        pltestouter = pwouter->label();
         if (pltestouter)
         {
             if (pltestouter->isSelected)
@@ -999,7 +991,7 @@ void Schematic::highlightWireLabels ()
                 // Search for matching labels on wires
                 for (Wire* pwinner : *a_Wires)
                 {
-                    pltestinner = pwinner->Label; // test any label associated with the wire
+                    pltestinner = pwinner->label(); // test any label associated with the wire
                     if (pltestinner)
                     {
                         // Highlight the label if it has the same name as the selected label
@@ -1017,7 +1009,7 @@ void Schematic::highlightWireLabels ()
                 // Search for matching labels on nodes
                 for (auto* pninner : *a_Nodes)
                 {
-                    pltestinner = pninner->Label; // test any label associated with the node
+                    pltestinner = pninner->label(); // test any label associated with the node
                     if (pltestinner)
                     {
                         if (pltestouter->Name == pltestinner->Name)
@@ -1039,7 +1031,7 @@ void Schematic::highlightWireLabels ()
     for (auto* pnouter : *a_Nodes)
     {
         // get any label associated with the node
-        pltestouter = pnouter->Label;
+        pltestouter = pnouter->label();
         if (pltestouter)
         {
             if (pltestouter->isSelected)
@@ -1048,7 +1040,7 @@ void Schematic::highlightWireLabels ()
                 // Search for matching labels on wires
                 for (auto* pwinner : *a_Wires)
                 {
-                    pltestinner = pwinner->Label; // test any label associated with the wire
+                    pltestinner = pwinner->label(); // test any label associated with the wire
                     if (pltestinner)
                     {
                         if (pltestouter->Name == pltestinner->Name)
@@ -1062,7 +1054,7 @@ void Schematic::highlightWireLabels ()
                 // Search for matching labels on nodes
                 for (auto* pninner : *a_Nodes)
                 {
-                    pltestinner = pninner->Label; // test any label associated with the node
+                    pltestinner = pninner->label(); // test any label associated with the node
                     if (pltestinner)
                     {
                         // Highlight the label if it has the same name as the selected label
@@ -1135,13 +1127,13 @@ int Schematic::selectElements(const QRect& selection_rect, bool append, bool ent
             selected_count++;
         }
 
-        if (wire->Label != nullptr && select_element(wire->Label, wire->Label->boundingRect())) {
+        if (wire->hasLabel() && select_element(wire->label(), wire->label()->boundingRect())) {
             selected_count++;
         }
     }
 
     for (Node *node : *a_Nodes) {
-        if (node->Label != nullptr && select_element(node->Label, node->Label->boundingRect())) {
+        if (node->hasLabel() && select_element(node->label(), node->label()->boundingRect())) {
             selected_count++;
         }
     }
@@ -1191,8 +1183,7 @@ bool Schematic::deleteElements()
     auto selection = currentSelection();
 
     for (auto* l : selection.labels) {
-        l->pOwner->Label = nullptr;
-        delete l;
+        l->pOwner->dropLabel();
         sel = true;
     }
 
@@ -1816,8 +1807,7 @@ void Schematic::insertRawComponent(Component *c, bool noOptimize)
         Element *pe = getWireLabel(c->Ports.first()->Connection);
         if(pe) if((pe->Type & isComponent) == 0)
             {
-                delete ((Conductor*)pe)->Label;
-                ((Conductor*)pe)->Label = 0;
+                ((Conductor*)pe)->dropLabel();
             }
         c->Model = "GND";    // rebuild component model
     }
@@ -1827,9 +1817,8 @@ void Schematic::recreateComponent(Component* comp)
 {
     std::stack<WireLabel*> saved_labels{};
     for (auto* port : comp->Ports) {
-        if (port->Connection->Label != nullptr && port->Connection->conn_count() == 1) {
-            saved_labels.push(port->Connection->Label);
-            port->Connection->Label = nullptr;
+        if (port->Connection->hasLabel() && port->Connection->conn_count() == 1) {
+            saved_labels.push(port->Connection->releaseLabel().release());
         }
     }
 
@@ -1890,8 +1879,7 @@ void Schematic::insertComponent(Component *c)
             Element *pe = getWireLabel(c->Ports.first()->Connection);
             if(pe) if((pe->Type & isComponent) == 0)
                 {
-                    delete ((Conductor*)pe)->Label;
-                    ((Conductor*)pe)->Label = 0;
+                    ((Conductor*)pe)->dropLabel();
                 }
             c->Model = "GND";    // rebuild component model
         }
@@ -2102,14 +2090,13 @@ void Schematic::oneLabel(Node *start_node)
     start_node->y1 = 1;  // mark Node as already checked
     for (auto* node : checked_nodes) {
 
-        if (node->Label) {
+        if (node->hasLabel()) {
             if (named) {
-                delete node->Label;
-                node->Label = nullptr;
+                node->dropLabel();
             }
             else {
                 named = true;
-                pl = node->Label;
+                pl = node->label();
             }
         }
 
@@ -2123,8 +2110,7 @@ void Schematic::oneLabel(Node *start_node)
                 if (comp->isActive == COMP_IS_ACTIVE && comp->Model == "GND") {
                     named = true;
                     if (pl) {
-                        pl->pOwner->Label = nullptr;
-                        delete pl;
+                        pl->pOwner->dropLabel();
                     }
                     pl = nullptr;
                 }
@@ -2137,13 +2123,12 @@ void Schematic::oneLabel(Node *start_node)
             other_node->y1 = 1;  // mark Node as already checked
             checked_nodes.push_back(other_node);
 
-            if (wire->Label) {
+            if (wire->hasLabel()) {
                 if (named) {
-                    delete wire->Label;
-                    wire->Label = nullptr;    // erase double names
+                    wire->dropLabel();
                 } else {
                     named = true;
-                    pl = wire->Label;
+                    pl = wire->label();
                 }
             }
         }
@@ -2166,13 +2151,11 @@ int Schematic::placeNodeLabel(WireLabel *pl)
             return -2;  // ground potential
         }
 
-        delete ((Conductor*)pe)->Label;
-        ((Conductor*)pe)->Label = 0;
+        ((Conductor*)pe)->dropLabel();
     }
 
-    pn->Label = pl;   // insert node label
+    pn->acquireLabel(pl);   // insert node label
     pl->Type = isNodeLabel;
-    pl->pOwner = pn;
     return 0;
 }
 
@@ -2191,7 +2174,7 @@ Element* Schematic::getWireLabel(Node *pn_)
     Cons.push_back(pn_);
     pn_->y1 = 1;  // mark Node as already checked
     for(auto* pn : Cons)
-        if(pn->Label) return pn;
+        if(pn->hasLabel()) return pn;
         else
             for(auto* pe : *pn)
             {
@@ -2203,7 +2186,7 @@ Element* Schematic::getWireLabel(Node *pn_)
                 }
 
                 pw = (Wire*)pe;
-                if(pw->Label) return pw;
+                if(pw->hasLabel()) return pw;
 
                 if(pn != pw->Port1) pNode = pw->Port1;
                 else pNode = pw->Port2;
@@ -2328,8 +2311,7 @@ std::pair<bool,Node*> Schematic::installWire(Wire* wire)
         qucs_s::geom::on_line(port1, port2, a_Nodes->begin(), a_Nodes->end());
 
     // Save for later
-    auto* wire_label = wire->Label;
-    wire->Label      = nullptr;
+    auto wire_label = wire->releaseLabel();
 
     // All the nodes the wire goes over taken by pairs, e.g. if the wires
     // goes over nodes A, B, C, D, then this is the sequence of [(A,B), (B,C),
@@ -2385,13 +2367,11 @@ std::pair<bool,Node*> Schematic::installWire(Wire* wire)
         auto* existing_wire =
             internal::find_wire(last_pair.first, last_pair.second, a_Wires->begin(), a_Wires->end());
 
-        if (wire->Label == nullptr) {
-            wire->Label = existing_wire->Label;
-            existing_wire->Label = nullptr;
+        if (!wire->hasLabel()) {
+            wire->acquireLabel(existing_wire->releaseLabel());
         } else {
-            delete existing_wire->Label;
-            existing_wire->Label = nullptr;
-        }
+            existing_wire->dropLabel();
+         }
 
         // Detach last wire
         existing_wire->Port1->disconnect(existing_wire);
@@ -2431,18 +2411,14 @@ std::pair<bool,Node*> Schematic::installWire(Wire* wire)
         if (wire_label->cx == node_pair.first->x() &&
             wire_label->cy == node_pair.first->y())
              {
-                delete node_pair.first->Label;
-                node_pair.first->Label = wire_label;
-                wire_label             = nullptr;
+                node_pair.first->acquireLabel(std::move(wire_label));
                 break;
              }
 
         // Second node of a pair
         if (wire_label->cx == node_pair.second->x() &&
             wire_label->cy == node_pair.second->y()) {
-                delete node_pair.second->Label;
-                node_pair.first->Label = wire_label;
-                wire_label             = nullptr;
+                node_pair.second->acquireLabel(std::move(wire_label));
                 break;
              }
 
@@ -2454,9 +2430,7 @@ std::pair<bool,Node*> Schematic::installWire(Wire* wire)
 
         if (qucs_s::geom::is_between(QPoint{wire_label->cx, wire_label->cy},
                                      a_wire->Port1, a_wire->Port2)) {
-            delete a_wire->Label;
-            a_wire->Label = wire_label;
-            wire_label    = nullptr;
+            a_wire->acquireLabel(std::move(wire_label));
             break;
          }
     }
@@ -2502,12 +2476,10 @@ public:
     }
 
     void putLabel(WireLabel* label, Node* dest_node) override {
-        delete dest_node->Label;
+        dest_node->dropLabel();
 
         // Transfer label to a new host
-        label->pOwner->Label = nullptr;
-        dest_node->Label = label;
-        label->pOwner = dest_node;
+        dest_node->acquireLabel(label);
         label->Type = isNodeLabel;
         label->moveRootTo(dest_node->center().x(), dest_node->center().y());
     }
@@ -2619,9 +2591,8 @@ bool Schematic::heal(const HealingParams* params) {
             qucs_s::UnorderedPair<Node*,Node*> p{wire->Port1, wire->Port2};
 
             if (unique_wires.contains(p)) {
-                if (unique_wires.at(p)->Label == nullptr) {
-                    unique_wires.at(p)->Label = wire->Label;
-                    wire->Label = nullptr;
+                if (!unique_wires.at(p)->hasLabel()) {
+                    unique_wires.at(p)->acquireLabel(wire->releaseLabel());
                 }
                 wire_duplicates.push_back(wire);
             } else {
@@ -2701,9 +2672,8 @@ bool Schematic::heal(const HealingParams* params) {
             qucs_s::UnorderedPair<Node*,Node*> p{wire->Port1, wire->Port2};
 
             if (unique_wires.contains(p)) {
-                if (unique_wires.at(p)->Label == nullptr) {
-                    unique_wires.at(p)->Label = wire->Label;
-                    wire->Label = nullptr;
+                if (!unique_wires.at(p)->hasLabel()) {
+                    unique_wires.at(p)->acquireLabel(wire->releaseLabel());
                 }
                 wire_duplicates.push_back(wire);
             } else {

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -2408,16 +2408,13 @@ std::pair<bool,Node*> Schematic::installWire(Wire* wire)
         // as one of the nodes over which the wire goes over
 
         // First node of a pair
-        if (wire_label->cx == node_pair.first->x() &&
-            wire_label->cy == node_pair.first->y())
-             {
+        if (wire_label->root() == node_pair.first->center()) {
                 node_pair.first->acquireLabel(std::move(wire_label));
                 break;
              }
 
         // Second node of a pair
-        if (wire_label->cx == node_pair.second->x() &&
-            wire_label->cy == node_pair.second->y()) {
+        if (wire_label->root() == node_pair.second->center()) {
                 node_pair.second->acquireLabel(std::move(wire_label));
                 break;
              }
@@ -2428,8 +2425,7 @@ std::pair<bool,Node*> Schematic::installWire(Wire* wire)
         auto* a_wire =
             internal::find_wire(node_pair.first, node_pair.second, a_Wires->begin(), a_Wires->end());
 
-        if (qucs_s::geom::is_between(QPoint{wire_label->cx, wire_label->cy},
-                                     a_wire->Port1, a_wire->Port2)) {
+        if (qucs_s::geom::is_between(wire_label->root(), a_wire->P1(), a_wire->P2())) {
             a_wire->acquireLabel(std::move(wire_label));
             break;
          }

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -1183,7 +1183,7 @@ bool Schematic::deleteElements()
     auto selection = currentSelection();
 
     for (auto* l : selection.labels) {
-        l->pOwner->dropLabel();
+        l->owner()->dropLabel();
         sel = true;
     }
 
@@ -2110,7 +2110,7 @@ void Schematic::oneLabel(Node *start_node)
                 if (comp->isActive == COMP_IS_ACTIVE && comp->Model == "GND") {
                     named = true;
                     if (pl) {
-                        pl->pOwner->dropLabel();
+                        pl->owner()->dropLabel();
                     }
                     pl = nullptr;
                 }
@@ -2142,6 +2142,9 @@ int Schematic::placeNodeLabel(WireLabel *pl)
     if (node == a_Nodes->end()) return -1;
 
     Node* pn = *node;
+
+    if (pn == pl->owner()) return 0;
+
     Element *pe = getWireLabel(pn);
     if(pe)      // name found ?
     {

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -548,20 +548,38 @@ Wire* Schematic::selectedWire(int x, int y)
     return 0;
 }
 
-// ---------------------------------------------------
-// Splits the wire "*pw" into two pieces by the node "*pn".
+// Splits the wire into two pieces by the node
 Wire* Schematic::splitWire(Wire *source_wire, Node *splitter_node)
 {
+    // It's definetely abnormal usage if the node doesn't lie on the wire
+    assert(qucs_s::geom::is_between(splitter_node, source_wire->P1(), source_wire->P2()));
+
+    // Create new wire
     Wire *new_wire = new Wire(splitter_node, source_wire->Port2);
     new_wire->isSelected = source_wire->isSelected;
-    source_wire->connectPort2(splitter_node);
     a_Wires->push_back(new_wire);
 
-    if(source_wire->hasLabel())
-        if((source_wire->label()->cx > splitter_node->cx) || (source_wire->label()->cy > splitter_node->cy))
-        {
-            new_wire->acquireLabel(source_wire->releaseLabel());   // label goes to the new wire
+    // Preserve label. Label has to be detached from host *before* schrinking the
+    // source wire in order to not move label's root. When size of a wire is
+    // changed, wire tries to preserve the ratio between distances from label root
+    // to wire ports. This is not wanted here and label root must stay in place.
+    auto label = source_wire->releaseLabel();
+
+    // Schrink source wire
+    source_wire->connectPort2(splitter_node);
+
+    // Find a host for the label
+    if (label != nullptr) {
+        if (qucs_s::geom::is_between(label->root(), new_wire->P1(), new_wire->P2())) {
+            new_wire->acquireLabel(std::move(label));
         }
+        else if (qucs_s::geom::is_between(label->root(), source_wire->P1(), source_wire->P2())) {
+            source_wire->acquireLabel(std::move(label));
+        }
+        else if (!splitter_node->hasLabel() && label->root() == splitter_node->center()) {
+            splitter_node->acquireLabel(std::move(label));
+        }
+    }
 
     return new_wire;
 }

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -930,7 +930,7 @@ bool Schematic::loadWires(QTextStream *stream, std::list<Element*> *List)
       }
 
       List->push_back(w);
-      if(w->hasLabel())  List->push_back(w->releaseLabel().release());
+      if(w->hasLabel())  List->push_back(w->label());
     }
     else {
       simpleInsertWire(w);

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -81,15 +81,15 @@ QString Schematic::createClipboardFile()
   for(Wire* pw : *a_Wires)
     if(pw->isSelected) {
       z++;
-      if(pw->Label) if(!pw->Label->isSelected) {
+      if(pw->hasLabel()) if(!pw->label()->isSelected) {
         s += pw->save().section('"', 0, 0)+"\"\" 0 0 0>\n";
         continue;
       }
       s += pw->save()+"\n";
     }
   for(Node *pn : *a_Nodes)
-    if(pn->Label) if(pn->Label->isSelected) {
-      s += pn->Label->save()+"\n";  z++; }
+    if(pn->hasLabel()) if(pn->label()->isSelected) {
+      s += pn->label()->save()+"\n";  z++; }
   s += "</Wires>\n";
 
   s += "<Diagrams>\n";
@@ -625,7 +625,7 @@ int Schematic::saveDocument()
 
   // save all labeled nodes as wires
   for(Node *pn : a_DocNodes)
-    if(pn->Label) stream << "  " << pn->Label->save() << "\n";
+    if(pn->hasLabel()) stream << "  " << pn->label()->save() << "\n";
   stream << "</Wires>\n";
 
   stream << "<Diagrams>\n";    // save all diagrams
@@ -880,12 +880,11 @@ void Schematic::simpleInsertWire(Wire *pw)
   Node* pn = provideNode(pw->P1());
 
   if(pw->P1() == pw->P2()) {
-    pn->Label = pw->Label;   // wire with length zero are just node labels
-    if (pn->Label) {
-      pn->Label->Type = isNodeLabel;
-      pn->Label->pOwner = pn;
+    pn->acquireLabel(pw->releaseLabel());   // wire with length zero are just node labels
+    if (pn->hasLabel()) {
+      pn->label()->Type = isNodeLabel;
     }
-    pw->Label = nullptr;
+
     delete pw;           // delete wire because this is not a wire
     return;
   }
@@ -923,17 +922,15 @@ bool Schematic::loadWires(QTextStream *stream, std::list<Element*> *List)
       // Only the label is kept, so it becomes "free" i.e. not having
       // a host element like wire or node. We must be careful to treat
       // such labels in a special way in other parts of the codebase.
-      if (w->P1() == w->P2() && w->Label) {
-        w->Label->Type = isNodeLabel;
-        List->push_back(w->Label);
-        w->Label->pOwner = nullptr;
-        w->Label = nullptr;
+      if (w->P1() == w->P2() && w->hasLabel()) {
+        w->label()->Type = isNodeLabel;
+        List->push_back(w->releaseLabel().release());
         delete w;
         continue;
       }
 
       List->push_back(w);
-      if(w->Label)  List->push_back(w->Label);
+      if(w->hasLabel())  List->push_back(w->releaseLabel().release());
     }
     else {
       simpleInsertWire(w);
@@ -1156,7 +1153,7 @@ QString Schematic::createUndoString(char Op)
     s += pw->save()+"\n";
   // save all labeled nodes as wires
   for(Node *pn : a_DocNodes)
-    if(pn->Label) s += pn->Label->save()+"\n";
+    if(pn->hasLabel()) s += pn->label()->save()+"\n";
   s += "</>\n";
 
   for(auto* pd : a_DocDiags)
@@ -1243,10 +1240,10 @@ bool Schematic::rebuildSymbol(QString *s)
 void Schematic::createNodeSet(QStringList& Collect, int& countInit,
           Conductor *pw, Node *p1)
 {
-  if(pw->Label)
-    if(!pw->Label->initValue.isEmpty())
+  if(pw->hasLabel())
+    if(!pw->label()->initValue.isEmpty())
       Collect.append("NodeSet:NS" + QString::number(countInit++) + " " +
-                     p1->Name + " U=\"" + pw->Label->initValue + "\"");
+                     p1->Name + " U=\"" + pw->label()->initValue + "\"");
 }
 
 // ---------------------------------------------------
@@ -1644,22 +1641,22 @@ bool Schematic::giveNodeNames(QTextStream *stream, int& countInit,
   // delete the node names
   for(Node *pn : a_DocNodes) {
     pn->State = 0;
-    if(pn->Label) {
+    if(pn->hasLabel()) {
       if(a_isAnalog)
-        pn->Name = pn->Label->Name;
+        pn->Name = pn->label()->Name;
       else
-        pn->Name = "net" + pn->Label->Name;
+        pn->Name = "net" + pn->label()->Name;
     }
     else pn->Name = "";
   }
 
   // set the wire names to the connected node
   for(Wire *pw : a_DocWires)
-    if(pw->Label != 0) {
+    if(pw->hasLabel()) {
       if(a_isAnalog)
-        pw->Port1->Name = pw->Label->Name;
+        pw->Port1->Name = pw->label()->Name;
       else  // avoid to use reserved VHDL words
-        pw->Port1->Name = "net" + pw->Label->Name;
+        pw->Port1->Name = "net" + pw->label()->Name;
     }
 
   // go through components

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -916,6 +916,10 @@ bool Schematic::loadWires(QTextStream *stream, std::list<Element*> *List)
       delete w;
       return false;
     }
+
+    // When this pointer is not null, "paste" operation is in progress.
+    // In this case loaded elements must be placed in the list and not
+    // into schematic.
     if(List) {
 
       // Special case: node label. It's stored as zero-length wire.
@@ -930,6 +934,15 @@ bool Schematic::loadWires(QTextStream *stream, std::list<Element*> *List)
       }
 
       List->push_back(w);
+
+      // Label is also added to the list as *independent* element. This is
+      // because items of this list a subject of moving, rotating, etc. and
+      // label must be treated the same way.
+      //
+      // Think of the list as of "selected items" and it will instantly make
+      // sense.
+      //
+      // Label ownership is still controlled by the host wire.
       if(w->hasLabel())  List->push_back(w->label());
     }
     else {

--- a/qucs/wire.cpp
+++ b/qucs/wire.cpp
@@ -33,7 +33,6 @@ Wire::Wire(int _x1, int _y1, int _x2, int _y2)
 
   Port1 = nullptr;
   Port2 = nullptr;
-  Label = nullptr;
 
   Type = isWire;
   isSelected = false;
@@ -46,20 +45,15 @@ Wire::Wire(Node* n1, Node* n2)
   connectPort2(n2);
 }
 
-Wire::~Wire()
-{
-  delete Label;
-}
-
 bool Wire::rotate() noexcept
 {
   qucs_s::geom::rotate_point_ccw(x1, y1, cx, cy);
   qucs_s::geom::rotate_point_ccw(x2, y2, cx, cy);
 
-  if (Label != nullptr) {
-    auto r = Label->root();
+  if (hasLabel()) {
+    auto r = label()->root();
     qucs_s::geom::rotate_point_ccw(r.rx(), r.ry(), cx, cy);
-    Label->moveRootTo(r.x(), r.y());
+    label()->moveRootTo(r.x(), r.y());
   }
 
   return true;
@@ -122,22 +116,20 @@ void Wire::setName(int distFromPort1, int text_x, int text_y, const QString& nam
 void Wire::setName(const QString& Name_, const QString& Value_, int root_x, int root_y, int x_, int y_)
 {
   if(Name_.isEmpty() && Value_.isEmpty()) {
-    delete Label;
-    Label = nullptr;
+    dropLabel();
     return;
   }
 
-  if(!Label) {
+  if(!hasLabel()) {
     if (y1 == y2)
-      Label = new WireLabel(Name_, root_x, y1, x_, y_, isHWireLabel);
+      acquireLabel(new WireLabel(Name_, root_x, y1, x_, y_, isHWireLabel));
     else if (x1 == x2)
-      Label = new WireLabel(Name_, x1, root_y, x_, y_, isVWireLabel);
+      acquireLabel(new WireLabel(Name_, x1, root_y, x_, y_, isVWireLabel));
     else
-      Label = new WireLabel(Name_, root_x, root_y, x_, y_, isLabel);
-    Label->pOwner = this;
-    Label->initValue = Value_;
+      acquireLabel(new WireLabel(Name_, root_x, root_y, x_, y_, isLabel));
+    label()->initValue = Value_;
   }
-  else Label->setName(Name_);
+  else label()->setName(Name_);
 }
 
 // Converts all necessary data of the wire into a string. This can be used to
@@ -146,11 +138,11 @@ QString Wire::save()
 {
   QString s  = "<"+QString::number(x1)+" "+QString::number(y1);
           s += " "+QString::number(x2)+" "+QString::number(y2);
-  if(Label) {
-          s += " \""+Label->Name+"\" ";
-          s += QString::number(Label->x1)+" "+QString::number(Label->y1)+" ";
-          s += QString::number(static_cast<int>(qucs_s::geom::distance(QPoint{x1, y1}, Label->root())));
-          s += " \""+Label->initValue+"\">";
+  if(hasLabel()) {
+          s += " \""+label()->Name+"\" ";
+          s += QString::number(label()->x1)+" "+QString::number(label()->y1)+" ";
+          s += QString::number(static_cast<int>(qucs_s::geom::distance(QPoint{x1, y1}, label()->root())));
+          s += " \""+label()->initValue+"\">";
   }
   else { s += R"( "" 0 0 0 "">)"; }
   return s;
@@ -229,7 +221,7 @@ bool Wire::moveCenter(int dx, int dy) noexcept
   y1 += dy;
   x2 += dx;
   y2 += dy;
-  if (Label) Label->moveRoot(dx, dy);
+  if (hasLabel()) label()->moveRoot(dx, dy);
   return dx != 0 || dy != 0;
 }
 
@@ -240,15 +232,15 @@ bool Wire::setP1(const QPoint& new_p1)
     return false;
   }
 
-  if (Label != nullptr) {
+  if (hasLabel()) {
     const QPoint old_p1{x1, y1};
     const QPoint p2{x2, y2};
 
-    const auto ratio = qucs_s::geom::distance(old_p1, Label->root()) / qucs_s::geom::distance(old_p1, p2);
+    const auto ratio = qucs_s::geom::distance(old_p1, label()->root()) / qucs_s::geom::distance(old_p1, p2);
     const auto x = static_cast<int>(std::round(new_p1.x() + ratio * (p2.x() - new_p1.x())));
     const auto y = static_cast<int>(std::round(new_p1.y() + ratio * (p2.y() - new_p1.y())));
 
-    Label->moveRootTo(x, y);
+    label()->moveRootTo(x, y);
   }
 
   x1 = new_p1.x();
@@ -266,15 +258,15 @@ bool Wire::setP2(const QPoint& new_p2)
     return false;
   }
 
-  if (Label != nullptr) {
+  if (hasLabel()) {
     const QPoint p1{x1, y1};
     const QPoint old_p2{x2, y2};
 
-    const auto ratio = qucs_s::geom::distance(p1, Label->root()) / qucs_s::geom::distance(p1, old_p2);
+    const auto ratio = qucs_s::geom::distance(p1, label()->root()) / qucs_s::geom::distance(p1, old_p2);
     const auto x = static_cast<int>(std::round(p1.x() + ratio * (new_p2.x() - p1.x())));
     const auto y = static_cast<int>(std::round(p1.y() + ratio * (new_p2.y() - p1.y())));
 
-    Label->moveRootTo(x, y);
+    label()->moveRootTo(x, y);
   }
 
   x2 = new_p2.x();
@@ -323,3 +315,4 @@ inline void Wire::updateCenter() noexcept {
   cx = std::midpoint(x1, x2);
   cy = std::midpoint(y1, y2);
 }
+

--- a/qucs/wire.h
+++ b/qucs/wire.h
@@ -19,7 +19,6 @@
 #define WIRE_H
 
 #include "conductor.h"
-#include "wirelabel.h"
 
 class Schematic;
 class QPainter;
@@ -30,7 +29,6 @@ class Wire : public Conductor {
 public:
   Wire(int _x1=0, int _y1=0, int _x2=0, int _y2=0);
   Wire(Node* n1, Node* n2);
- ~Wire() override;
 
   void paint(QPainter* painter) const;
   void paintScheme(Schematic* sch) override;

--- a/qucs/wirelabel.cpp
+++ b/qucs/wirelabel.cpp
@@ -211,3 +211,16 @@ QRect WireLabel::boundingRect() const noexcept
     .normalized()
     .united(QRect{{x1, y1}, textSize}.normalized());
 }
+
+void WireLabel::setOwner(Conductor* c)
+{
+  pOwner = c;
+
+  if (c == nullptr) return;
+
+  if (Wire* w = dynamic_cast<Wire*>(c); w != nullptr) {
+    Type = w->isHorizontal() ? isHWireLabel : isVWireLabel;
+  } else {
+    Type = isNodeLabel;
+  }
+}

--- a/qucs/wirelabel.h
+++ b/qucs/wirelabel.h
@@ -27,6 +27,7 @@ class QPainter;
 
 
 class WireLabel : public Element {
+  Conductor* pOwner = nullptr;  // Wire or Node where label belongs to
 public:
   WireLabel(const QString& _Name=0, int _cx=0, int _cy=0,
             int _x1=0, int _y1=0, int _Type=isNodeLabel);
@@ -36,7 +37,8 @@ public:
   void setHighlighted (bool newval) { isHighlighted = newval; };
 
 
-  Conductor* pOwner = nullptr;  // Wire or Node where label belongs to
+  void setOwner(Conductor* c);
+  Conductor* owner() const { return pOwner; }
   QString Name = "";
   QString initValue = "";
 

--- a/qucs/wirelabel.h
+++ b/qucs/wirelabel.h
@@ -18,10 +18,11 @@
 #ifndef WIRELABEL_H
 #define WIRELABEL_H
 
-#include "conductor.h"
-
 #include <QString>
 
+#include "element.h"
+
+class Conductor;
 class QPainter;
 
 


### PR DESCRIPTION
Hi, Vadim!

#1398 is once again caused by improper memory management of labels. I've refactored control of conductor labels to make it less tedious — to avoid explicit deletes, assigning nullptrs, etc. Main character here is the `Conductor` interface which is not just a plain storage for a pointer anymore, but offers a set of methods for consistent control of labels.

I've tested it a bit. It solves the problem described in #1398. I believe it should be okay overall, but can't guarantee something has not been broken. Anyway, let's give it a try, I'm here to fix in case of any problems.

Fixes: #1398