### PR TITLE
Remove some label types in favour of single 'isLabel'

### DIFF
--- a/qucs/element.h
+++ b/qucs/element.h
@@ -165,12 +165,6 @@ struct Text : qucs::DrawingPrimitive {
 #define isPaintingResize   0x2001
 
 #define isLabel            0x4000
-#define isHWireLabel       0x4020
-#define isVWireLabel       0x4040
-#define isNodeLabel        0x4080
-#define isMovingLabel      0x4001
-#define isHMovingLabel     0x4002
-#define isVMovingLabel     0x4004
 
 #define isDiagram          0x8000
 #define isDiagramResize    0x8001

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1618,9 +1618,14 @@ void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
                 Doc->enlargeView(pe);
                 break;
             }
-            case isNodeLabel:
-                Doc->placeNodeLabel((WireLabel *) pe);
+            case isLabel: {
+                auto wl = dynamic_cast<WireLabel*>(pe);
+                if (wl->owner() != nullptr) break;
+                // If label here has no owner it means it was a node label.
+                // New host node has to be found for it.
+                Doc->placeNodeLabel(wl);
                 break;
+            }
             case isComponent:
             case isAnalogComponent:
             case isDigitalComponent:
@@ -1817,9 +1822,6 @@ void MouseActions::editElement(Schematic *Doc, QMouseEvent *Event)
         MPressLabel(Doc, Event, fX, fY);
         break;
 
-    case isNodeLabel:
-    case isHWireLabel:
-    case isVWireLabel:
     case isLabel:
         editLabel(Doc, (WireLabel *) focusElement);
         // update highlighting, labels may have changed

--- a/qucs/node.cpp
+++ b/qucs/node.cpp
@@ -75,7 +75,7 @@ void Node::setName(const QString& name, const QString& value, int x, int y)
   assert(!(name.isEmpty() && value.isEmpty()));
 
   if (!hasLabel()) {
-    acquireLabel(new WireLabel(name, cx, cy, x, y, isNodeLabel));
+    acquireLabel(new WireLabel(name, cx, cy, x, y));
   }
   else {
     label()->setName(name);

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -2182,7 +2182,6 @@ int Schematic::placeNodeLabel(WireLabel *pl)
     }
 
     pn->acquireLabel(pl);   // insert node label
-    pl->Type = isNodeLabel;
     return 0;
 }
 
@@ -2503,7 +2502,6 @@ public:
 
         // Transfer label to a new host
         dest_node->acquireLabel(label);
-        label->Type = isNodeLabel;
         label->moveRootTo(dest_node->center().x(), dest_node->center().y());
     }
 

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -988,10 +988,6 @@ void Schematic::simpleInsertWire(Wire *pw)
 
   if(pw->P1() == pw->P2()) {
     pn->acquireLabel(pw->releaseLabel());   // wire with length zero are just node labels
-    if (pn->hasLabel()) {
-      pn->label()->Type = isNodeLabel;
-    }
-
     delete pw;           // delete wire because this is not a wire
     return;
   }
@@ -1034,7 +1030,6 @@ bool Schematic::loadWires(QTextStream *stream, std::list<Element*> *List)
       // a host element like wire or node. We must be careful to treat
       // such labels in a special way in other parts of the codebase.
       if (w->P1() == w->P2() && w->hasLabel()) {
-        w->label()->Type = isNodeLabel;
         List->push_back(w->releaseLabel().release());
         delete w;
         continue;

--- a/qucs/wire.cpp
+++ b/qucs/wire.cpp
@@ -124,11 +124,11 @@ void Wire::setName(const QString& Name_, const QString& Value_, int root_x, int 
 
   if(!hasLabel()) {
     if (y1 == y2)
-      acquireLabel(new WireLabel(Name_, root_x, y1, x_, y_, isHWireLabel));
+      acquireLabel(new WireLabel(Name_, root_x, y1, x_, y_));
     else if (x1 == x2)
-      acquireLabel(new WireLabel(Name_, x1, root_y, x_, y_, isVWireLabel));
+      acquireLabel(new WireLabel(Name_, x1, root_y, x_, y_));
     else
-      acquireLabel(new WireLabel(Name_, root_x, root_y, x_, y_, isLabel));
+      acquireLabel(new WireLabel(Name_, root_x, root_y, x_, y_));
     label()->initValue = Value_;
   }
   else label()->setName(Name_);

--- a/qucs/wirelabel.cpp
+++ b/qucs/wirelabel.cpp
@@ -25,7 +25,7 @@
 #include <QPainter>
 
 WireLabel::WireLabel(const QString& _Name, int _cx, int _cy,
-                     int _x1, int _y1, int _Type)
+                     int _x1, int _y1)
 {
   cx = _cx;
   cy = _cy;
@@ -38,7 +38,7 @@ WireLabel::WireLabel(const QString& _Name, int _cx, int _cy,
   x2 = x1 + textSize.width();
   y2 = y1 + textSize.height();
 
-  Type = _Type;
+  Type = isLabel;
 }
 
 bool WireLabel::getSelected(int x, int y)
@@ -89,22 +89,10 @@ void WireLabel::paint(QPainter *p) const {
     bottom ? text_br.bottom() : text_br.top()
   );
 
-  if (Type != isNodeLabel) {
-    int start_angle = 0;
-    // TODO: angle need to be calculated from the wire
-    // angle or not used at all.
-    switch (Type) {
-    case isHWireLabel:
-      start_angle = 16 * (right ? 45 : 225);
-      break;
-    case isVWireLabel:
-    case isLabel: //  same as V for simplicity
-      start_angle = 16 * (bottom ? -45 : 135);
-      break;
-    default:
-      assert(false);  // shouln't get there
-    }
-
+  if (pOwner != nullptr && pOwner->Type == isWire) {
+    const int start_angle = dynamic_cast<Wire*>(pOwner)->isHorizontal()
+      ? 16 * (right  ?  45 : 225)
+      : 16 * (bottom ? -45 : 135);
     constexpr int span_angle = 16 * 270;
     p->drawArc(cx-4, cy-4, 8, 8, start_angle, span_angle);
   }
@@ -215,12 +203,4 @@ QRect WireLabel::boundingRect() const noexcept
 void WireLabel::setOwner(Conductor* c)
 {
   pOwner = c;
-
-  if (c == nullptr) return;
-
-  if (Wire* w = dynamic_cast<Wire*>(c); w != nullptr) {
-    Type = w->isHorizontal() ? isHWireLabel : isVWireLabel;
-  } else {
-    Type = isNodeLabel;
-  }
 }

--- a/qucs/wirelabel.h
+++ b/qucs/wirelabel.h
@@ -30,7 +30,7 @@ class WireLabel : public Element {
   Conductor* pOwner = nullptr;  // Wire or Node where label belongs to
 public:
   WireLabel(const QString& _Name=0, int _cx=0, int _cy=0,
-            int _x1=0, int _y1=0, int _Type=isNodeLabel);
+            int _x1=0, int _y1=0);
 
   bool getSelected(int, int);
   void setName(const QString& Name_);


### PR DESCRIPTION
- remove macros isHWireLabel, isHMovingLabel, etc.
- always use 'isLabel' type for labels

Some of the removed macros, such as isHMovingLabel are pre-#1266 legacy and are no longer in use.

The distinction between HWireLabel and VWireLabel is relevant only during painting a label and can be inferred directly from the host wire of the label. No need to keep dedicated label types for that.

Node and wire labels can be distinguished via their respective host elements, accessible through "owner()".