### PR TITLE
config: Add option for always prefixing datasets with the simulation label

### DIFF
--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -147,13 +147,19 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     appSettingsGrid->addWidget(checkFullTraceNames, 6, 1);
     checkFullTraceNames->setChecked(QucsSettings.fullTraceName);
 
-    appSettingsGrid->addWidget(new QLabel(tr("Flexible wires (requires restart):"), appSettingsTab), 7, 0);
-    allowFlexibleWires = new QCheckBox(appSettingsTab);
-    appSettingsGrid->addWidget(allowFlexibleWires, 7, 1);
+    appSettingsGrid->addWidget(new QLabel(tr("Always prefix the dataset with simulation label:")), 7, 0);
+    alwaysPrefixDataset = new QCheckBox(appSettingsTab);
+    alwaysPrefixDataset->setToolTip(tr("Always use the prefix for dataset, i.e. \"tr1.v(out)\" rather than \"v(out)\""));
+    appSettingsGrid->addWidget(alwaysPrefixDataset, 7, 1);
+    alwaysPrefixDataset->setChecked(QucsSettings.alwaysPrefixDataset);
 
-    appSettingsGrid->addWidget(new QLabel(tr("Lay wires anew when moving elements (requires restart):"), appSettingsTab), 8, 0);
+    appSettingsGrid->addWidget(new QLabel(tr("Flexible wires (requires restart):"), appSettingsTab), 8, 0);
+    allowFlexibleWires = new QCheckBox(appSettingsTab);
+    appSettingsGrid->addWidget(allowFlexibleWires, 8, 1);
+
+    appSettingsGrid->addWidget(new QLabel(tr("Lay wires anew when moving elements (requires restart):"), appSettingsTab), 9, 0);
     allowLayingWiresAnew = new QCheckBox(appSettingsTab);
-    appSettingsGrid->addWidget(allowLayingWiresAnew, 8, 1);
+    appSettingsGrid->addWidget(allowLayingWiresAnew, 9, 1);
 
     t->addTab(appSettingsTab, tr("Settings"));
 
@@ -780,6 +786,12 @@ void QucsSettingsDialog::slotApply()
     if (QucsSettings.fullTraceName != checkFullTraceNames->isChecked())
     {
       QucsSettings.fullTraceName = checkFullTraceNames->isChecked();
+      changed = true;
+    }
+
+    if (QucsSettings.alwaysPrefixDataset != alwaysPrefixDataset->isChecked())
+    {
+      QucsSettings.alwaysPrefixDataset = alwaysPrefixDataset->isChecked();
       changed = true;
     }
 

--- a/qucs/dialogs/qucssettingsdialog.h
+++ b/qucs/dialogs/qucssettingsdialog.h
@@ -88,7 +88,7 @@ public:
     QCheckBox *checkWiring, *checkLoadFromFutureVersions,
               *allowFlexibleWires, *allowLayingWiresAnew,
               *checkAntiAliasing, *checkTextAntiAliasing,
-              *checkFullTraceNames;
+              *checkFullTraceNames,  *alwaysPrefixDataset;
     QComboBox *LanguageCombo,
               *StyleCombo;
     QPushButton *FontButton, *AppFontButton, *TextFontButton, *BGColorButton, *GridColorButton;

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -68,6 +68,9 @@ AbstractSpiceKernel::AbstractSpiceKernel(Schematic *schematic, QObject *parent) 
         a_schematic->setShowBias(0);
     }
 
+    // Enforce dataset prefix from config:
+    a_needsPrefix = QucsSettings.alwaysPrefixDataset;
+
     a_workdir = QucsSettings.S4Qworkdir;
     QFileInfo inf(a_workdir);
     if (!inf.exists()) {

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -366,7 +366,7 @@ void Ngspice::createNetlist(
            << ".endc\n";
     stream << ".END\n";
 
-    a_needsPrefix = ( (dcSims | freqSims | timeSims | fourSims | pzSims) > 1 );
+    a_needsPrefix = a_needsPrefix || ( (dcSims | freqSims | timeSims | fourSims | pzSims) > 1 );
 
     qDebug() << '\n'
              << "Simulations:\n"

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -148,6 +148,7 @@ bool loadSettings()
     QucsSettings.GraphAntiAliasing = _settings::Get().item<bool>("GraphAntiAliasing");
     QucsSettings.TextAntiAliasing = _settings::Get().item<bool>("TextAntiAliasing");
     QucsSettings.fullTraceName = _settings::Get().item<bool>("fullTraceName");
+    QucsSettings.alwaysPrefixDataset = _settings::Get().item<bool>("alwaysPrefixDataset");
     QucsSettings.RecentProjects = _settings::Get().item<QString>("RecentProjects").split("*", Qt::SkipEmptyParts);
     QucsSettings.RecentDocs = _settings::Get().item<QString>("RecentDocs").split("*", Qt::SkipEmptyParts);
     QucsSettings.numRecentDocs = QucsSettings.RecentDocs.count();
@@ -222,6 +223,7 @@ bool saveApplSettings()
     qs.setItem<bool>("GraphAntiAliasing", QucsSettings.GraphAntiAliasing);
     qs.setItem<bool>("TextAntiAliasing", QucsSettings.TextAntiAliasing);
     qs.setItem<bool>("fullTraceName",QucsSettings.fullTraceName);
+    qs.setItem<bool>("alwaysPrefixDataset",QucsSettings.alwaysPrefixDataset);
 
     // Copy the list of directory paths in which Qucs should
     // search for subcircuit schematics from qucsPathList

--- a/qucs/main.h
+++ b/qucs/main.h
@@ -107,6 +107,7 @@ struct tQucsSettings {
 
   bool hasDarkTheme;
   bool fullTraceName;
+  bool alwaysPrefixDataset;
 
   bool firstRun;
 };


### PR DESCRIPTION
This setting allows for a more consistent usage with datasets, especially in cases where one toggles on-off different simulations triggering the `a_needsPrefix` variable in NGSpice.

This setting always enforces `a_needsPrefix` giving us the dataset like `tr1.v(out)` rather than `v(vout)` in the scenario where you have one of each simulations.

There are probably other ways around fixing the "issue" at hand here, but I'd thought putting this feature behind a config flag would be the path of least resistance in terms of potentially breaking backward compatibility.

# Example

Typical use case I have seen using this:
1. Have a transient simulation
2. Have a SP-simulation
3. Make plots/diagrams from the results for both transient and SP-analysis
4. Add spectrum analysis
5. --> This triggers `a_needsPrefix = true`
6. The diagrams now don't have any valid data for the transient simulation and SP-analaysis

This config flag would then force the labeling to be `tr1.XYZ`, `sp1.XYZ` and `fft1.XYZ`, allowing the diagrams to be displayed regardless of whether one adds more analysis (triggering `a_needsPrefix`) or not