### PR TITLE
S-parameter Viewer: Fixes

### DIFF
--- a/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
+++ b/qucs-s-spar-viewer/qucs-s-spar-viewer.cpp
@@ -1710,7 +1710,13 @@ void Qucs_S_SPAR_Viewer::removeTrace() {
 
   DisplayMode mode;
   if (!scrollname.compare(QString("magnitudePhaseScrollArea"))) {
-    mode = DisplayMode::Magnitude_dB;
+    // Check if the trace is magnitude or phase
+    if (ID.endsWith("_dB")){
+      mode = DisplayMode::Magnitude_dB;
+    } else {
+      // It's a phase trace
+      mode = DisplayMode::Phase;
+    }
   } else if (!scrollname.compare(QString("smithScrollArea"))) {
     mode = DisplayMode::Smith;
   } else if (!scrollname.compare(QString("polarScrollArea"))) {

--- a/qucs-s-spar-viewer/rectangularplotwidget.cpp
+++ b/qucs-s-spar-viewer/rectangularplotwidget.cpp
@@ -303,6 +303,12 @@ void RectangularPlotWidget::updatePlot()
     }
   }
 
+  if (getY2AxisTraceCount() == 0) {
+    y2Axis->setVisible(false);
+  } else {
+    y2Axis->setVisible(true);
+  }
+
   // Draw markers if any
   for (auto it = markers.constBegin(); it != markers.constEnd(); ++it) {
     const Marker& marker = it.value();


### PR DESCRIPTION
This PR addresses the following issues:

1) The phase-trace widgets were overlapping with the dB-trace widgets. This occurred because the phase and magnitude traces were displayed in the same plot, and the program only counted the magnitude traces.

2) When monitoring a directory for new files, they were automatically added. This could be annoying. Now, when a new file appears, the program asks if the new file(s) should be added.

<img width="1134" height="711" alt="image" src="https://github.com/user-attachments/assets/f14fdca3-04c7-4cb5-b9ae-d396b0aab431" />


3)  The program crashed if a phase trace was deleted.