### PR TITLE
LibComp: replace 'gnd' nodes with '0' nodes

### DIFF
--- a/qucs/components/libcomp.cpp
+++ b/qucs/components/libcomp.cpp
@@ -367,7 +367,7 @@ QString LibComp::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
 
     QString s = SpiceModel + Name + " 0 "; // connect ground of subckt to circuit ground
     for (Port *p1 : Ports)
-      s += " "+p1->Connection->Name;   // node names
+      s += " "  + spicecompat::normalize_node_name(p1->Connection->Name);   // node names
     s += " " + createType();
 
     // output user defined parameters

--- a/qucs/components/libcomp.cpp
+++ b/qucs/components/libcomp.cpp
@@ -365,7 +365,7 @@ QString LibComp::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
 {
     Q_UNUSED(dialect);
 
-    QString s = SpiceModel + Name + " 0 "; // connect ground of subckt to circuit ground
+    QString s = SpiceModel + Name + " " + "0"; // connect ground of subckt to circuit ground
     for (Port *p1 : Ports)
       s += " "  + spicecompat::normalize_node_name(p1->Connection->Name);   // node names
     s += " " + createType();


### PR DESCRIPTION
This does the same string replacement that can be seen in Component::GetSpiceNetlist, where the ground node "gnd" gets replaced by "0". This isn't an issue in NGSpice since it handles gnd as a global 0 anyways, however Xyce (by default) doesn't, so currently one can get a mix of "0" and "gnd", which then fails on Xyce.

## Testbench:

Simple test schematic using IHP's PDK:

<img width="579" height="386" alt="Test Schematic" src="https://github.com/user-attachments/assets/aee8eb12-5b41-4cdc-8883-45f447c27c03" />

## On current-branch:
This gets netlisted as:
`Xsg13_lv_nmos1 0  0 gnd 0 gnd IHP_PDK_nonlinear_components_sg13_lv_nmos ...`

This passes simulation because we currently have two ground nodes, (hence they are connected to _something_), however this will not simulate _as if_ you had these grounded.

Another possibility would be to use the option: `.PREPROCESS REPLACEGROUND TRUE`, which would then according to the reference manual: 
> The purpose of ground synonym replacement is to treat nodes with the names GND, GND!, GROUND or any
capital/lowercase variant thereof as synonyms for node 0.

## With this PR:
This gets netlisted as:
`Xsg13_lv_nmos1 0 0 0 0 0 IHP_PDK_nonlinear_components_sg13_lv_nmos ...`

Additionally I removed the double trailing whitespace, but that's more of a cosmetic fix rather than a functional one