### PR TITLE
Feature: Reload netlist and log-files

### DIFF
--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -1704,7 +1704,7 @@ void QucsApp::slotTextNew()
 // --------------------------------------------------------------
 // Changes to the document "Name". If already open then it goes to it
 // directly, otherwise it loads it.
-bool QucsApp::gotoPage(const QString& Name)
+bool QucsApp::gotoPage(const QString& Name, bool reloadPage)
 {
   int No = DocumentTab->currentIndex();
 
@@ -1714,6 +1714,19 @@ bool QucsApp::gotoPage(const QString& Name)
   if(d) {   // open page found ?
     d->becomeCurrent(true);
     DocumentTab->setCurrentIndex(i);  // make new document the current
+    // if reloadPage is set AND it's a textDocument AND it has changed on disk -> reload
+    if (reloadPage) {
+      QWidget *w = DocumentTab->currentWidget();
+      if (isTextDocument(w)) {
+        TextDoc *tDoc = dynamic_cast<TextDoc*>(w);
+        if (tDoc->hasFileChangedOnDisk()) {
+          if(!tDoc -> reload()) {
+            return false;
+          }
+          qDebug() << "Successfully reloaded textDocument";
+        }
+      }
+    }
     return true;
   }
 

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -364,7 +364,7 @@ private:
    ************************************************** */
 
 public:
-  void editFile(const QString&);
+  void editFile(const QString&, bool reloadFile = false);
 
   QAction *insWire, *insLabel, *insGround, *insPort, *insEquation, *magPlus,
           *editRotate, *editMirror, *editMirrorY, *editPaste, *select,

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -95,7 +95,7 @@ public:
   bool closeAllFiles(int exceptTab = -1);
   bool closeAllLeft(int);
   bool closeAllRight(int);
-  bool gotoPage(const QString&);   // to load a document
+  bool gotoPage(const QString&, bool reloadPage = false);   // to load a document
   QucsDoc *getDoc(int No=-1);
   QucsDoc* findDoc (QString, int * Pos = 0);
   QString fileType (const QString&);

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -697,7 +697,7 @@ extern QString lastDirOpenSave; // to remember last directory and file
 // ------------------------------------------------------------------------
 // Is called by slotShowLastMsg(), by slotShowLastNetlist() and from the
 // component edit dialog.
-void QucsApp::editFile(const QString& File)
+void QucsApp::editFile(const QString& File, bool reloadFile)
 {
     if ((QucsSettings.Editor.toLower() == "qucs") || QucsSettings.Editor.isEmpty())
     {
@@ -716,7 +716,7 @@ void QucsApp::editFile(const QString& File)
             if(!finfo.exists())
                 statusBar()->showMessage(tr("Opening aborted, file not found."), 2000);
             else {
-                gotoPage(File);
+                gotoPage(File, reloadFile);
                 lastDirOpenSave = File;   // remember last directory and file
                 statusBar()->showMessage(tr("Ready."));
             }
@@ -775,7 +775,7 @@ void QucsApp::editFile(const QString& File)
 // Is called to show the output messages of the last simulation.
 void QucsApp::slotShowLastMsg()
 {
-  editFile(QucsSettings.tempFilesDir.filePath("log.txt"));
+  editFile(QucsSettings.tempFilesDir.filePath("log.txt"), /*reloadFile=*/true);
 }
 
 // ------------------------------------------------------------------------
@@ -828,7 +828,7 @@ void QucsApp::slotShowLastNetlist()
     }
 
     for(const auto &netlist: netlists) {
-        editFile(netlist);
+        editFile(netlist, /*reloadFile=*/true);
     }
 }
 

--- a/qucs/textdoc.cpp
+++ b/qucs/textdoc.cpp
@@ -387,6 +387,16 @@ bool TextDoc::load ()
   return true;
 }
 
+/*!
+ * \brief TextDoc::clears and re-loads a text document
+ * \return true/false if the document was opened with success
+ */
+bool TextDoc::reload()
+{
+  clear();
+  return load();
+}
+
 
 /*!
  * \brief TextDoc::save saves the current document and it settings

--- a/qucs/textdoc.cpp
+++ b/qucs/textdoc.cpp
@@ -377,6 +377,9 @@ bool TextDoc::load ()
 
   QTextStream stream (&file);
   insertPlainText(stream.readAll());
+  // Store timestamp
+  QFileInfo fileInfo(a_DocName);
+  lastLoadModTime = fileInfo.lastModified();
   document()->setModified(false);
   slotSetChanged ();
   file.close ();
@@ -623,4 +626,15 @@ void TextDoc::refreshLanguage()
     this->setLanguage(a_DocName);
     syntaxHighlight->setLanguage(language);
     syntaxHighlight->setDocument(document());
+}
+
+// Returns true if file on disk has a lastModified timestamp newer than the object's
+// last load modified time
+bool TextDoc::hasFileChangedOnDisk() const
+{
+  QFileInfo fileInfo(a_DocName);
+  if (!fileInfo.exists()) {
+    return true; // File is removed -> has changed
+  }
+  return fileInfo.lastModified() > lastLoadModTime;
 }

--- a/qucs/textdoc.h
+++ b/qucs/textdoc.h
@@ -20,6 +20,7 @@ Copyright (C) 2014 by Guilherme Brondani Torri <guitorri@gmail.com>
 
 #include <QPlainTextEdit>
 #include <QFont>
+#include <qdatetime.h>
 
 #include "qucsdoc.h"
 
@@ -53,6 +54,7 @@ public:
   void  setName (const QString&);
   bool  load ();
   bool  reload ();
+  bool  hasFileChangedOnDisk() const;
   int   save ();
   virtual double zoomBy (double zoom) override;
   virtual void showNoZoom () override;
@@ -99,6 +101,7 @@ public slots:
 
 private:
   SyntaxHighlighter * syntaxHighlight;
+  QDateTime lastLoadModTime; // Timestamp of last successful load
 
 private slots:
   void highlightCurrentLine();

--- a/qucs/textdoc.h
+++ b/qucs/textdoc.h
@@ -52,6 +52,7 @@ public:
 
   void  setName (const QString&);
   bool  load ();
+  bool  reload ();
   int   save ();
   virtual double zoomBy (double zoom) override;
   virtual void showNoZoom () override;


### PR DESCRIPTION
## What

This PR adds the option for reloading already opened files, specifically netlist files and log files are being reloaded by default.

## Motiviation

When using the "Show last log" and "Show last netlist" one (usually) expects it to be the latest available netlist,
however currently on `current` if you have already opened the file, it will not refresh (getting the latest file available) and it will just show you the previously loaded netlist/log files, hence potentially giving you "stale" data. 

Typical scenario on `current` branch:
---

1. Run a simulation
2. Open up the netlist using F6
3. Leave it open
4. Change schematic
5. Run simulation
6. Open up the netlist using F6
7. --> The netlist shown is the one created during step 1.

With this PR:
---

1. Run a simulation
2. Open up the netlist using F6
3. Leave it open
4. Change schematic
5. Run simulation
6. Open up the netlist using F6
7. --> The netlist shown is now the one generated in step 5. 

## Notes

The filesystem checking etc is fairly simple in this case, since we assume that the files (netlists and log files) are purely "external", of course there are multiple ways of handling this kind of scenario.

Naturally open for suggestions/improvements if needed/wanted, thanks!