### PR TITLE
graphictext: Refactor code to compute boundingRect dynamically

### DIFF
--- a/qucs/paintings/graphictext.cpp
+++ b/qucs/paintings/graphictext.cpp
@@ -300,3 +300,21 @@ QRectF GraphicText::getTextBounds(QPainter* painter) const {
 
     return textBounds;
 }
+
+// Returns the center of the transformed text boundary
+QPoint GraphicText::center() const noexcept {
+    return getTransform()
+        .map(getTextBounds().center())
+        .toPoint();
+}
+
+bool GraphicText::moveCenterTo(int x, int y) noexcept {
+    QPoint currentCenter = center();
+    return moveCenter(x - currentCenter.x(), y - currentCenter.y());
+}
+
+bool GraphicText::moveCenter(int dx, int dy) noexcept {
+    x1 += dx;
+    y1 += dy;
+    return true;
+}

--- a/qucs/paintings/graphictext.cpp
+++ b/qucs/paintings/graphictext.cpp
@@ -45,11 +45,6 @@ void GraphicText::paint(QPainter* painter) {
     // Calculate (local) textBox boundary
     QRectF textBox = getTextBounds(painter);
 
-    QRect br = boundingRect();
-    x2 = x1 + br.width();
-    y2 = y1 + br.height();
-    updateCenter();
-
     if (isSelected) {
         painter->setPen(QPen(Qt::darkGray, 3));
         painter->drawRect(textBox);
@@ -119,11 +114,6 @@ bool GraphicText::load(const QString &s)
         return false;
 
     misc::convert2Unicode(text);
-
-    QRect textBounds = getTextBounds().toRect();
-
-    x2 = x1 + textBounds.width();
-    y2 = y1 + textBounds.height();
 
     return true;
 }

--- a/qucs/paintings/graphictext.cpp
+++ b/qucs/paintings/graphictext.cpp
@@ -42,15 +42,9 @@ void GraphicText::paint(QPainter* painter) {
     // Apply current transformation
     // Use combined transform to handle zooming
     painter->setTransform(getTransform(), /*combine=*/true);
-
-    // Set font and pen color
     painter->setPen(color);
-    QFont f = font;
-    f.setPixelSize(QFontInfo{font}.pixelSize());
-    painter->setFont(f);
-
-    QRectF textBox;
-    misc::draw_richtext(painter, 0, 0, text, &textBox);
+    // Calculate (local) textBox boundary
+    QRectF textBox = getTextBounds(painter);
 
     // Store the transformed boundingRect
     br = getTransform().mapRect(textBox.toRect());
@@ -124,15 +118,10 @@ bool GraphicText::load(const QString &s)
 
     misc::convert2Unicode(text);
 
-    // Size of the text is calculated here in order to set x2 and y2 coordinates.
-    // But there is a caveat: text may contain LaTeX-like macros for subscripts
-    // and upperscripts and here we treat these macros as usual text. Because
-    // of that, if text contains LaTeX-like macros it's countour is bigger than
-    // the actual text when it's being copied-and-pasted.
-    QFontMetrics metrics(QucsSettings.font, 0);
-    br = metrics.boundingRect(text);
-    x2 = x1 + br.width();
-    y2 = y1 + br.height();
+    QRect textBounds = getTextBounds().toRect();
+
+    x2 = x1 + textBounds.width();
+    y2 = y1 + textBounds.height();
 
     return true;
 }
@@ -280,4 +269,29 @@ QTransform GraphicText::getTransform() const {
     transform.translate(x1, y1);
     transform.rotate(-angle);
     return transform;
+}
+
+QRectF GraphicText::getTextBounds(QPainter* painter) const {
+    QPainter* p = painter;
+    QPixmap textPixmap;
+    QPainter textPainter;
+
+    // If there is no painter given
+    // we create a minimal temporary painter
+    if (!p) {
+        textPixmap = QPixmap(1, 1);
+        textPainter.begin(&textPixmap);
+        p = &textPainter;
+    }
+
+    // Setup font
+    QFont f = font;
+    f.setPixelSize(QFontInfo{font}.pixelSize());
+    p->setFont(f);
+
+    // Draw text using draw_richtext
+    QRectF textBounds;
+    misc::draw_richtext(p, 0, 0, text, &textBounds);
+
+    return textBounds;
 }

--- a/qucs/paintings/graphictext.cpp
+++ b/qucs/paintings/graphictext.cpp
@@ -33,7 +33,6 @@ GraphicText::GraphicText()
     x1 = x2 = 0;
     y1 = y2 = 0;
     angle = 0;
-    br = QRect(0, 0, 0, 0);
 }
 
 void GraphicText::paint(QPainter* painter) {
@@ -46,9 +45,7 @@ void GraphicText::paint(QPainter* painter) {
     // Calculate (local) textBox boundary
     QRectF textBox = getTextBounds(painter);
 
-    // Store the transformed boundingRect
-    br = getTransform().mapRect(textBox.toRect());
-
+    QRect br = boundingRect();
     x2 = x1 + br.width();
     y2 = y1 + br.height();
     updateCenter();
@@ -63,7 +60,12 @@ void GraphicText::paint(QPainter* painter) {
 
 void GraphicText::paintScheme(Schematic *p)
 {
-    p->PostPaintEvent(_Rect, x1, y1, x2 - x1, y2 - y1);
+    QRect br = boundingRect();
+    p->PostPaintEvent(_Rect,
+                      br.x(),
+                      br.y(),
+                      br.width(),
+                      br.height());
 }
 
 Painting* GraphicText::newOne()
@@ -215,7 +217,10 @@ bool GraphicText::rotate(int rcx, int rcy) noexcept
 
 QRect GraphicText::boundingRect() const noexcept
 {
-    return br;
+    // Return the transformed text-boundary
+    return getTransform()
+        .mapRect(getTextBounds())
+        .toRect();
 }
 
 bool GraphicText::Dialog(QWidget *parent)

--- a/qucs/paintings/graphictext.cpp
+++ b/qucs/paintings/graphictext.cpp
@@ -39,13 +39,9 @@ GraphicText::GraphicText()
 void GraphicText::paint(QPainter* painter) {
     painter->save();
 
-    // Build transformation
-    QTransform transform;
-    transform.translate(x1, y1);
-    transform.rotate(-angle);
-
+    // Apply current transformation
     // Use combined transform to handle zooming
-    painter->setTransform(transform, true);
+    painter->setTransform(getTransform(), /*combine=*/true);
 
     // Set font and pen color
     painter->setPen(color);
@@ -57,7 +53,7 @@ void GraphicText::paint(QPainter* painter) {
     misc::draw_richtext(painter, 0, 0, text, &textBox);
 
     // Store the transformed boundingRect
-    br = transform.mapRect(textBox.toRect());
+    br = getTransform().mapRect(textBox.toRect());
 
     x2 = x1 + br.width();
     y2 = y1 + br.height();
@@ -277,4 +273,11 @@ bool GraphicText::Dialog(QWidget *parent)
         }
 
     return changed;
+}
+
+QTransform GraphicText::getTransform() const {
+    QTransform transform;
+    transform.translate(x1, y1);
+    transform.rotate(-angle);
+    return transform;
 }

--- a/qucs/paintings/graphictext.h
+++ b/qucs/paintings/graphictext.h
@@ -46,6 +46,7 @@ public:
   bool rotate(int rcx, int rcy) noexcept override;
 
   QRect boundingRect() const noexcept override;
+  QRectF getTextBounds(QPainter* painter = nullptr) const;
 
   bool Dialog(QWidget* parent = nullptr) override;
 
@@ -55,6 +56,7 @@ private:
   QString  text;
   int      angle;
   QRect    br;
+  QTransform getTransform() const;
 };
 
 #endif

--- a/qucs/paintings/graphictext.h
+++ b/qucs/paintings/graphictext.h
@@ -54,7 +54,6 @@ private:
   QFont    font;
   QString  text;
   int      angle;
-  QRect    br;
   QTransform getTransform() const;
   QRectF getTextBounds(QPainter* painter = nullptr) const;
 };

--- a/qucs/paintings/graphictext.h
+++ b/qucs/paintings/graphictext.h
@@ -46,7 +46,6 @@ public:
   bool rotate(int rcx, int rcy) noexcept override;
 
   QRect boundingRect() const noexcept override;
-  QRectF getTextBounds(QPainter* painter = nullptr) const;
 
   bool Dialog(QWidget* parent = nullptr) override;
 
@@ -57,6 +56,7 @@ private:
   int      angle;
   QRect    br;
   QTransform getTransform() const;
+  QRectF getTextBounds(QPainter* painter = nullptr) const;
 };
 
 #endif

--- a/qucs/paintings/graphictext.h
+++ b/qucs/paintings/graphictext.h
@@ -46,6 +46,9 @@ public:
   bool rotate(int rcx, int rcy) noexcept override;
 
   QRect boundingRect() const noexcept override;
+  QPoint center() const noexcept override;
+  bool moveCenter(int dx, int dy) noexcept override;
+  bool moveCenterTo(int x, int y) noexcept;
 
   bool Dialog(QWidget* parent = nullptr) override;
 


### PR DESCRIPTION
What?
---
This PR refactors large parts of the code in graphictext, specifically around the handling of boundingRect.
In general this PR goes from an attribute approach to a more dynamic approach to avoid stale content.

Motivation
---
In `current`, when copying a graphictext object, one can see two effects: 

1. The boundingRect of the copy isn't necessarily rotated
2. There is an offset between where the text will be copied to and where it is previewed

Short overview
---

  1. Move transformation logic to `getTransform()`
  2. Move textBoundary logic into `getTextBounds()`
    1. This removed the discrepancy between `paint`'s and `load'`s text boundary
  3. `boundingRect` is now calculated dynamically
    1. This ensures the boundingRect is correct for both "regular" and copy-paste use
  4. `center`, `moveCenter` and `moveCenterTo` is overridden
    1. This ensures that we get the transformed center in the case where we copy-paste, removing the offset seen.
  5. Dependency/Calculations on `x2, y2, cx, cy` were removed, since we handle the boundary dynamically

Performance considerations
---
The dynamic approach creates a temporary QPixmap for text measurement when no QPainter is available. However:
- Text measurement only occurs when `boundingRect()` is called
- During painting, we reuse the existing QPainter, avoiding the temporary pixmap

I assume this performance penalty is gonna be negligible 

Other
---
This is effectively a continuation of the work started in #1397 