### PR TITLE
Fix issue #1053: Smith chart: stars/circles not rendered correctly when close to the chart border

### DIFF
--- a/qucs/diagrams/diagram.cpp
+++ b/qucs/diagrams/diagram.cpp
@@ -351,10 +351,13 @@ int Diagram::regionCode(float x, float y) const {
 // ------------------------------------------------------------
 // Is virtual. This one is for round diagrams only.
 bool Diagram::insideDiagram(float x, float y) const {
-    float R = float(x2) / 2.0 + 1.0; // +1 seems better (graph sometimes little outside)
-    x -= R;
-    y -= R;
-    return ((x * x + y * y) <= R * R);
+  float tol = 0.5;  // Tolerance. Otherwise, it may discard points close to the circular plot border
+  float R = float(x2) / 2.0 + 1.0; // +1 seems better (graph sometimes little outside)
+  x -= R;
+  y -= R;
+
+  float rTol = R + tol; // Radius plus tolerance
+  return ((x * x + y * y) <= rTol * rTol);
 }
 
 /*!


### PR DESCRIPTION
Hello:

I took a look at issue #1053. I found that the missing points were being discarded in [Diagram::insideDiagram(float x, float y)](https://github.com/ra3xdh/qucs_s/blob/current/qucs/diagrams/diagram.cpp#L357) because they didn't stricly meet the condition to check whether a point is inside the chart or not.

This happens with stars and circles and not with solid lines because they are handled by the default case in the switch condition of Diagram::calcData(Graph *g) whereas the solid line is handled in a different way.

I've added a very small tolerance in the Diagram::insideDiagram check to fix this.

<img width="812" height="330" alt="imagen" src="https://github.com/user-attachments/assets/15aabc39-2dab-4dea-910a-53534a09c974" />


**Before this PR**

<img width="1418" height="728" alt="imagen" src="https://github.com/user-attachments/assets/8b90a1e7-2276-4ee9-8a4f-3867a786b57e" />


**This PR**

<img width="1525" height="792" alt="imagen" src="https://github.com/user-attachments/assets/413f650d-59de-41e9-9be2-63f287fd34f2" />



I attach the test schematic [here](https://github.com/user-attachments/files/21739056/smith_problem_0R.zip)
