### PR TITLE
feat(paintings): auto-snap to grid after rotation

### DIFF
--- a/qucs/paintings/arrow.cpp
+++ b/qucs/paintings/arrow.cpp
@@ -300,6 +300,13 @@ bool Arrow::rotate(int xc, int yc) noexcept
   return true;
 }
 
+void Arrow::snapToGrid(Schematic* sch)
+{
+  sch->setOnGrid(x1, y1);
+  sch->setOnGrid(x2, y2);
+  updateHead();
+}
+
 // Mirrors about center line.
 bool Arrow::mirrorX() noexcept
 {

--- a/qucs/paintings/arrow.h
+++ b/qucs/paintings/arrow.h
@@ -47,6 +47,8 @@ public:
 
   bool  rotate() noexcept override;
   bool  rotate(int, int) noexcept override;
+  void  snapToGrid(Schematic* sch) override;
+
   bool  mirrorX() noexcept override;
   bool  mirrorY() noexcept override;
 

--- a/qucs/paintings/ellipse.cpp
+++ b/qucs/paintings/ellipse.cpp
@@ -324,6 +324,13 @@ bool qucs::Ellipse::rotate(int xc, int yc) noexcept
   return true;
 }
 
+void qucs::Ellipse::snapToGrid(Schematic* sch)
+{
+  sch->setOnGrid(x1, y1);
+  sch->setOnGrid(x2, y2);
+  updateCenter();
+}
+
 bool qucs::Ellipse::Dialog(QWidget* parent)
 {
   bool changed = false;

--- a/qucs/paintings/ellipse.h
+++ b/qucs/paintings/ellipse.h
@@ -49,6 +49,7 @@ public:
 
   bool rotate() noexcept override;
   bool rotate(int, int) noexcept override;
+  void snapToGrid(Schematic* sch) override;
 
   bool Dialog(QWidget* parent = nullptr) override;
 

--- a/qucs/paintings/ellipsearc.cpp
+++ b/qucs/paintings/ellipsearc.cpp
@@ -325,6 +325,13 @@ bool EllipseArc::rotate() noexcept
   return true;
 }
 
+void EllipseArc::snapToGrid(Schematic* sch)
+{
+  sch->setOnGrid(x1, y1);
+  sch->setOnGrid(x2, y2);
+  updateCenter();
+}
+
 // Mirrors about center line.
 bool EllipseArc::mirrorX() noexcept
 {

--- a/qucs/paintings/ellipsearc.h
+++ b/qucs/paintings/ellipsearc.h
@@ -44,6 +44,8 @@ public:
   void MouseResizeMoving(int, int, Schematic*) override;
 
   bool rotate() noexcept override;
+  void snapToGrid(Schematic* sch) override;
+
   bool mirrorX() noexcept override;
   bool mirrorY() noexcept override;
 

--- a/qucs/paintings/graphicline.cpp
+++ b/qucs/paintings/graphicline.cpp
@@ -229,6 +229,13 @@ bool GraphicLine::rotate(int xc, int yc) noexcept
   return true;
 }
 
+void GraphicLine::snapToGrid(Schematic* sch)
+{
+  sch->setOnGrid(x1, y1);
+  sch->setOnGrid(x2, y2);
+  updateCenter();
+}
+
 // Mirrors about center line.
 bool GraphicLine::mirrorX() noexcept
 {

--- a/qucs/paintings/graphicline.h
+++ b/qucs/paintings/graphicline.h
@@ -46,6 +46,8 @@ public:
 
   bool rotate() noexcept override;
   bool rotate(int, int) noexcept override;
+  void snapToGrid(Schematic* sch) override;
+
   bool mirrorX() noexcept override;
   bool mirrorY() noexcept override;
 

--- a/qucs/paintings/painting.h
+++ b/qucs/paintings/painting.h
@@ -42,6 +42,8 @@ public:
 
   virtual void MouseResizeMoving(int, int, Schematic*) {};
 
+  virtual void snapToGrid(Schematic* /*sch*/) {};
+
   using Element::moveCenterTo;
   bool  moveCenterTo(int x, int y) noexcept override;
   bool  moveCenter(int dx, int dy) noexcept override;

--- a/qucs/paintings/rectangle.cpp
+++ b/qucs/paintings/rectangle.cpp
@@ -333,6 +333,13 @@ bool qucs::Rectangle::rotate(int xc, int yc) noexcept
   return true;
 }
 
+void qucs::Rectangle::snapToGrid(Schematic* sch)
+{
+  sch->setOnGrid(x1, y1);
+  sch->setOnGrid(x2, y2);
+  updateCenter();
+}
+
 // Calls the property dialog for the painting and changes them accordingly.
 // If there were changes, it returns 'true'.
 bool qucs::Rectangle::Dialog(QWidget *parent)

--- a/qucs/paintings/rectangle.h
+++ b/qucs/paintings/rectangle.h
@@ -48,6 +48,7 @@ public:
 
   bool rotate() noexcept override;
   bool rotate(int, int) noexcept override;
+  void snapToGrid(Schematic* sch) override;
 
   bool Dialog(QWidget* parent = nullptr) override;
 

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -1577,8 +1577,16 @@ bool Schematic::rotateElements()
     const auto rotc = setOnGrid(bounds->center());
 
     bool any_rotated = false;
-    const auto rotator = [&any_rotated, in_place, rotc](Element* e) {
-        any_rotated = (in_place ? e->rotate() : e->rotate(rotc)) || any_rotated;
+    const auto rotator = [&any_rotated, in_place, rotc, this](Element* e) {
+        const bool elem_rotated = in_place ? e->rotate() : e->rotate(rotc);
+        any_rotated = elem_rotated || any_rotated;
+
+        // Snap painting to grid if rotated
+        if(elem_rotated) {
+            if (auto* painting = dynamic_cast<Painting*>(e)) {
+                painting->snapToGrid(this);
+            }
+        }
     };
 
     std::ranges::for_each(selection.components, rotator);


### PR DESCRIPTION
## What

Implements `snapToGrid()` method on _most_ paintings (GraphicLine, Arrow, Ellipse, EllipseArc, Rectangle) to snap coordinates to the schematic grid.

And uses this new method in `Schematic::rotateElements()` to ensure we get an on-grid painting.


## Why

When rotating paintings that span an even number of grid points, we can end up in an off-grid situation. This is especially noticable when creating symbols using GraphicLine.

An example using graphicLine:

<img width="1094" height="588" alt="image" src="https://github.com/user-attachments/assets/0a56fbf4-16da-45f2-8eb6-c858f5446c81" />

Here we see the 1x10 graphicLine and it's rotated counterpart, where the latter is now off-grid. For the 1x11 graphicLine, we can see the rotation is still on grid.

## Short summary

- Added `snapToGrid(Schematic* sch)` method to `Painting` class
- Implementation done for `GraphicLine`, `Arrow`, `Ellipse`, `EllipseArc`, and `Rectangle`
-  Integrated into `Schematic::rotateElements()` to snap paintings _if_ they got rotated