### PR TITLE
plot noise contributors

### DIFF
--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -272,7 +272,7 @@ void Ngspice::createNetlist(
             } else {  // Set Noise1 plot to output noise spectrum
                 spiceNetlist.append("setplot noise1\n");
             }
-            nods = "inoise_spectrum onoise_spectrum";
+            nods = "noise1.all";
         } else if ( sim_typ == ".PZ" ) {
             pzSims++;
             spiceNetlist.append(pc->getSpiceNetlist());
@@ -325,7 +325,24 @@ void Ngspice::createNetlist(
             QString out = "spice4qucs." + sim_name + ".ngspice.dc.print";
             spiceNetlist.append(QStringLiteral("print %1 > %2\n").arg(nods).arg(out));
             outputs.append(out);
-        } else if ( (sim_typ != ".PZ") && (sim_typ != ".SENS") && (sim_typ != ".SENS_AC") ) {
+        } 
+        else if (sim_typ == ".NOISE") {
+            nods = nods.simplified();
+            if ( !nods.isEmpty() ) {
+                QString basenam = "spice4qucs";
+                QString filename;
+                if ( hasParSWP && hasDblSWP )
+                    filename = QStringLiteral("%1.%2._swp_swp.raw").arg(basenam).arg(sim_name);
+                else if ( hasParSWP )
+                    filename = QStringLiteral("%1.%2._swp.raw").arg(basenam).arg(sim_name);
+                else
+                    filename = QStringLiteral("%1.%2.raw").arg(basenam).arg(sim_name);
+                filename.replace(' ', '_'); // Ngspice cannot understand spaces in filename
+                spiceNetlist.append(QStringLiteral("write %1 %2\n").arg(filename).arg(nods));
+                outputs.append(filename);
+            }
+        }
+        else if ( (sim_typ != ".PZ") && (sim_typ != ".SENS") && (sim_typ != ".SENS_AC") ) {
             nods = nods.simplified();
             if ( !nods.isEmpty() ) {
                 QString basenam = "spice4qucs";


### PR DESCRIPTION
Part of my motivation for the earlier issue (#1439 ) was because I would like to view noise contributions of each component, this actually proved more difficult to unearth than I expected... it seems the noise data per component is buried in a kind of obscure way (https://sourceforge.net/p/ngspice/discussion/133842/thread/3740da63/#6804)

Anyway, if you write all, you can save the contributions and plot them all together:
<img width="2130" height="871" alt="Screenshot From 2025-08-18 23-10-47" src="https://github.com/user-attachments/assets/3b3f619a-98e5-4040-9835-9d2ba055c9dd" />

This is not exactly an ideal way to do it, because you actually save quite a lot of junk alongside the important signals (`noise.ac.onoise_r.xx**.....`), I'm not sure if it's possible to discard these with a regex or something? The important signals have more sane names like `noise.ac.onoise_r1`, so they would be easy to sort, but I don't know how much flexibility ngspice will give you on sorting names...

<img width="865" height="788" alt="Screenshot From 2025-08-18 23-10-10" src="https://github.com/user-attachments/assets/62637830-aa77-479e-a305-581e22d71c9c" />

Thankfully these extra data are only generated if you are using the optional pts_per_summary that you've added for me earlier this week. Do you think this would be a useful addition to qucs-s?
