### PR TITLE
refactor(PortSymbol): Introduce setter for port name

### DIFF
--- a/qucs/paintings/portsymbol.cpp
+++ b/qucs/paintings/portsymbol.cpp
@@ -328,3 +328,9 @@ void PortSymbol::updateBounds()
   x2 = cx + br.right();
   y2 = cy + br.bottom();
 }
+
+void PortSymbol::setPortName(const QString& newName)
+{
+  nameStr = newName;
+  updateBounds();
+}

--- a/qucs/paintings/portsymbol.h
+++ b/qucs/paintings/portsymbol.h
@@ -49,6 +49,7 @@ public:
   bool Dialog(QWidget *Doc) override;
 
   QString numberStr, nameStr;
+  void setPortName(const QString& newName);
 private:
   int angle;
   QPoint m_textOrigin;

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1572,7 +1572,7 @@ int Schematic::adjustPortNumbers()
                 }
 
                 if (pp) {
-                    ((PortSymbol *) pp)->nameStr = pc->Name;
+                    ((PortSymbol *) pp)->setPortName(pc->Name);
                 } else {
                     a_SymbolPaints.push_back(new PortSymbol(x1, y2, Str, pc->Name));
                     y2 += 40;


### PR DESCRIPTION
# What?

This PR introduces a setter for the port name in `PortSymbol`


# Why?

In the case where we modify the attribute, `nameStr`, directly, one can end up with a stale boundary box.

This case is replicated by doing the following:

1. Make a port with a short name like `P1`
2. Make a port with a long name like `P2ButWithAVeryLongSuffix`
3. Create the symbol by pressing F9 (Edit symbol)
4. Go back to schematic editing by pressing F9
6. Swap the port number of the aforementioned ports
7. Go to Symbol mode again
8. You can now see that the text has changed, but the boundary box stays the same.

Example:

<img width="45%" height="340" alt="image" src="https://github.com/user-attachments/assets/43b86f4c-1303-4618-bf6c-d2bcdcdbbc41" /> 
<img width="45%" height="425" alt="image" src="https://github.com/user-attachments/assets/5ef36767-0635-4a59-b8cc-00037f87d2a1" />

Left: PortSymbol during creation (step 3)
Right: Post swap-num (step 7) 

The mentioned setter is now used in `Schematic::adjustPortNumbers` and now the number-swap shows the expected boundary box. 

Post swap-num with this PR:

<img width="50%" height="330" alt="image" src="https://github.com/user-attachments/assets/bd1cd8f3-723d-4440-9026-75372830161f" />
