### PR TITLE
Change schematic healing logic: extend/shrink wires when possible

### DIFF
--- a/qucs/geometry/multi_point.h
+++ b/qucs/geometry/multi_point.h
@@ -224,6 +224,25 @@ std::vector<P> on_line(P first, P last, It begin, It end) {
 
     return in_between;
 }
+
+// Tells whether three given lay on the same one line
+template<PointLike P>
+bool is_it_line(P a, P b, P c)
+{
+    // Use matrix determinant method
+    // | x1 y1 1 |
+    // | x2 y2 1 | = 0
+    // | x3 y3 1 |
+    using internal::get_x;
+    using internal::get_y;
+
+    double determinant = (get_x(a) * (get_y(b) - get_y(c))) +
+                         (get_x(b) * (get_y(c) - get_y(a))) +
+                         (get_x(c) * (get_y(a) - get_y(b)));
+
+    return determinant == 0;
+}
+
 } // namespace qucs_s::geom
 
 #endif

--- a/qucs/healer.cpp
+++ b/qucs/healer.cpp
@@ -290,7 +290,7 @@ bool isSpecialCase(const JointStateAssessor& jsa)
 
     const QPoint p1 = single_wire->P1();
     const QPoint p2 = single_wire->P2();
-    return *other_loc == p1 || *other_loc == p2 || geom::is_between(*other_loc, p1, p2);
+    return *other_loc == p1 || *other_loc == p2 || qucs_s::geom::is_it_line(*other_loc, p1, p2);
 }
 }
 
@@ -383,10 +383,11 @@ vector<Healer::HealingAction> Healer::HealerImpl::processMisplacedNodeCase(Node*
             actions.push_back(make_unique<ReplaceNode>(port.get()));
             actions.push_back(make_unique<ConnectWithWire>(port->center(), node->center()));
         } else {
-            if (m_params.allowWireReshaping) {
+            auto* wire = port->hostWire();
+
+            if (m_params.allowWireReshaping || qucs_s::geom::is_it_line(node->center(), wire->P1(), wire->P2())) {
                 actions.push_back(make_unique<MovePort>(port.get(), node->center()));
             } else {
-                auto* wire = port->hostWire();
                 auto* other_node = wire->Port1 == node ? wire->Port2 : wire->Port1;
 
                 if (wire->hasLabel()) {


### PR DESCRIPTION
Hi!

The changes are in the title, this also should fix #1443. 

* geometry/multi_point.h Add 'is_it_line' function to check if three points form a line

* healer.cpp Adjust logic to extend and shrink a wire when the node it is connected to is on the same line as the wire itself.

