### PR TITLE
Set PixelSize instead of PointSize for simulation label fonts.

### DIFF
--- a/qucs/components/simulation.cpp
+++ b/qucs/components/simulation.cpp
@@ -76,7 +76,7 @@ QFont labelFont()
 {
     auto label_font = _settings::Get().item<QFont>("font");
     label_font.setWeight(QFont::DemiBold);
-    label_font.setPointSizeF(_settings::Get().item<double>("LargeFontSize"));
+    label_font.setPixelSize(static_cast<int>(_settings::Get().item<double>("LargeFontSize")));
     return label_font;
 }
 } // namespace


### PR DESCRIPTION
Fix an issue when printing where the simulation labels fill the whole page.

The QPrinter class documentation says that when combining text with graphics we should specify the font size in pixels to ensure the relative sizes are respected.

Fixes #1452