### PR TITLE
Connect ComponentDialog::slotOKButton() to QDialog::accepted().

### DIFF
--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -492,8 +492,9 @@ ComponentDialog::ComponentDialog(Component* schematicComponent, Schematic* schem
   QDialogButtonBox* buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | 
                                       QDialogButtonBox::Apply | QDialogButtonBox::Cancel);
 
-  connect(buttonBox, &QDialogButtonBox::accepted, this, &ComponentDialog::slotOKButton);
+  connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
   connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+  connect(this, &QDialog::accepted, this, &ComponentDialog::slotOKButton);
   connect(buttonBox->button(QDialogButtonBox::Apply), &QPushButton::clicked, this, &ComponentDialog::slotApplyButton);
   mainLayout->addWidget(buttonBox);
 
@@ -761,7 +762,6 @@ void ComponentDialog::slotOKButton()
   settings.setValue("ComponentDialog/geometry", saveGeometry());
 
   slotApplyButton();
-  done(QDialog::Accepted);
 }
 
 // -------------------------------------------------------------------------


### PR DESCRIPTION
Instead of connecting directly the QDialogButtonBox::accepted() signal to ComponentDialog::slotOKButton(), connect it to QDialog::accept() and then connect QDialog::accepted() to the slotOKButton() method.

This effectively splits the accepted signal delivery in two steps: from QDialogButtonBox to QDialog and from QDialog to slotOKButton().

On some systems, this allows the cell editors of the property table to store any pending changes before reading back the data and returning to the Qucs-S editor.

Fixes #1453.