### PR TITLE
Update QT and NGSpice versions in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,10 +14,10 @@ env:
   EXECUTABLE_NAME: "qucs-s"
   PUBLISHER_NAME: "The Qucs-S Team"
   BUILD_TYPE: Release
-  QT_VERSION: 6.9.0
+  QT_VERSION: 6.9.2
   QUCS_MACOS_BIN: ${{github.workspace}}/build/qucs/qucs-s.app/Contents/MacOS/bin
   QUCS_MACOS_RESOURCES: ${{github.workspace}}/build/qucs/qucs-s.app/Contents/MacOS/share/qucs-s
-  NGSPICE_URL: https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/44.2/ngspice-44.2_64.7z
+  NGSPICE_URL: https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/45/ngspice-45_64.7z
 
 jobs:
   setup:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -251,7 +251,7 @@ jobs:
           path: ${{ env.APP_NAME }}-${{ env.VERSION }}-${{ matrix.dmg_suffix }}.dmg
 
   build-windows-msvc:
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: setup
     strategy:
       fail-fast: false


### PR DESCRIPTION
Hi, this PR updates dependencies to the following versions:

- Qt → v6.9.2
- ngspice → v45