### PR TITLE
Update NGspice URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ env:
   QT_VERSION: 6.9.2
   QUCS_MACOS_BIN: ${{github.workspace}}/build/qucs/qucs-s.app/Contents/MacOS/bin
   QUCS_MACOS_RESOURCES: ${{github.workspace}}/build/qucs/qucs-s.app/Contents/MacOS/share/qucs-s
-  NGSPICE_URL: https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/45/ngspice-45_64.7z
+  NGSPICE_URL: https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/45.2/ngspice-45.2_64.7z
 
 jobs:
   setup:


### PR DESCRIPTION
I've noticed that the link in the 'NGSPICE_URL' field no longer works. This is causing the Windows builds to fail.

It seems that NGSpice released version 45.2 yesterday and the version 45 link no longer exists.

This PR simply updates the NGSpice download link.