### PR TITLE
fix(WireLabel::mirrorX/Y): Handle axis input

### DIFF
--- a/qucs/wirelabel.cpp
+++ b/qucs/wirelabel.cpp
@@ -180,16 +180,27 @@ bool WireLabel::rotate() noexcept
 
 bool WireLabel::mirrorX() noexcept
 {
+  return mirrorX(root().y());
+}
+
+bool WireLabel::mirrorX(int axis) noexcept{
   return moveCenterTo(
     center().x(),
-    qucs_s::geom::mirror_coordinate(center().y(), root().y()));
+    qucs_s::geom::mirror_coordinate(center().y(), axis)
+  );
 }
 
 bool WireLabel::mirrorY() noexcept
 {
+  return mirrorY(root().x());
+}
+
+bool WireLabel::mirrorY(int axis) noexcept
+{
   return moveCenterTo(
-    qucs_s::geom::mirror_coordinate(center().x(), root().x()),
-    center().y());
+    qucs_s::geom::mirror_coordinate(center().x(), axis),
+    center().y()
+  );
 }
 
 

--- a/qucs/wirelabel.h
+++ b/qucs/wirelabel.h
@@ -76,11 +76,11 @@ public:
   /** Mirrors label horizontally relative to its root */
   bool mirrorY() noexcept override;
 
-  /** Same as mirrorX() */
-  bool mirrorX(int /*axis*/) noexcept override { return mirrorX(); }
+  /** Mirrors labels vertically relative to an axis */
+  bool mirrorX(int /*axis*/) noexcept override;
 
-  /** Same as mirrorY() */
-  bool mirrorY(int /*axis*/) noexcept override { return mirrorY(); }
+  /** Mirrors label horizontally relative to an axis */
+  bool mirrorY(int /*axis*/) noexcept override;
 
   QRect boundingRect() const noexcept override;
 


### PR DESCRIPTION
WireLabel would always mirror relative to its root position, causing incorrect positioning when mirroring with multiple elements.
Using the axis as input we get the same mirroring effect that we have with other components.

Example
---

Reference circuit before mirroring:

<img width="442" height="299" alt="image" src="https://github.com/user-attachments/assets/7a44256b-b64d-4c00-ad37-2e39b66d7bf0" />

Left: Mirror around Y-axis on `current`
Right: Mirror around Y-axis using this PR

<img width="45%" height="338" alt="image" src="https://github.com/user-attachments/assets/c4cb1072-9393-483e-920a-0218c5139e49" />
<img width="45%" height="422" alt="image" src="https://github.com/user-attachments/assets/960c0a9a-e508-4954-ad85-4802d0d79c77" />

