### PR TITLE
fix(WireLabel): Handle transformations for detached WireLabels

### DIFF
--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -1509,6 +1509,30 @@ bool Schematic::distributeVertical()
 
     return true;
 }
+namespace internal {
+
+// Label snapping differs depending on whether or not it's attached
+// Returns true if the label moved.
+bool snapLabelToGrid(Schematic* sch, WireLabel* label)
+{
+    if (label->owner() == nullptr) {
+        // Detached: snap root and move text center the same distance
+        QPoint oldRoot = label->root();
+        QPoint newRoot = sch->setOnGrid(oldRoot);
+        QPoint delta = newRoot - oldRoot;
+
+        if (delta.x() != 0 || delta.y() != 0) {
+            label->moveRoot(delta.x(), delta.y());
+            label->moveCenter(delta.x(), delta.y());
+            return true;
+        }
+        return false;
+    }
+    // Attached: only snap the text center, root stays on wire
+    return label->moveCenterTo(sch->setOnGrid(label->center()));
+}
+
+} // namespace internal
 
 // Sets selected elements on grid.
 bool Schematic::elementsOnGrid()
@@ -1526,7 +1550,9 @@ bool Schematic::elementsOnGrid()
     // std::ranges::for_each(selection.paintings, onGridSetter);
     std::ranges::for_each(selection.components, onGridSetter);
     std::ranges::for_each(selection.diagrams, onGridSetter);
-    std::ranges::for_each(selection.labels, onGridSetter);
+    std::ranges::for_each(selection.labels, [&any_set, this](WireLabel* label) {
+        any_set = internal::snapLabelToGrid(this, label) || any_set;
+    });
     std::ranges::for_each(selection.markers, onGridSetter);
     std::ranges::for_each(selection.wires, [&any_set, this](Wire* w) {
         auto p1_moved = w->setP1(setOnGrid(w->P1()));

--- a/qucs/wirelabel.cpp
+++ b/qucs/wirelabel.cpp
@@ -174,7 +174,22 @@ bool WireLabel::moveCenter(int dx, int dy) noexcept
 
 bool WireLabel::rotate() noexcept
 {
-  qucs_s::geom::rotate_point_ccw(x1, y1, cx, cy);
+  return rotate(root().x(), root().y());
+}
+
+bool WireLabel::rotate(int rcx, int rcy) noexcept
+{
+  QPoint old_center = center();
+  // Rotate the text center around (rcx, rcy)
+  int new_center_x = old_center.x();
+  int new_center_y = old_center.y();
+  qucs_s::geom::rotate_point_ccw(new_center_x, new_center_y, rcx, rcy);
+  moveCenterTo(new_center_x, new_center_y);
+
+  // Rotate root if detached
+  if (owner() == nullptr) {
+    qucs_s::geom::rotate_point_ccw(cx, cy, rcx, rcy);
+  }
   return true;
 }
 
@@ -183,11 +198,22 @@ bool WireLabel::mirrorX() noexcept
   return mirrorX(root().y());
 }
 
-bool WireLabel::mirrorX(int axis) noexcept{
-  return moveCenterTo(
-    center().x(),
-    qucs_s::geom::mirror_coordinate(center().y(), axis)
-  );
+bool WireLabel::mirrorX(int axis) noexcept
+{
+  QPoint old_center = center();
+  int old_cy = cy;
+
+  // Mirror the text center
+  int new_center_y = qucs_s::geom::mirror_coordinate(old_center.y(), axis);
+  moveCenterTo(old_center.x(), new_center_y);
+
+  // Mirror the root if detached
+  if (owner() == nullptr) {
+    cy = qucs_s::geom::mirror_coordinate(old_cy, axis);
+  }
+
+  // text or root moved?
+  return (new_center_y != old_center.y()) || (owner() == nullptr && cy != old_cy);
 }
 
 bool WireLabel::mirrorY() noexcept
@@ -197,10 +223,20 @@ bool WireLabel::mirrorY() noexcept
 
 bool WireLabel::mirrorY(int axis) noexcept
 {
-  return moveCenterTo(
-    qucs_s::geom::mirror_coordinate(center().x(), axis),
-    center().y()
-  );
+  QPoint old_center = center();
+  int old_cx = cx;
+
+  // Mirror the text center
+  int new_center_x = qucs_s::geom::mirror_coordinate(old_center.x(), axis);
+  moveCenterTo(new_center_x, old_center.y());
+
+  // Mirror the root if detached
+  if (owner() == nullptr) {
+    cx = qucs_s::geom::mirror_coordinate(old_cx, axis);
+  }
+
+  // text or root moved?
+  return (new_center_x != old_center.x()) || (owner() == nullptr && cx != old_cx);
 }
 
 

--- a/qucs/wirelabel.h
+++ b/qucs/wirelabel.h
@@ -67,8 +67,8 @@ public:
   /** Rotates label around its root */
   bool rotate() noexcept override;
 
-  /** Same as rotate() */
-  bool rotate(int /*rcx*/, int /*rcy*/) noexcept override { return rotate(); }
+  /** Rotates label around a given center (rcx, rcy) */
+  bool rotate(int /*rcx*/, int /*rcy*/) noexcept override;
 
   /** Mirrors label vertically relative to its root */
   bool mirrorX() noexcept override;


### PR DESCRIPTION
# What?

- Fixed transformations (rotate, mirror, snap-to-grid) for detached WireLabels to transform both the text center _and_ the root
- Fixed multi-element rotation by handling an arbitrary center point (int rcx, int rcy), similar to the https://github.com/ra3xdh/qucs_s/pull/1473. 

# Why?

Previously, when wire labels were copied (detaching from the owner), transformation operations only moved the text center, but not the root. This made it impossible to correctly re-attach labels to wires after copy+paste, since wires were transformed but label roots were not, causing misalignment. 
