### PR TITLE
feat(Schematic): Add transformations to paste selection

### DIFF
--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1598,6 +1598,7 @@ void MouseActions::paintElementsScheme(Schematic *p)
 void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
 {
     int rot;
+    Schematic::Selection sel;
     QFileInfo Info(Doc->getDocName());
 
     switch (Event->button()) {
@@ -1638,9 +1639,19 @@ void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
         }
 
         pasteElements(Doc);
-        // keep rotation sticky for pasted elements
+        // keep transformations sticky for pasted elements
         rot = movingRotated;
-        while (rot--) std::ranges::for_each(movingElements, [](Element* e) { e->rotate(); });
+        sel = Doc->elementsToSelection(movingElements);
+        if (movingMirrorX) {
+            Doc->mirrorXComponents(sel);
+        }
+
+        if (movingMirrorY) {
+            Doc->mirrorYComponents(sel);
+        }        
+        while (rot--) {
+            Doc->rotateElements(sel);
+        }
 
         QucsMain->MouseMoveAction = &MouseActions::MMovePaste;
         QucsMain->MousePressAction = nullptr;
@@ -1942,6 +1953,62 @@ void MouseActions::MPressTune(Schematic *Doc, QMouseEvent *Event, float fX, floa
             }
         }
     }
+}
+// ***********************************************************************
+// **********                                                   **********
+// **********    Functions for transforming moving elements     **********
+// **********                                                   **********
+// ***********************************************************************
+
+void MouseActions::mirrorXMovingElements(Schematic* Doc)
+{
+    if (movingElements.empty()) {
+        return;
+    }
+
+    Schematic::Selection selection = Doc->elementsToSelection(movingElements);
+    Doc->mirrorXComponents(selection);
+
+    // save mirror operation
+    movingMirrorX++;
+    movingMirrorX &= 1;
+
+    paintElementsScheme(Doc);
+    Doc->viewport()->update();
+}
+
+void MouseActions::mirrorYMovingElements(Schematic* Doc)
+{
+    if (movingElements.empty()) {
+        return;
+    }
+
+    Schematic::Selection selection = Doc->elementsToSelection(movingElements);
+    Doc->mirrorYComponents(selection);
+
+    // save mirror operation
+    movingMirrorY++;
+    movingMirrorY &= 1;
+
+    paintElementsScheme(Doc);
+    Doc->viewport()->update();
+}
+
+void MouseActions::rotateMovingElements(Schematic* Doc)
+{
+    if (movingElements.empty()) {
+        return;
+    }
+
+    Schematic::Selection selection = Doc->elementsToSelection(movingElements);
+    Doc->rotateElements(selection);
+
+    // Save rotation
+    movingRotated++;
+    movingRotated &= 3;
+
+    paintElementsScheme(Doc);
+    Doc->viewport()->update();
 }
 
 // vim:ts=8:sw=2:noet

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1605,41 +1605,41 @@ void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
     QFileInfo Info(Doc->getDocName());
 
     switch (Event->button()) {
-    case Qt::LeftButton:
+    case Qt::LeftButton: {
         // insert all moved elements into document
-        for (auto* pe : movingElements) {
-            pe->isSelected = false;
-            switch (pe->Type) {
-            case isWire:
-                Doc->installWire(dynamic_cast<Wire*>(pe));
-                break;
-            case isDiagram:
-                Doc->a_Diagrams->push_back((Diagram *) pe);
-                ((Diagram *) pe)
-                    ->loadGraphData(Info.absolutePath() + QDir::separator() + Doc->getDataSet());
-                Doc->enlargeView(pe);
-                break;
-            case isPainting: {
-                Doc->a_Paintings->push_back((Painting *) pe);
-                Doc->enlargeView(pe);
-                break;
-            }
-            case isLabel: {
-                auto wl = dynamic_cast<WireLabel*>(pe);
-                if (wl->owner() != nullptr) break;
+        // NOTE: Markers and nodes are excluded
+        for (auto* pc : movingState.selection.components) {
+            pc->isSelected = false;
+            Doc->insertComponent(pc);
+            Doc->enlargeView(pc);
+        }
+
+        for (auto* pw : movingState.selection.wires) {
+            pw->isSelected = false;
+            Doc->installWire(pw);
+        }
+
+        for (auto* pd : movingState.selection.diagrams) {
+            pd->isSelected = false;
+            Doc->a_Diagrams->push_back(pd);
+            pd->loadGraphData(Info.absolutePath() + QDir::separator() + Doc->getDataSet());
+            Doc->enlargeView(pd);
+        }
+
+        for (auto* pp : movingState.selection.paintings) {
+            pp->isSelected = false;
+            Doc->a_Paintings->push_back(pp);
+            Doc->enlargeView(pp);
+        }
+
+        for (auto* pl : movingState.selection.labels) {
+            pl->isSelected = false;
+            if (pl->owner() == nullptr) {
                 // If label here has no owner it means it was a node label.
                 // New host node has to be found for it.
-                Doc->placeNodeLabel(wl);
-                break;
+                Doc->placeNodeLabel(pl);
             }
-            case isComponent:
-            case isAnalogComponent:
-            case isDigitalComponent:
-                Doc->insertComponent((Component *) pe);
-                Doc->enlargeView(pe);
-                break;
-            }
-        }
+         }
 
         pasteElements(Doc);
         // since the elements are now pasted, we need to re-do the selection
@@ -1669,6 +1669,7 @@ void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
         // to avoid waiting for the user to move their mouse
         MouseActions::MMovePaste(Doc, Event);
         break;
+    }
 
     // ............................................................
     case Qt::RightButton: {// right button rotates the elements

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1662,6 +1662,12 @@ void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
 
         Doc->viewport()->update();
         Doc->setChanged(true, true);
+
+        // Input handler dependency: To transform moving selection, we need to be in MMovePaste2,
+        // otherwise it transforms the schematic's selection.
+        // Manually trigger the move action to enforce the state transition,
+        // to avoid waiting for the user to move their mouse
+        MouseActions::MMovePaste(Doc, Event);
         break;
 
     // ............................................................

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -415,6 +415,11 @@ void MouseActions::MMovePaste(Schematic *Doc, QMouseEvent *Event)
         }
     }
 
+    // Cache selection
+    if (!movingState.selection.isValid()) {
+        movingState.selection = Doc->elementsToSelection(movingElements);
+    }
+
     QucsMain->MouseMoveAction = &MouseActions::MMovePaste2;
     QucsMain->MouseReleaseAction = &MouseActions::MReleasePaste;
 }
@@ -1597,7 +1602,6 @@ void MouseActions::paintElementsScheme(Schematic *p)
 // -----------------------------------------------------------
 void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
 {
-    Schematic::Selection sel;
     QFileInfo Info(Doc->getDocName());
 
     switch (Event->button()) {
@@ -1639,16 +1643,16 @@ void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
 
         pasteElements(Doc);
         // since the elements are now pasted, we need to re-do the selection
-        sel = Doc->elementsToSelection(movingElements);
+        movingState.selection = Doc->elementsToSelection(movingElements);
         // keep transformations sticky for pasted elements
         if (movingState.mirrorX) {
-            Doc->mirrorXComponents(sel);
+            Doc->mirrorXComponents(movingState.selection);
         }
         if (movingState.mirrorY) {
-            Doc->mirrorYComponents(sel);
+            Doc->mirrorYComponents(movingState.selection);
         }
         for (int i = 0; i < movingState.rotated; i++) {
-            Doc->rotateElements(sel);
+            Doc->rotateElements(movingState.selection);
         }
 
         QucsMain->MouseMoveAction = &MouseActions::MMovePaste;
@@ -1953,8 +1957,7 @@ void MouseActions::mirrorXMovingElements(Schematic* Doc)
         return;
     }
 
-    Schematic::Selection selection = Doc->elementsToSelection(movingElements);
-    Doc->mirrorXComponents(selection);
+    Doc->mirrorXComponents(movingState.selection);
     // Save transformation
     movingState.mirrorX = !movingState.mirrorX;
 
@@ -1968,8 +1971,7 @@ void MouseActions::mirrorYMovingElements(Schematic* Doc)
         return;
     }
 
-    Schematic::Selection selection = Doc->elementsToSelection(movingElements);
-    Doc->mirrorYComponents(selection);
+    Doc->mirrorYComponents(movingState.selection);
     // Save transformation
     movingState.mirrorY = !movingState.mirrorY;
 
@@ -1983,8 +1985,7 @@ void MouseActions::rotateMovingElements(Schematic* Doc)
         return;
     }
 
-    Schematic::Selection selection = Doc->elementsToSelection(movingElements);
-    Doc->rotateElements(selection);
+    Doc->rotateElements(movingState.selection);
     // Save transformation
     movingState.rotated++;
     movingState.rotated &= 3;

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1597,7 +1597,6 @@ void MouseActions::paintElementsScheme(Schematic *p)
 // -----------------------------------------------------------
 void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
 {
-    int rot;
     Schematic::Selection sel;
     QFileInfo Info(Doc->getDocName());
 
@@ -1639,17 +1638,16 @@ void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
         }
 
         pasteElements(Doc);
-        // keep transformations sticky for pasted elements
-        rot = movingRotated;
+        // since the elements are now pasted, we need to re-do the selection
         sel = Doc->elementsToSelection(movingElements);
-        if (movingMirrorX) {
+        // keep transformations sticky for pasted elements
+        if (movingState.mirrorX) {
             Doc->mirrorXComponents(sel);
         }
-
-        if (movingMirrorY) {
+        if (movingState.mirrorY) {
             Doc->mirrorYComponents(sel);
-        }        
-        while (rot--) {
+        }
+        for (int i = 0; i < movingState.rotated; i++) {
             Doc->rotateElements(sel);
         }
 
@@ -1664,18 +1662,7 @@ void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
 
     // ............................................................
     case Qt::RightButton: {// right button rotates the elements
-
-
-        if (movingElements.size() == 1) {
-            movingElements.front()->rotate();
-        } else {
-            const auto rot_c = Doc->setOnGrid(Doc->contentsToModel(Event->pos()));
-            std::ranges::for_each(movingElements, [rot_c](Element* e){ e->rotate(rot_c); });
-        }
-        paintElementsScheme(Doc);
-        // save rotation
-        movingRotated++;
-        movingRotated &= 3;
+        rotateMovingElements(Doc);
         break;
     }
 
@@ -1968,10 +1955,8 @@ void MouseActions::mirrorXMovingElements(Schematic* Doc)
 
     Schematic::Selection selection = Doc->elementsToSelection(movingElements);
     Doc->mirrorXComponents(selection);
-
-    // save mirror operation
-    movingMirrorX++;
-    movingMirrorX &= 1;
+    // Save transformation
+    movingState.mirrorX = !movingState.mirrorX;
 
     paintElementsScheme(Doc);
     Doc->viewport()->update();
@@ -1985,10 +1970,8 @@ void MouseActions::mirrorYMovingElements(Schematic* Doc)
 
     Schematic::Selection selection = Doc->elementsToSelection(movingElements);
     Doc->mirrorYComponents(selection);
-
-    // save mirror operation
-    movingMirrorY++;
-    movingMirrorY &= 1;
+    // Save transformation
+    movingState.mirrorY = !movingState.mirrorY;
 
     paintElementsScheme(Doc);
     Doc->viewport()->update();
@@ -2002,10 +1985,9 @@ void MouseActions::rotateMovingElements(Schematic* Doc)
 
     Schematic::Selection selection = Doc->elementsToSelection(movingElements);
     Doc->rotateElements(selection);
-
-    // Save rotation
-    movingRotated++;
-    movingRotated &= 3;
+    // Save transformation
+    movingState.rotated++;
+    movingState.rotated &= 3;
 
     paintElementsScheme(Doc);
     Doc->viewport()->update();

--- a/qucs/mouseactions.h
+++ b/qucs/mouseactions.h
@@ -33,6 +33,12 @@ class QucsApp;
 
 extern QAction *formerAction;
 
+struct MovingState {
+  int rotated = 0;
+  bool mirrorX = false;
+  bool mirrorY = false;
+};
+
 
 class MouseActions {
 public:
@@ -50,9 +56,8 @@ public:
 
   int  MAx1, MAy1,MAx2, MAy2, MAx3, MAy3;  // cache for mouse movements
   std::list<Element*> movingElements;
-  int movingRotated;
-  int movingMirrorX;
-  int movingMirrorY;
+  // movingElements transformations state
+  MovingState movingState;
 
   // menu appearing by right mouse button click on component
   QMenu *ComponentMenu;

--- a/qucs/mouseactions.h
+++ b/qucs/mouseactions.h
@@ -51,6 +51,8 @@ public:
   int  MAx1, MAy1,MAx2, MAy2, MAx3, MAy3;  // cache for mouse movements
   std::list<Element*> movingElements;
   int movingRotated;
+  int movingMirrorX;
+  int movingMirrorY;
 
   // menu appearing by right mouse button click on component
   QMenu *ComponentMenu;
@@ -122,6 +124,11 @@ public:
 
   void paintElementsScheme(Schematic*);
   void rightPressMenu(Schematic*, QMouseEvent*, float, float);
+
+  // Transformation of moving elements
+  void mirrorXMovingElements(Schematic*);
+  void mirrorYMovingElements(Schematic*);
+  void rotateMovingElements(Schematic*);
 };
 
 #endif

--- a/qucs/mouseactions.h
+++ b/qucs/mouseactions.h
@@ -19,6 +19,7 @@
 #define MOUSEACTIONS_H
 
 #include "element.h"
+#include "schematic_selection.h"
 #include <QAction>
 
 
@@ -37,6 +38,7 @@ struct MovingState {
   int rotated = 0;
   bool mirrorX = false;
   bool mirrorY = false;
+  SchematicSelection selection = {};
 };
 
 
@@ -56,7 +58,7 @@ public:
 
   int  MAx1, MAy1,MAx2, MAy2, MAx3, MAy3;  // cache for mouse movements
   std::list<Element*> movingElements;
-  // movingElements transformations state
+  // movingElements transformations and selection state
   MovingState movingState;
 
   // menu appearing by right mouse button click on component

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -134,6 +134,18 @@ void QucsApp::slotOnGrid(bool on)
 // Is called when the rotate toolbar button is pressed.
 void QucsApp::slotEditRotate(bool on)
 {
+  // If we're in paste mode, rotate moving elements instead of schematic elements
+  if (MouseMoveAction == &MouseActions::MMovePaste2) {
+    editRotate->blockSignals(true);
+    editRotate->setChecked(false);
+    editRotate->blockSignals(false);
+
+    Schematic* Doc = dynamic_cast<Schematic*>(DocumentTab->currentWidget());
+    if (Doc != nullptr) {
+      view->rotateMovingElements(Doc);
+    }
+    return;
+  }
   performToggleAction(on, editRotate, &Schematic::rotateElements,
     &MouseActions::MMoveRotate, &MouseActions::MPressRotate);
 }
@@ -142,6 +154,18 @@ void QucsApp::slotEditRotate(bool on)
 // Is called when the mirror toolbar button is pressed.
 void QucsApp::slotEditMirrorX(bool on)
 {
+  // If we're in paste mode, mirror moving elements instead of schematic elements
+  if (MouseMoveAction == &MouseActions::MMovePaste2) {
+    editMirror->blockSignals(true);
+    editMirror->setChecked(false);
+    editMirror->blockSignals(false);
+
+    Schematic* Doc = dynamic_cast<Schematic*>(DocumentTab->currentWidget());
+    if (Doc != nullptr) {
+      view->mirrorXMovingElements(Doc);
+    }
+    return;
+  }
   performToggleAction(on, editMirror, &Schematic::mirrorXComponents,
     &MouseActions::MMoveMirrorX, &MouseActions::MPressMirrorX);
 }
@@ -150,6 +174,18 @@ void QucsApp::slotEditMirrorX(bool on)
 // Is called when the mirror toolbar button is pressed.
 void QucsApp::slotEditMirrorY(bool on)
 {
+  // If we're in paste mode, mirror moving elements instead of schematic elements
+  if (MouseMoveAction == &MouseActions::MMovePaste2) {
+    editMirrorY->blockSignals(true);
+    editMirrorY->setChecked(false);
+    editMirrorY->blockSignals(false);
+
+    Schematic* Doc = dynamic_cast<Schematic*>(DocumentTab->currentWidget());
+    if (Doc != nullptr) {
+      view->mirrorYMovingElements(Doc);
+    }
+    return;
+  }
   performToggleAction(on, editMirrorY, &Schematic::mirrorYComponents,
     &MouseActions::MMoveMirrorY, &MouseActions::MPressMirrorY);
 }

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -442,9 +442,7 @@ void QucsApp::slotEditPaste(bool on)
     activeAction = editPaste;
 
     MouseMoveAction = &MouseActions::MMovePaste;
-    view->movingRotated = 0;
-    view->movingMirrorX = 0;
-    view->movingMirrorY = 0;
+    view->movingState = {};
     MousePressAction = nullptr;
     MouseReleaseAction = nullptr;
     MouseDoubleClickAction = nullptr;

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -407,6 +407,8 @@ void QucsApp::slotEditPaste(bool on)
 
     MouseMoveAction = &MouseActions::MMovePaste;
     view->movingRotated = 0;
+    view->movingMirrorX = 0;
+    view->movingMirrorY = 0;
     MousePressAction = nullptr;
     MouseReleaseAction = nullptr;
     MouseDoubleClickAction = nullptr;

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1229,6 +1229,53 @@ Schematic::Selection Schematic::currentSelection() const {
     return selection;
 }
 
+// Convert an element list to Selection
+Schematic::Selection Schematic::elementsToSelection(const std::list<Element*> &elements) const
+{
+        std::optional<QRect> totalBounds = std::nullopt;
+        Selection selection;
+
+        // A helper to simplify uniting bounding boxes.
+        auto addElement = [&](auto* element, auto& list) {
+            list.push_back(element);
+            // Special case for Components which have different bounding rect method
+            if constexpr (std::is_same_v<decltype(element), Component*>) {
+                internal::unite(totalBounds, element->boundingRectIncludingProperties());
+            } else {
+                internal::unite(totalBounds, element->boundingRect());
+            }
+        };
+
+        for (Element* element : elements) {
+            if (element == nullptr) {
+                continue;
+            }
+
+            if (auto* pc = dynamic_cast<Component*>(element)) {
+                addElement(pc, selection.components);
+            } else if (auto* pw = dynamic_cast<Wire*>(element)) {
+                addElement(pw, selection.wires);
+            } else if (auto* pn = dynamic_cast<Node*>(element)) {
+                addElement(pn, selection.nodes);
+            } else if (auto* pl = dynamic_cast<WireLabel*>(element)) {
+                addElement(pl, selection.labels);
+            } else if (auto* pd = dynamic_cast<Diagram*>(element)) {
+                addElement(pd, selection.diagrams);
+            } else if (auto* pm = dynamic_cast<Marker*>(element)) {
+                addElement(pm, selection.markers);
+            } else if (auto* pp = dynamic_cast<Painting*>(element)) {
+                addElement(pp, selection.paintings);
+            }
+        }
+
+        if(!totalBounds) {
+            return {};
+        }
+
+        selection.bounds = *totalBounds;
+        return selection;
+}
+
 // ---------------------------------------------------
 // Updates the graph data of all diagrams (load from data files).
 void Schematic::reloadGraphs()

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -29,6 +29,7 @@
 
 #include "qucsdoc.h"
 #include "wire_planner.h"
+#include "schematic_selection.h"
 
 #include "qt3_compat/q3scrollview.h"
 #include <QVector>
@@ -108,17 +109,7 @@ public:
   */
   QRect allBoundingRect();
 
-  struct Selection {
-    QRect bounds;
-    std::vector<Component*> components;
-    std::vector<Wire*> wires;
-    std::vector<Painting*> paintings;
-    std::vector<Diagram*> diagrams;
-    std::vector<WireLabel*> labels;
-    std::vector<Marker*> markers;
-    std::vector<Node*> nodes;
-  };
-
+  using Selection = SchematicSelection;
   Selection  currentSelection() const;
   Selection  elementsToSelection(const std::list<Element*>&) const;
   bool  rotateElements();

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -124,9 +124,15 @@ public:
   bool  rotateElements();
   bool  mirrorXComponents();
   bool  mirrorYComponents();
+  // Same as above - but with an arbitrary selection
+  bool  rotateElements(Selection selection);
+  bool  mirrorXComponents(Selection selection);
+  bool  mirrorYComponents(Selection selection);
+
   QPoint setOnGrid(const QPoint& p);
   void  setOnGrid(int&, int&);
   bool  elementsOnGrid();
+  bool  elementsOnGrid(Selection selection);
 
   /**
     Zoom around a "zooming center". Zooming center is a point on the canvas,

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -120,6 +120,7 @@ public:
   };
 
   Selection  currentSelection() const;
+  Selection  elementsToSelection(const std::list<Element*>&) const;
   bool  rotateElements();
   bool  mirrorXComponents();
   bool  mirrorYComponents();

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -1537,8 +1537,10 @@ bool snapLabelToGrid(Schematic* sch, WireLabel* label)
 // Sets selected elements on grid.
 bool Schematic::elementsOnGrid()
 {
-    auto selection = currentSelection();
-
+    return elementsOnGrid(currentSelection());
+}
+bool Schematic::elementsOnGrid(Selection selection)
+{
     const auto count = internal::total_count(selection);
     if (count == 0) return false;
 
@@ -1590,7 +1592,12 @@ bool symbolElementsOnGrid(Schematic* sch, const std::vector<Painting*>& painting
 // Rotates all selected components around their midpoint.
 bool Schematic::rotateElements()
 {
-    auto selection = currentSelection();
+    return rotateElements(currentSelection());
+}
+
+// Rotates a selection of components around their midpoint.
+bool Schematic::rotateElements(Selection selection)
+{
 
     const auto count = internal::total_count(selection);
 
@@ -1631,7 +1638,7 @@ bool Schematic::rotateElements()
     } else {
         // elementsOnGrid heals and adds undo-entry by its own
         // if it changes something
-        if (!elementsOnGrid()) {
+        if (!elementsOnGrid(selection)) {
             heal(&noninteractiveMutationParams);
             setChanged(true, true);
         }
@@ -1640,10 +1647,15 @@ bool Schematic::rotateElements()
     return true;
 }
 
-// Mirrors all selected components.
+// Mirrors all selected components along X-axis
 bool Schematic::mirrorXComponents()
 {
-    const auto selection = currentSelection();
+    return mirrorXComponents(currentSelection());
+}
+
+// Mirrors selection of components along X-axis
+bool Schematic::mirrorXComponents(Selection selection)
+{
 
     const auto count = internal::total_count(selection);
 
@@ -1676,7 +1688,7 @@ bool Schematic::mirrorXComponents()
     } else {
         // elementsOnGrid heals and adds undo-entry by its own
         // if it changes something
-        if (!elementsOnGrid()) {
+        if (!elementsOnGrid(selection)) {
             heal(&noninteractiveMutationParams);
             setChanged(true, true);
         }
@@ -1685,11 +1697,15 @@ bool Schematic::mirrorXComponents()
     return true;
 }
 
-// Mirrors all selected components.
+// Mirrors all selected components along Y-axis
 bool Schematic::mirrorYComponents()
 {
-    const auto selection = currentSelection();
+    return mirrorYComponents(currentSelection());
+}
 
+// Mirrors selection of components along Y-axis
+bool Schematic::mirrorYComponents(Selection selection)
+{
     const auto count = internal::total_count(selection);
 
     if (count < 1) return false;
@@ -1721,7 +1737,7 @@ bool Schematic::mirrorYComponents()
     } else {
         // elementsOnGrid heals and adds undo-entry by its own
         // if it changes something
-        if (!elementsOnGrid()) {
+        if (!elementsOnGrid(selection)) {
             heal(&noninteractiveMutationParams);
             setChanged(true, true);
         }

--- a/qucs/schematic_selection.h
+++ b/qucs/schematic_selection.h
@@ -1,0 +1,63 @@
+#ifndef SCHEMATIC_SELECTION_H
+#define SCHEMATIC_SELECTION_H
+
+#include <vector>
+#include <QRect>
+
+class Component;
+class Wire;
+class Painting;
+class Diagram;
+class WireLabel;
+class Marker;
+class Node;
+
+struct SchematicSelection {
+  QRect bounds;
+  std::vector<Component*> components;
+  std::vector<Wire*> wires;
+  std::vector<Painting*> paintings;
+  std::vector<Diagram*> diagrams;
+  std::vector<WireLabel*> labels;
+  std::vector<Marker*> markers;
+  std::vector<Node*> nodes;
+
+  // Return whether the selection is empty
+  bool isEmpty() const {
+    return components.empty() &&
+      wires.empty() &&
+      paintings.empty() &&
+      diagrams.empty() &&
+      labels.empty() &&
+      markers.empty() &&
+      nodes.empty();
+  }
+  // Valid checks if we are not empty and has a valid boundary
+  bool isValid() const {
+    return !isEmpty() && bounds.isValid() && !bounds.isEmpty();
+  }
+
+  // Return total amount of elements selected
+  std::size_t count() const {
+    return components.size() +
+      wires.size() +
+      paintings.size() +
+      diagrams.size() +
+      labels.size() +
+      markers.size() +
+      nodes.size();
+  }
+
+  // Clear selection
+  void clear() {
+    components.clear();
+    wires.clear();
+    paintings.clear();
+    diagrams.clear();
+    labels.clear();
+    markers.clear();
+    nodes.clear();
+    bounds = QRect();
+  }
+};
+#endif


### PR DESCRIPTION
# What?

- Implements `rotate` and `mirror{X, Y}` transformations for elements during copy-paste operations
- Re-uses most of the transformation logic in `Schematic` by introducing `Selection`-based overloads
- Refactors the paste code to use `Selection` instead of `movingElements` list directly. 

# Why?

Previously, one could only rotate pasted elements (via right-click), but couldn't mirror them.
Additionally, the rotation logic was re-implemented inside `MouseActions` rather than re-using the logic found in `Schematic`.

This PR intercepts the existing toolbar/keyboard actions for  MirrorX, MirrorY and Rotate (right-click is also kept) while in paste-mode, allowing for the same transformations we have in regular Schematic mode.

# Notes

This depends on https://github.com/ra3xdh/qucs_s/pull/1487 for correct WireLabel re-attachment after copy.

# Demo

Short video demonstration:

[qucs-paste-transformation.webm](https://github.com/user-attachments/assets/0f357259-6785-46ec-b4e6-4f64b3967970)
