### PR TITLE
refactor(MouseActions): extract mouse movement logic and fix tracking bug

### DIFF
--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -323,6 +323,9 @@ void MouseActions::MMoveResizePainting(Schematic *Doc, QMouseEvent *Event)
 void MouseActions::MMoveMoving(Schematic *Doc, QMouseEvent *Event)
 {
     setPainter(Doc);
+    // initialize total movement
+    MAx3 = 0;
+    MAy3 = 0;
 
     updateMouseMove(Doc, Event, /*onGrid=*/true);
 

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1915,7 +1915,7 @@ void MouseActions::MPressTune(Schematic *Doc, QMouseEvent *Event, float fX, floa
 
 void MouseActions::mirrorXMovingElements(Schematic* Doc)
 {
-    if (movingElements.empty()) {
+    if (!movingState.selection.isValid()) {
         return;
     }
 
@@ -1929,7 +1929,7 @@ void MouseActions::mirrorXMovingElements(Schematic* Doc)
 
 void MouseActions::mirrorYMovingElements(Schematic* Doc)
 {
-    if (movingElements.empty()) {
+    if (!movingState.selection.isValid()) {
         return;
     }
 
@@ -1943,7 +1943,7 @@ void MouseActions::mirrorYMovingElements(Schematic* Doc)
 
 void MouseActions::rotateMovingElements(Schematic* Doc)
 {
-    if (movingElements.empty()) {
+    if (!movingState.selection.isValid()) {
         return;
     }
 

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -324,14 +324,8 @@ void MouseActions::MMoveMoving(Schematic *Doc, QMouseEvent *Event)
 {
     setPainter(Doc);
 
-    auto inModel = Doc->contentsToModel(Event->pos());
-    MAx2 = inModel.x();
-    MAy2 = inModel.y();
+    updateMouseMove(Doc, Event, /*onGrid=*/true);
 
-    Doc->setOnGrid(MAx2, MAy2);
-
-    MAx1 = MAx2;
-    MAy1 = MAy2;
     QucsMain->MouseMoveAction = &MouseActions::MMoveMoving2;
     QucsMain->MouseReleaseAction = &MouseActions::MReleaseMoving;
     QucsMain->editRotate->blockSignals(true);
@@ -343,26 +337,16 @@ void MouseActions::MMoveMoving(Schematic *Doc, QMouseEvent *Event)
 // Moves components by keeping the mouse button pressed.
 void MouseActions::MMoveMoving2(Schematic *Doc, QMouseEvent *Event)
 {
-  setPainter(Doc);
+    setPainter(Doc);
 
-  auto inModel = Doc->contentsToModel(Event->pos());
-  MAx2 = inModel.x();
-  MAy2 = inModel.y();
-
-  if ((Event->modifiers().testFlag(Qt::ControlModifier)) == 0)
-    Doc->setOnGrid(MAx2, MAy2); // use grid only if CTRL key not pressed
-  MAx1 = MAx2 - MAx1;
-  MAy1 = MAy2 - MAy1;
-  MAx3 += MAx1;
-  MAy3 += MAy1; // keep track of the complete movement
+    // use grid _unless_ CTRL key is pressed
+    bool onGrid = Event->modifiers().testFlag(Qt::ControlModifier) == 0;
+    QPoint delta = updateMouseMove(Doc, Event, onGrid);
 
     auto selection = Doc->currentSelection();
-    selection.moveCenter(MAx1, MAy1);
+    selection.moveCenter(delta.x(), delta.y());
 
     Doc->displayMutations();
-
-  MAx1 = MAx2;
-  MAy1 = MAy2;
 }
 
 /**
@@ -389,10 +373,7 @@ void MouseActions::MMovePaste(Schematic *Doc, QMouseEvent *Event)
 
 void MouseActions::MMovePaste2(Schematic *Doc, QMouseEvent *Event)
 {
-    const auto inModel = Doc->setOnGrid(Doc->contentsToModel(Event->pos()));
-    auto diff = inModel - QPoint{MAx1, MAy1};
-    MAx1 = inModel.x();
-    MAy1 = inModel.y();
+    QPoint diff = updateMouseMove(Doc, Event, /*onGrid=*/true);
     movingState.selection.moveCenter(diff.x(), diff.y());
     paintElementsScheme(Doc);
 }
@@ -1954,6 +1935,37 @@ void MouseActions::rotateMovingElements(Schematic* Doc)
 
     paintElementsScheme(Doc);
     Doc->viewport()->update();
+}
+
+
+// **********************************************
+// **********                          **********
+// **********    Utility functions     **********
+// **********                          **********
+// **********************************************
+
+// Helper function that updates and tracks mouse movement
+// Returns the mouse movement delta as a QPoint
+QPoint MouseActions::updateMouseMove(Schematic* Doc, QMouseEvent* Event, bool onGrid)
+{
+
+    auto inModel = Doc->contentsToModel(Event->pos());
+    MAx2 = inModel.x();
+    MAy2 = inModel.y();
+
+    if (onGrid) {
+      Doc->setOnGrid(MAx2, MAy2);
+    }
+
+    QPoint delta(MAx2-MAx1, MAy2-MAy1);
+    MAx1 = MAx2;
+    MAy1 = MAy2;
+
+    // Track complete movement
+    MAx3 += delta.x();
+    MAy3 += delta.y();
+
+    return delta;
 }
 
 // vim:ts=8:sw=2:noet

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -376,43 +376,13 @@ void MouseActions::MMovePaste(Schematic *Doc, QMouseEvent *Event)
     MAx1 = cursor.x();
     MAy1 = cursor.y();
 
-    QPoint diff;
-
-    if (movingElements.size() == 1) {
-        diff = cursor - Doc->setOnGrid(movingElements.front()->center());
-    } else {
-
-        const auto get_br = [](const Element* e) {
-            return e->boundingRect();
-        };
-
-        auto br = std::transform_reduce(
-            ++movingElements.begin(),
-            movingElements.end(),
-            get_br(movingElements.front()),
-            [](const QRect& a, const QRect& b) { return a.united(b);},
-            get_br
-        );
-
-        diff = cursor - Doc->setOnGrid(br.center());
-    }
-
-
-    for (auto* pe : movingElements) {
-        pe->moveCenter(diff.x(), diff.y());
-
-        // Special case: node label. Pasted node label has no host element,
-        // which would move its root, thus it has to be moved explicitely.
-        if (auto* l = dynamic_cast<WireLabel*>(pe); l != nullptr && l->owner() == nullptr) {
-            l->moveRoot(diff.x(), diff.y());
-        }
-    }
-
     // Cache selection
     if (!movingState.selection.isValid()) {
         movingState.selection = Doc->elementsToSelection(movingElements);
     }
 
+    QPoint diff = cursor - Doc->setOnGrid(movingState.selection.center());
+    movingState.selection.moveCenter(diff.x(), diff.y());
     QucsMain->MouseMoveAction = &MouseActions::MMovePaste2;
     QucsMain->MouseReleaseAction = &MouseActions::MReleasePaste;
 }
@@ -423,15 +393,7 @@ void MouseActions::MMovePaste2(Schematic *Doc, QMouseEvent *Event)
     auto diff = inModel - QPoint{MAx1, MAy1};
     MAx1 = inModel.x();
     MAy1 = inModel.y();
-    for (auto* pe : movingElements) {
-        pe->moveCenter(diff.x(), diff.y());
-
-        // Special case: node label. Pasted node label has no host element,
-        // which would move its root, thus it has to be moved explicitely.
-        if (auto* l = dynamic_cast<WireLabel*>(pe); l != nullptr && l->owner() == nullptr) {
-            l->moveRoot(diff.x(), diff.y());
-        }
-    }
+    movingState.selection.moveCenter(diff.x(), diff.y());
     paintElementsScheme(Doc);
 }
 

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -356,15 +356,8 @@ void MouseActions::MMoveMoving2(Schematic *Doc, QMouseEvent *Event)
   MAx3 += MAx1;
   MAy3 += MAy1; // keep track of the complete movement
 
-    const auto mover = [this](Element* e) { e->moveCenter(MAx1, MAy1); };
     auto selection = Doc->currentSelection();
-    std::ranges::for_each(selection.paintings, mover);
-    std::ranges::for_each(selection.diagrams, mover);
-    std::ranges::for_each(selection.labels, mover);
-    std::ranges::for_each(selection.markers, mover);
-    std::ranges::for_each(selection.components, mover);
-    std::ranges::for_each(selection.wires, mover);
-    std::ranges::for_each(selection.nodes, mover);
+    selection.moveCenter(MAx1, MAy1);
 
     Doc->displayMutations();
 

--- a/qucs/mouseactions.h
+++ b/qucs/mouseactions.h
@@ -136,6 +136,9 @@ public:
   void mirrorXMovingElements(Schematic*);
   void mirrorYMovingElements(Schematic*);
   void rotateMovingElements(Schematic*);
+
+  // Helper functions
+  QPoint updateMouseMove(Schematic*, QMouseEvent*, bool onGrid=true);
 };
 
 #endif

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1238,12 +1238,7 @@ Schematic::Selection Schematic::elementsToSelection(const std::list<Element*> &e
         // A helper to simplify uniting bounding boxes.
         auto addElement = [&](auto* element, auto& list) {
             list.push_back(element);
-            // Special case for Components which have different bounding rect method
-            if constexpr (std::is_same_v<decltype(element), Component*>) {
-                internal::unite(totalBounds, element->boundingRectIncludingProperties());
-            } else {
-                internal::unite(totalBounds, element->boundingRect());
-            }
+            internal::unite(totalBounds, element->boundingRect());
         };
 
         for (Element* element : elements) {

--- a/qucs/schematic_selection.h
+++ b/qucs/schematic_selection.h
@@ -66,12 +66,24 @@ struct SchematicSelection {
     for (auto* pw : wires)        pw->moveCenter(dx, dy);
     for (auto* pp : paintings)    pp->moveCenter(dx, dy);
     for (auto* pd : diagrams)     pd->moveCenter(dx, dy);
-    for (auto* pl : labels)       pl->moveCenter(dx, dy);
+    for (auto* pl : labels) {
+      pl->moveCenter(dx, dy);
+      // Special case: labels that doesn't have an owner needs to also have it's root moved.
+      // This is seen during paste of elements, where the node doesn't have a host element
+      if (pl->owner() == nullptr) {
+        pl->moveRoot(dx, dy);
+      }
+    }
     for (auto* pm : markers)      pm->moveCenter(dx, dy);
     for (auto* pn : nodes)        pn->moveCenter(dx, dy);
 
     // Move bounds
     bounds.moveCenter(QPoint(dx, dy));
+  }
+
+  // Center of selection is the center of the bounds
+  QPoint center() const {
+    return bounds.center();
   }
 };
 #endif

--- a/qucs/schematic_selection.h
+++ b/qucs/schematic_selection.h
@@ -4,13 +4,13 @@
 #include <vector>
 #include <QRect>
 
-class Component;
-class Wire;
-class Painting;
-class Diagram;
-class WireLabel;
-class Marker;
-class Node;
+#include "component.h"
+#include "wire.h"
+#include "painting.h"
+#include "diagram.h"
+#include "wirelabel.h"
+#include "marker.h"
+#include "node.h"
 
 struct SchematicSelection {
   QRect bounds;
@@ -58,6 +58,20 @@ struct SchematicSelection {
     markers.clear();
     nodes.clear();
     bounds = QRect();
+  }
+
+  // Move center for all components
+  void moveCenter(int dx, int dy) {
+    for (auto* pc : components)   pc->moveCenter(dx, dy);
+    for (auto* pw : wires)        pw->moveCenter(dx, dy);
+    for (auto* pp : paintings)    pp->moveCenter(dx, dy);
+    for (auto* pd : diagrams)     pd->moveCenter(dx, dy);
+    for (auto* pl : labels)       pl->moveCenter(dx, dy);
+    for (auto* pm : markers)      pm->moveCenter(dx, dy);
+    for (auto* pn : nodes)        pn->moveCenter(dx, dy);
+
+    // Move bounds
+    bounds.moveCenter(QPoint(dx, dy));
   }
 };
 #endif


### PR DESCRIPTION
This PR is mostly code cleanup and de-duplication, there shouldn't be any functional changes
other than the center boundary calculations, where component text is now disregarded to avoid (IMO) an awkward center offset.

---

What:
- Extract repeated mouse coordinate transformation and grid-snapping code into
  `updateMouseMove()` helper.
- Move element movement operations into `SchematicSelection::moveCenter()`

Why:
- Reduce code duplication.
- Make it simpler to add functionality with similar structure to mouse-movement.
- Additionally fixes a mouse-movement tracking bug where accumulation variables
  persisted across operations.

How:
- Add: `MouseActions::updateMouseMove()` that handles delta mouse movement
  calculations and tracking.
- Add: `SchematicSelection::moveCenter()` to move the logic from specific mouse
  movement functions into the struct itself.
- Add: `SchematicSelection::center()` to provide selection center coordinates.
- Fix: Check `movingState` struct rather than `movingElements`, covering a more
  generic case.
- Fix: Reset `MAx3/MAy3` in `MouseActions::MMoveMoving` so it tracks that
  particular mouse-movement operation in isolation.