### PR TITLE
Fix Issue #1510: Bug with microstrip filter synthesis 

### DIFF
--- a/qucs-filter/qucsfilter.cpp
+++ b/qucs-filter/qucsfilter.cpp
@@ -235,7 +235,7 @@ QucsFilter::QucsFilter()
   ComboEr = new QComboBox(this);
   ComboEr->setEditable(true);
   ComboEr->lineEdit()->setValidator(DoubleVal);
-  connect(ComboEr, SIGNAL(activated(const QString&)), SLOT(slotTakeEr(const QString&)));
+  connect(ComboEr, SIGNAL(currentTextChanged(const QString &)), SLOT(slotTakeEr(const QString &)));
   gbox2->addWidget(ComboEr, 0,1);
 
   const char **p = List_er;


### PR DESCRIPTION
This PR fixes issue #1510 . The connection of the slotTakeEr() function was broken, consequently L#361:
`
    Substrate.er = ComboEr->currentText().toDouble();`

returned a wrong  _er_ and this caused the failure in the MS synthesis.

It seems that the _activated()_ signal no longer works for QComboBox.

**Before this PR**

<img width="845" height="600" alt="image" src="https://github.com/user-attachments/assets/d33a9b9e-8062-4feb-bb13-d60b498def47" />

**After this PR**

<img width="816" height="617" alt="image" src="https://github.com/user-attachments/assets/3e15ec24-200e-46c4-95b1-e24f0167d081" />
