### PR TITLE
Refactor(Schematic): node disconnection and element decoupling logic with `doHeal` control

### DIFF
--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1585,13 +1585,13 @@ void MouseActions::MReleasePaste(Schematic *Doc, QMouseEvent *Event)
         movingState.selection = Doc->elementsToSelection(movingElements);
         // keep transformations sticky for pasted elements
         if (movingState.mirrorX) {
-            Doc->mirrorXComponents(movingState.selection);
+            Doc->mirrorXComponents(movingState.selection, /*doHeal=*/false);
         }
         if (movingState.mirrorY) {
-            Doc->mirrorYComponents(movingState.selection);
+            Doc->mirrorYComponents(movingState.selection, /*doHeal=*/false);
         }
         for (int i = 0; i < movingState.rotated; i++) {
-            Doc->rotateElements(movingState.selection);
+            Doc->rotateElements(movingState.selection, /*doHeal=*/false);
         }
 
         QucsMain->MouseMoveAction = &MouseActions::MMovePaste;
@@ -1903,7 +1903,7 @@ void MouseActions::mirrorXMovingElements(Schematic* Doc)
         return;
     }
 
-    Doc->mirrorXComponents(movingState.selection);
+    Doc->mirrorXComponents(movingState.selection, /*doHeal=*/false);
     // Save transformation
     movingState.mirrorX = !movingState.mirrorX;
 
@@ -1917,7 +1917,7 @@ void MouseActions::mirrorYMovingElements(Schematic* Doc)
         return;
     }
 
-    Doc->mirrorYComponents(movingState.selection);
+    Doc->mirrorYComponents(movingState.selection, /*doHeal=*/false);
     // Save transformation
     movingState.mirrorY = !movingState.mirrorY;
 
@@ -1931,7 +1931,7 @@ void MouseActions::rotateMovingElements(Schematic* Doc)
         return;
     }
 
-    Doc->rotateElements(movingState.selection);
+    Doc->rotateElements(movingState.selection, /*doHeal=*/false);
     // Save transformation
     movingState.rotated++;
     movingState.rotated &= 3;

--- a/qucs/node.cpp
+++ b/qucs/node.cpp
@@ -115,3 +115,16 @@ bool Node::moveCenter(int dx, int dy) noexcept
 
     return donor;
 }
+
+bool Node::isOverlapping(int otherX, int otherY) const {
+  return (otherX == x() && otherY == y());
+}
+
+bool Node::isOverlapping(const Node* other) const {
+  // Comparison of self is false
+  if (this == other) {
+    return false;
+  }
+
+  return isOverlapping(other->x(), other->y());
+}

--- a/qucs/node.h
+++ b/qucs/node.h
@@ -46,6 +46,9 @@ public:
   bool is_connected(Wire* wire) const { return std::ranges::find(m_wires, wire) != m_wires.end(); }
   bool is_connected(Component* comp) const { return std::ranges::find(m_components, comp) != m_components.end(); }
 
+  bool isOverlapping(int, int) const;
+  bool isOverlapping(const Node*) const;
+
   std::size_t conn_count() const { return m_wires.size() + m_components.size(); }
 
   Wire* anyWire() const { return m_wires.empty() ? nullptr : m_wires.front(); }

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -428,6 +428,10 @@ public:
     NodeDisconnectResult port1;
     NodeDisconnectResult port2;
   };
+  struct CompDisconnectResult {
+    std::vector<NodeDisconnectResult> ports;
+  };
+
   Node* createNode(int, int) const;
   Node* createNode(const QPoint& p) const { return createNode(p.x(), p.y()); }
   Node* findNode(int, int) const;
@@ -455,9 +459,6 @@ public:
   Wire* selectedWire(int, int);
   Wire* splitWire(Wire*, Node*);
   void  deleteWire(Wire*, bool remove_orphans=true);
-  struct CompDisconnectResult {
-    std::vector<NodeDisconnectResult> ports;
-  };
   WireDisconnectResult disconnectWire(Wire*, bool remove_orphans=true, bool keepNodeLabel=false);
   void  decoupleWire(Wire*, bool keepNodeLabel=false);
 
@@ -483,9 +484,11 @@ public:
   bool       activateSelectedComponents();
   Component* selectCompText(int, int, int&, int&) const;
   Component* searchSelSubcircuit();
-  void       deleteComp(Component*);
-  void       detachComp(Component*);
+  void       deleteComp(Component*, bool remove_orphans=true);
+  void       detachComp(Component*, bool remove_orphans=true, bool keepNodeLabel=false);
+  void       decoupleComp(Component*, bool keepNodeLabel=false);
   Component* getComponentByName(const QString& compname) const;
+  CompDisconnectResult disconnectComp(Component*, bool remove_orphans=true, bool keepNodeLabel=false);
 
   void     oneLabel(Node*);
   int      placeNodeLabel(WireLabel*);

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -419,6 +419,10 @@ private:
    ******************************************************************** */
 
 public:
+  Node* createNode(int, int) const;
+  Node* createNode(const QPoint& p) const { return createNode(p.x(), p.y()); }
+  Node* findNode(int, int) const;
+  Node* findNode(const QPoint& p) const { return findNode(p.x(), p.y()); }
   Node* provideNode(int, int);
   Node* provideNode(const QPoint& p) { return provideNode(p.x(), p.y()); }
   Node* selectedNode(int, int);

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -419,6 +419,15 @@ private:
    ******************************************************************** */
 
 public:
+  // structs for node creation/deletion
+  struct NodeDisconnectResult {
+    bool disconnected;
+    bool removed;
+  };
+  struct WireDisconnectResult {
+    NodeDisconnectResult port1;
+    NodeDisconnectResult port2;
+  };
   Node* createNode(int, int) const;
   Node* createNode(const QPoint& p) const { return createNode(p.x(), p.y()); }
   Node* findNode(int, int) const;
@@ -446,6 +455,11 @@ public:
   Wire* selectedWire(int, int);
   Wire* splitWire(Wire*, Node*);
   void  deleteWire(Wire*, bool remove_orphans=true);
+  struct CompDisconnectResult {
+    std::vector<NodeDisconnectResult> ports;
+  };
+  WireDisconnectResult disconnectWire(Wire*, bool remove_orphans=true, bool keepNodeLabel=false);
+  void  decoupleWire(Wire*, bool keepNodeLabel=false);
 
   Marker* setMarker(int, int);
   void    markerLeftRight(bool, const std::vector<Marker*>& markers);
@@ -482,6 +496,7 @@ public:
 
 private:
   void insertComponentNodes(Component*, bool);
+  NodeDisconnectResult disconnectNode(Node*, Element*, bool remove_orphans=true, bool keepNodeLabel=false) const;
 
 /* ********************************************************************
    *****  The following methods are in the file                   *****

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -117,14 +117,14 @@ public:
   bool  mirrorXComponents();
   bool  mirrorYComponents();
   // Same as above - but with an arbitrary selection
-  bool  rotateElements(Selection selection);
-  bool  mirrorXComponents(Selection selection);
-  bool  mirrorYComponents(Selection selection);
+  bool  rotateElements(Selection selection, bool doHeal=true);
+  bool  mirrorXComponents(Selection selection, bool doHeal=true);
+  bool  mirrorYComponents(Selection selection, bool doHeal=true);
 
   QPoint setOnGrid(const QPoint& p);
   void  setOnGrid(int&, int&);
   bool  elementsOnGrid();
-  bool  elementsOnGrid(Selection selection);
+  bool  elementsOnGrid(Selection selection, bool doHeal=true);
 
   /**
     Zoom around a "zooming center". Zooming center is a point on the canvas,

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -112,6 +112,7 @@ public:
   using Selection = SchematicSelection;
   Selection  currentSelection() const;
   Selection  elementsToSelection(const std::list<Element*>&) const;
+  void  decoupleElements(Selection selection, bool keepNodeLabel=false);
   bool  rotateElements();
   bool  mirrorXComponents();
   bool  mirrorYComponents();

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -560,22 +560,98 @@ Wire* Schematic::splitWire(Wire *source_wire, Node *splitter_node)
 // become orphan after removing the wires.
 void Schematic::deleteWire(Wire *w, bool remove_orphans)
 {
-    w->Port1->disconnect(w);
-    // Delete node if it has become an orphan
-    if (remove_orphans && w->Port1->conn_count() == 0) {
-        a_Nodes->remove(w->Port1);
+    auto wireStatus = disconnectWire(w, remove_orphans, /*keepNodeLabel=*/false);
+    // Delete nodes if it has become an orphan
+    if (wireStatus.port1.removed) {
         delete w->Port1;
     }
 
-    w->Port2->disconnect(w);
-    // Delete node if it has become an orphan
-    if (remove_orphans && w->Port2->conn_count() == 0) {
-        a_Nodes->remove(w->Port2);
+    if (wireStatus.port2.removed) {
         delete w->Port2;
     }
 
     a_Wires->remove(w);
     delete w;
+}
+
+/** Disconnects a wire from the schematic by disconnecting both its port nodes.
+ *
+ * @param wire The wire to disconnect.
+ * @param remove_orphans If true, orphaned nodes are removed from a_Nodes. Default: true
+ * @param keepNodeLabel If true, nodes with labels are preserved (not disconnected). Default: false
+ * @return WireDisconnectResult containing disconnection status for both ports; {port1, port2}
+ *
+ * @note No memory is deallocated here; caller is responsible for cleanup
+ */
+Schematic::WireDisconnectResult Schematic::disconnectWire(Wire* wire, bool remove_orphans, bool keepNodeLabel)
+{
+    NodeDisconnectResult p1 = disconnectNode(wire->Port1, wire, remove_orphans, keepNodeLabel);
+    NodeDisconnectResult p2 = disconnectNode(wire->Port2, wire, remove_orphans, keepNodeLabel);
+
+    return {p1, p2};
+}
+
+/** Decouples a wire by disconnecting it and providing new isolated nodes
+ *
+ * @param wire The wire to decouple
+ * @param keepNodeLabel If true, nodes with labels are preserved. Default: false.
+ *
+ * @note: Caller is responsible for reconnecting the wire, or deallocating it. 
+ */
+void Schematic::decoupleWire(Wire* wire, bool keepNodeLabel)
+{
+    // Store coordinates for ports
+    QPoint P1 = wire->P1();
+    QPoint P2 = wire->P2();
+
+    // Disconnect wire ports
+    auto wireStatus = disconnectWire(wire, /*remove_orphans=*/true, keepNodeLabel);
+
+    // Create and connect new isolated port to Port1 if it was disconnected
+    if (wireStatus.port1.disconnected) {
+        wire->connectPort1(createNode(P1));
+    }
+
+    // Create and connect new isolated port to Port2 if it was disconnected
+    if (wireStatus.port2.disconnected) {
+        wire->connectPort2(createNode(P2));
+    }
+}
+
+/** Disconnects a node from a wire and optionally removed orphaned nodes.
+ *
+ * @param  node The node to disconnect. if nullptr, returns {false, false}.
+ * @param  elem The element (Wire or Component) to disconnect the node from.
+ * @param  remove_orphans If true, orphaned nodes are removed from a_Nodes. Default: true
+ * @param  keepNodeLabel If true, nodes with labels are preserved (not disconnected). Default: false
+ * @return NodeDisconnectResult with {disconnected, removed} flags. 
+ *
+ * @note No memory is deallocated here; caller is responsible for cleanup.
+ */
+Schematic::NodeDisconnectResult Schematic::disconnectNode(Node* node, Element* elem, bool remove_orphans, bool keepNodeLabel) const
+{
+    if (node == nullptr) return {false, false};
+
+    // Preserve nodes with labels if requested
+    if (keepNodeLabel && node->hasLabel()) {
+        return {false, false};
+    }
+
+    // Disconnect from wire or component
+    if (auto* wire = dynamic_cast<Wire*>(elem)) {
+        node->disconnect(wire);
+    } else if (auto* component = dynamic_cast<Component*>(elem)) {
+        node->disconnect(component);
+    } else {
+        return {false, false};
+    }
+
+    // Remove if orphaned and flag is set
+    if (remove_orphans && node->conn_count() == 0) {
+        a_Nodes->remove(node);
+        return {true, true};
+    }
+    return {true, false};
 }
 
 /* *******************************************************************

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -31,6 +31,7 @@
 #include <ranges>
 #include <set>
 #include <unordered_map>
+#include <unordered_set>
 
 struct Schematic::HealingParams
 {
@@ -1835,6 +1836,48 @@ bool Schematic::mirrorYComponents(Selection selection)
     }
 
     return true;
+}
+
+void Schematic::decoupleElements(Selection selection, bool keepNodeLabel)
+{
+    // store all new nodes created during decoupling
+    std::unordered_set<Node*> nodeSet;
+
+    // decouple all components and save nodes
+    for (auto* pc : selection.components) {
+        decoupleComp(pc, keepNodeLabel);
+        for (auto* port : pc->Ports) {
+            nodeSet.insert(port->Connection);
+        }
+    }
+
+    // decouple all wire segments and save nodes
+    for (auto* pw : selection.wires) {
+        decoupleWire(pw, keepNodeLabel);
+        nodeSet.insert(pw->Port1);
+        nodeSet.insert(pw->Port2);
+    }
+
+    // comparison function for QPoint
+    auto cmp = [](const QPoint& a, const QPoint& b) {
+        return a.x() != b.x() ? a.x() < b.x() : a.y() < b.y();
+    };
+
+    // group nodes by position and merge overlapping ones
+    // NOTE: Schematic::Heal has the same kind of logic,
+    // however we don't have access to internal::sameloc_nodes() here.
+    std::map<QPoint, Node*, decltype(cmp)> nodeMap;
+    for (auto* node : nodeSet) {
+        QPoint pos = node->center();
+        auto [it, inserted] = nodeMap.insert({pos, node});
+
+        if (!inserted) {
+            // position exists, merge nodes
+            Node* merged = it->second->merge(node);
+            a_Nodes->remove(merged);
+            delete merged;
+        }
+    }
 }
 
 /* *******************************************************************

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -1629,9 +1629,9 @@ bool snapLabelToGrid(Schematic* sch, WireLabel* label)
 // Sets selected elements on grid.
 bool Schematic::elementsOnGrid()
 {
-    return elementsOnGrid(currentSelection());
+    return elementsOnGrid(currentSelection(), /*doHeal=*/true);
 }
-bool Schematic::elementsOnGrid(Selection selection)
+bool Schematic::elementsOnGrid(Selection selection, bool doHeal)
 {
     const auto count = internal::total_count(selection);
     if (count == 0) return false;
@@ -1656,7 +1656,9 @@ bool Schematic::elementsOnGrid(Selection selection)
 
     if (!any_set) return false;
 
-    heal(&noninteractiveMutationParams);
+    if (doHeal) {
+        heal(&noninteractiveMutationParams);
+    }
     setChanged(true, true);
     return true;
 }
@@ -1684,11 +1686,11 @@ bool symbolElementsOnGrid(Schematic* sch, const std::vector<Painting*>& painting
 // Rotates all selected components around their midpoint.
 bool Schematic::rotateElements()
 {
-    return rotateElements(currentSelection());
+    return rotateElements(currentSelection(), /*doHeal=*/true);
 }
 
 // Rotates a selection of components around their midpoint.
-bool Schematic::rotateElements(Selection selection)
+bool Schematic::rotateElements(Selection selection, bool doHeal)
 {
 
     const auto count = internal::total_count(selection);
@@ -1730,8 +1732,10 @@ bool Schematic::rotateElements(Selection selection)
     } else {
         // elementsOnGrid heals and adds undo-entry by its own
         // if it changes something
-        if (!elementsOnGrid(selection)) {
-            heal(&noninteractiveMutationParams);
+        if (!elementsOnGrid(selection, doHeal)) {
+            if (doHeal) {
+                heal(&noninteractiveMutationParams);
+            }
             setChanged(true, true);
         }
     }
@@ -1742,11 +1746,11 @@ bool Schematic::rotateElements(Selection selection)
 // Mirrors all selected components along X-axis
 bool Schematic::mirrorXComponents()
 {
-    return mirrorXComponents(currentSelection());
+    return mirrorXComponents(currentSelection(), /*doHeal=*/true);
 }
 
 // Mirrors selection of components along X-axis
-bool Schematic::mirrorXComponents(Selection selection)
+bool Schematic::mirrorXComponents(Selection selection, bool doHeal)
 {
 
     const auto count = internal::total_count(selection);
@@ -1780,8 +1784,10 @@ bool Schematic::mirrorXComponents(Selection selection)
     } else {
         // elementsOnGrid heals and adds undo-entry by its own
         // if it changes something
-        if (!elementsOnGrid(selection)) {
-            heal(&noninteractiveMutationParams);
+        if (!elementsOnGrid(selection, doHeal)) {
+            if (doHeal) {
+                heal(&noninteractiveMutationParams);
+            }
             setChanged(true, true);
         }
     }
@@ -1796,7 +1802,7 @@ bool Schematic::mirrorYComponents()
 }
 
 // Mirrors selection of components along Y-axis
-bool Schematic::mirrorYComponents(Selection selection)
+bool Schematic::mirrorYComponents(Selection selection, bool doHeal)
 {
     const auto count = internal::total_count(selection);
 
@@ -1829,8 +1835,10 @@ bool Schematic::mirrorYComponents(Selection selection)
     } else {
         // elementsOnGrid heals and adds undo-entry by its own
         // if it changes something
-        if (!elementsOnGrid(selection)) {
-            heal(&noninteractiveMutationParams);
+        if (!elementsOnGrid(selection, doHeal)) {
+            if (doHeal) {
+                heal(&noninteractiveMutationParams);
+            }
             setChanged(true, true);
         }
     }

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -320,20 +320,35 @@ bool geometryIsInOrder(const std::list<Component*>* components, const std::list<
    *****              Actions handling the nodes                 *****
    *****                                                         *****
    ******************************************************************* */
+Node* Schematic::createNode(int x, int y) const
+{
+    Node* node = new Node(x, y);
+    a_Nodes->push_back(node);
+    return node;
+}
+
+// Returns Node* at (x,y), else nullptr
+Node* Schematic::findNode(int x, int y) const
+{
+    for (auto* node : *a_Nodes) {
+        if (node->isOverlapping(x, y)) {
+            return node;
+        }
+    }
+    return nullptr;
+}
 
 // Provides a node located at given coordinates, either new or existing one
 Node* Schematic::provideNode(int x, int y)
 {
     // Check if there is a node at given coordinates
-    for (auto* node : *a_Nodes) {
-      if (node->x() == x && node->y() == y) {
+    Node* node = findNode(x, y);
+    if (node != nullptr) {
         return node;
-      }
     }
 
     // Create new node, if no existing one at given coordinates
-    Node *new_node = new Node(x, y);
-    a_Nodes->push_back(new_node);
+    Node* new_node = createNode(x, y);
 
     // Check if the new node lies upon an existing wire
     for (auto* wire : *a_Wires)

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -399,6 +399,57 @@ Node* find_redundant_node(NodeContainer* nodes) {
     return nullptr;
 }
 
+template<typename NodeContainer>
+std::vector<std::vector<Node*>> sameloc_nodes(NodeContainer& nodes) {
+    std::set<Node*> processed;
+    std::vector<std::vector<Node*>> ret;
+
+    for (auto* n1 : nodes) {
+        if (processed.contains(n1)) continue;
+
+        std::vector<Node*> s;
+        for (auto* n2 : nodes) {
+            if (n1->isOverlapping(n2)) {
+                s.push_back(n2);
+                processed.insert(n2);
+            }
+        }
+        if (!s.empty()) {
+            s.push_back(n1);
+            ret.push_back(s);
+        }
+    }
+    return ret;
+}
+
+
+// Check for overlapping nodes in @nodes,
+// remove the donor nodes from both @nodes and @globalList
+template<typename NodeContainer>
+bool mergeOverlappingNodes(NodeContainer& nodes, NodeContainer& globalList) {
+    bool anyChanges = false;
+    for (auto nodeGroup : sameloc_nodes(nodes)) {
+        auto recipient = nodeGroup.front();
+        for (auto donor = (nodeGroup.begin() + 1);
+        donor != nodeGroup.end(); donor++) {
+            recipient->merge(*donor);
+            nodes.remove(*donor);
+            // NOTE: doesn't do anything if nodes == globalList
+            globalList.remove(*donor);
+            delete *donor;
+            anyChanges = true;
+        }
+    }
+    return anyChanges;
+}
+
+// Override: Used for checking and removing from the same container, @nodes
+// typical use case is checking: @a_Nodes
+template<typename NodeContainer>
+bool mergeOverlappingNodes(NodeContainer& nodes) {
+    return mergeOverlappingNodes(nodes, nodes);
+}
+
 Wire* merge_wires_at_node(Node* node) {
     auto* extended_wire = node->anyWire();
     auto* dissapearing_wire = node->other_than(extended_wire);
@@ -1866,26 +1917,9 @@ void Schematic::decoupleElements(Selection selection, bool keepNodeLabel)
         nodeSet.insert(pw->Port2);
     }
 
-    // comparison function for QPoint
-    auto cmp = [](const QPoint& a, const QPoint& b) {
-        return a.x() != b.x() ? a.x() < b.x() : a.y() < b.y();
-    };
-
-    // group nodes by position and merge overlapping ones
-    // NOTE: Schematic::Heal has the same kind of logic,
-    // however we don't have access to internal::sameloc_nodes() here.
-    std::map<QPoint, Node*, decltype(cmp)> nodeMap;
-    for (auto* node : nodeSet) {
-        QPoint pos = node->center();
-        auto [it, inserted] = nodeMap.insert({pos, node});
-
-        if (!inserted) {
-            // position exists, merge nodes
-            Node* merged = it->second->merge(node);
-            a_Nodes->remove(merged);
-            delete merged;
-        }
-    }
+    // Remove all overlapping nodes
+    std::list<Node*> nodeList(nodeSet.begin(), nodeSet.end());
+    internal::mergeOverlappingNodes(nodeList, *a_Nodes);
 }
 
 /* *******************************************************************
@@ -2704,28 +2738,6 @@ public:
     }
 };
 
-template<typename NodeContainer>
-std::vector<std::vector<Node*>> sameloc_nodes(NodeContainer* nodes) {
-    std::set<Node*> processed;
-    std::vector<std::vector<Node*>> ret;
-
-    for (auto* n1 : *nodes) {
-        if (processed.contains(n1)) continue;
-
-        std::vector<Node*> s;
-        for (auto* n2 : *nodes) {
-            if (n1 != n2 && n1->center() == n2->center()) {
-                s.push_back(n2);
-                processed.insert(n2);
-            }
-        }
-        if (!s.empty()) {
-            s.push_back(n1);
-            ret.push_back(s);
-        }
-    }
-    return ret;
-}
 }
 
 void Schematic::displayMutations() {
@@ -2767,16 +2779,7 @@ bool Schematic::heal(const HealingParams* params) {
 
 
     // Merge nodes having the same location
-    for (auto sameloc_node_group : internal::sameloc_nodes(a_Nodes)) {
-        auto recipient = sameloc_node_group.front();
-
-        for (auto donor = (sameloc_node_group.begin() + 1); donor != sameloc_node_group.end(); donor++) {
-            recipient->merge(*donor);
-            a_Nodes->remove(*donor);
-            delete *donor;
-            thereWereChanges = true;
-        }
-    }
+    thereWereChanges = internal::mergeOverlappingNodes(*a_Nodes) || thereWereChanges;
 
     // Fix "node above wire" anomalies
     {

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -2159,16 +2159,15 @@ Component* Schematic::searchSelSubcircuit()
 // Disconnect component and remove it from the list of schematic components.
 // Component is not deleted, pointer remains valid after call. It is responsibility
 // of the caller to handle it by deleting, reinstalling, etc.
-void Schematic::detachComp(Component *c)
+void Schematic::detachComp(Component *c, bool remove_orphans, bool keepNodeLabel)
 {
-    // delete all port connections
-    for (auto* port : c->Ports) {
-        port->Connection->disconnect(c);
+    // disconnect all ports from component, and remove them if remove_orphans=True
+    auto compStatus = disconnectComp(c, remove_orphans, keepNodeLabel);
 
-        // Remove node if it has become orphan
-        if (port->Connection->conn_count() == 0) {
-            a_Nodes->remove(port->Connection);
-            delete port->Connection;
+    // loop over all ports, and delete if orphan
+    for (size_t i = 0; i < c->Ports.size(); ++i) {
+        if (compStatus.ports[i].removed) {
+            delete c->Ports[i]->Connection;
         }
     }
     emit signalComponentDeleted(c);
@@ -2176,10 +2175,55 @@ void Schematic::detachComp(Component *c)
 }
 
 // Deletes the component 'c'.
-void Schematic::deleteComp(Component *c)
+void Schematic::deleteComp(Component *c, bool remove_orphans)
 {
-    detachComp(c);
+    detachComp(c, remove_orphans, /*keepNodeLabel=*/false);
     delete c;
+}
+
+/** Disconnects a component from the schematic by disconnecting all of its ports.
+ *
+ * @param component The component to disconnect.
+ * @param remove_orphans If true, orphaned nodes are removed from a_Nodes. Default: true
+ * @param keepNodeLabel If true, nodes with labels are preserved (not disconnected). Default: false
+ * @return CompDisonnectResult containing disconnection status for all ports stored in a vector.
+ *
+ * @note No memory is deallocated here; caller is responsible for cleanup
+ */
+Schematic::CompDisconnectResult Schematic::disconnectComp(Component* component, bool remove_orphans, bool keepNodeLabel)
+{
+    CompDisconnectResult result;
+    for (auto* port : component->Ports) {
+        result.ports.push_back(disconnectNode(port->Connection,  component, remove_orphans, keepNodeLabel));
+    }
+    return result;
+}
+
+/** Decouples a component by disconnecting it and providing new isolated nodes
+ *
+ * @param component The component to decouple
+ * @param keepNodeLabel If true, nodes with labels are preserved. Default: false.
+ *
+ * @note: Caller is responsible for reconnecting the component ports, or deallocating them. 
+ */
+void Schematic::decoupleComp(Component* component, bool keepNodeLabel)
+{
+    // store all port position
+    std::vector<QPoint> portPos;
+    for (auto* port : component->Ports) {
+        portPos.push_back(port->Connection->center());
+    }
+
+    auto compStatus = disconnectComp(component, /*remove_orphans=*/true, keepNodeLabel);
+
+    // Loop over all ports, and create new (isolated) nodes for all ports that got disconnected
+    for (size_t i = 0; i < component->Ports.size(); ++i) {
+        if (compStatus.ports[i].disconnected) {
+            Node* new_node = createNode(portPos[i]);
+            new_node->connect(component);
+            component->Ports[i]->Connection = new_node;
+        }
+    }
 }
 
 Component *Schematic::getComponentByName(const QString& compname) const


### PR DESCRIPTION
# What

This PR refactors node/wire/component disconnection and deletion logic to:

1. Decouple automatic healing from transformations via a new `doHeal` parameter.
2. Add utility functions for explicit disconnection and decoupling of elements.
3. Reuse and generalize code for merging overlapping nodes.

# Why

The primary goal is to enable "isolated moves" (in a separate PR) by:

1. Skipping automatic healing during transforms (e.g., rotations, mirroring).
2. Supporting decoupling of wires/components, especially for disconnecting selected components from non-selected ones.

# How

1. Adding `doHeal` Parameter:
   - Added to `rotateElements`, `mirrorXComponents`, `mirrorYComponents`, and `elementsOnGrid`.
   - Defaults to `true` (preserves existing behavior); set to `false` for paste operations.

2. New Utilities:
   - `disconnectWire`, `disconnectComp`, `decoupleElements`: Explicitly manage disconnections.
   - `Node::isOverlapping` and `mergeOverlappingNodes`: Streamline node overlap handling.

3. Refactoring:
   - Extracted `createNode()` and `findNode()` to their own functions to reuse a common pattern.
   - Reused `mergeOverlappingNodes` from `heal()`, now supporting merging a subset of nodes while deleting them from the global list (e.g., in `decoupleElements`).
   - Streamlined `deleteWire` and `detachComp` using the new utilities.
