### PR TITLE
Text Editor: Add line numbers widget

### DIFF
--- a/qucs/textdoc.cpp
+++ b/qucs/textdoc.cpp
@@ -21,6 +21,7 @@ Copyright (C) 2014 by Guilherme Brondani Torri <guitorri@gmail.com>
 #include <QAction>
 #include <QMessageBox>
 #include <QTextStream>
+#include <QPainter>
 #include <qpalette.h>
 
 #include "main.h"
@@ -85,6 +86,15 @@ TextDoc::TextDoc(QucsApp *App_, const QString& Name_) : QPlainTextEdit(), QucsDo
 
   connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(highlightCurrentLine()));
   highlightCurrentLine();
+
+  // Line numbering
+  lineNumberArea = new LineNumberArea(this);
+
+  connect(this, SIGNAL(blockCountChanged(int)), this, SLOT(updateLineNumberAreaWidth(int)));
+  connect(this, SIGNAL(updateRequest(QRect,int)), this, SLOT(updateLineNumberArea(QRect,int)));
+  connect(this, SIGNAL(cursorPositionChanged()), SLOT(highlightCurrentLine()));
+
+  updateLineNumberAreaWidth(0);
 }
 
 /*!
@@ -637,4 +647,70 @@ bool TextDoc::hasFileChangedOnDisk() const
     return true; // File is removed -> has changed
   }
   return fileInfo.lastModified() > lastLoadModTime;
+}
+
+
+int TextDoc::lineNumberAreaWidth()
+{
+    int digits = 1;
+    int max = qMax(1, blockCount());
+    while (max >= 10) {
+        max /= 10;
+        ++digits;
+    }
+
+    int space = 3 + fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits;
+    return space;
+}
+
+void TextDoc::updateLineNumberAreaWidth(int /* newBlockCount */)
+{
+    setViewportMargins(lineNumberAreaWidth(), 0, 0, 0);
+}
+
+void TextDoc::updateLineNumberArea(const QRect &rect, int dy)
+{
+    if (dy){
+        lineNumberArea->scroll(0, dy);
+    } else {
+        lineNumberArea->update(0, rect.y(), lineNumberArea->width(), rect.height());
+    }
+
+    if (rect.contains(viewport()->rect())) {
+        updateLineNumberAreaWidth(0);
+    }
+}
+
+void TextDoc::resizeEvent(QResizeEvent *e)
+{
+    QPlainTextEdit::resizeEvent(e);
+
+    QRect cr = contentsRect();
+    lineNumberArea->setGeometry(QRect(cr.left(), cr.top(),
+        lineNumberAreaWidth(), cr.height()));
+}
+
+void TextDoc::lineNumberAreaPaintEvent(QPaintEvent *event)
+{
+    QPainter painter(lineNumberArea);
+    painter.fillRect(event->rect(), Qt::lightGray);
+
+    QTextBlock block = firstVisibleBlock();
+    int blockNumber = block.blockNumber();
+    int top = qRound(blockBoundingGeometry(block).translated(contentOffset()).top());
+    int bottom = top + qRound(blockBoundingRect(block).height());
+
+    while (block.isValid() && top <= event->rect().bottom()) {
+        if (block.isVisible() && bottom >= event->rect().top()) {
+            QString number = QString::number(blockNumber + 1);
+            painter.setPen(Qt::black);
+            painter.drawText(0, top, lineNumberArea->width(), fontMetrics().height(),
+                Qt::AlignRight, number);
+        }
+
+        block = block.next();
+        top = bottom;
+        bottom = top + qRound(blockBoundingRect(block).height());
+        ++blockNumber;
+    }
 }

--- a/qucs/textdoc.h
+++ b/qucs/textdoc.h
@@ -31,6 +31,7 @@ Copyright (C) 2014 by Guilherme Brondani Torri <guitorri@gmail.com>
 
 class SyntaxHighlighter;
 class QString;
+class LineNumberArea;
 
 // device type flags
 #define DEV_BJT      0x0001
@@ -86,6 +87,9 @@ public:
 
   QMenu* createStandardContextMenu();
 
+  void lineNumberAreaPaintEvent(QPaintEvent *event);
+  int lineNumberAreaWidth();
+
 signals:
   void signalCursorPosChanged(int, int, QString);
   void signalFileChanged(bool);
@@ -99,13 +103,43 @@ public slots:
   void slotCursorPosChanged ();
   void slotSetChanged ();
 
+protected:
+      void resizeEvent(QResizeEvent *event) override;
+
 private:
   SyntaxHighlighter * syntaxHighlight;
   QDateTime lastLoadModTime; // Timestamp of last successful load
+  LineNumberArea *lineNumberArea;
 
 private slots:
   void highlightCurrentLine();
   bool baseSearch(const QString &, bool, bool, bool);
+
+  // Line numbering
+  void updateLineNumberAreaWidth(int newBlockCount);
+  void updateLineNumberArea(const QRect &rect, int dy);
+};
+
+// Line numbering widget
+class LineNumberArea : public QWidget
+{
+public:
+    LineNumberArea(TextDoc *editor) : QWidget(editor), codeEditor(editor)
+    {}
+
+    QSize sizeHint() const override
+    {
+        return QSize(codeEditor->lineNumberAreaWidth(), 0);
+    }
+
+protected:
+    void paintEvent(QPaintEvent *event) override
+    {
+        codeEditor->lineNumberAreaPaintEvent(event);
+    }
+
+private:
+    TextDoc *codeEditor;
 };
 
 #endif


### PR DESCRIPTION
I added a line numbering widget to the TextDoc class by following the Qt "Code Editor Example" [1].

I think this addition is useful for inspecting files.

[1] https://doc.qt.io/archives/qt-5.15/qtwidgets-widgets-codeeditor-example.html

<img width="796" height="469" alt="image" src="https://github.com/user-attachments/assets/9d19d300-a616-4975-981f-5a2015686ea3" />
