### PR TITLE
refactor(Schematic): move node transformation logic to owner

### DIFF
--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -387,6 +387,18 @@ void Component::paintScheme(Schematic *p) {
         p->PostPaintEvent(_Ellipse, cx + pa->x, cy + pa->y, pa->w, pa->h);
 }
 
+bool Component::moveCenter(int dx, int dy) noexcept {
+    bool moved = Element::moveCenter(dx, dy);
+
+    if (moved) {
+        // We also need to move every port node
+        for (auto* pp : Ports) {
+            setNodePortCenter(pp);
+        }
+    }
+    return moved;
+}
+
 // -------------------------------------------------------
 // Rotates the component 90 counter-clockwise around its center
 bool Component::rotate() noexcept {
@@ -411,6 +423,9 @@ bool Component::rotate() noexcept {
         tmp = -p2->x;
         p2->x = p2->y;
         p2->y = tmp;
+
+        // rotate node(s)
+        setNodePortCenter(p2);
     }
 
     // rotate all arcs
@@ -515,8 +530,11 @@ bool Component::mirrorX() noexcept {
     }
 
     // mirror all ports
-    for (Port *p2: Ports)
+    for (Port *p2: Ports) {
         p2->y = -p2->y;
+        // mirror node(s)
+        setNodePortCenter(p2);
+    }
 
     // mirror all arcs
     for (qucs::Arc *p3: Arcs) {
@@ -585,8 +603,11 @@ bool Component::mirrorY() noexcept {
     }
 
     // mirror all ports
-    for (Port *p2: Ports)
+    for (Port *p2: Ports) {
         p2->x = -p2->x;
+        // mirror node(s)
+        setNodePortCenter(p2);
+    }
 
     // mirror all arcs
     for (qucs::Arc *p3: Arcs) {
@@ -642,6 +663,27 @@ bool Component::mirrorY() noexcept {
     rotated += 2;
     rotated &= 3;
     return true;
+}
+
+/**
+ * Moves the node connected to port `p` so its center aligns with the port's center.
+ * The new center is calculated as: (component center + port_offset)
+ *
+ * @param p The port whose connected node will be repositioned
+ * @return True if a node was moved, false otherwise
+ *
+ */
+bool Component::setNodePortCenter(Port* p) {
+    Node* node = p->Connection;
+
+    if (node != nullptr) {
+        // use the center of the component, and then the port as an offset
+        auto [ccx, ccy] = center();
+        node->moveCenterTo(ccx + p->x, ccy + p->y);
+        return true;
+    }
+
+    return false;
 }
 
 // -------------------------------------------------------

--- a/qucs/components/component.h
+++ b/qucs/components/component.h
@@ -66,11 +66,15 @@ public:
   QRect   boundingRectIncludingProperties() const noexcept;
   bool    getSelected(int x, int y) const { return boundingRect().contains(x, y); }
   int     getTextSelected(int, int);
+  bool    moveCenter(int, int)   noexcept override;
   bool    rotate() noexcept override;
   bool    mirrorX() noexcept override;
   bool    mirrorY() noexcept override;
   QString save();
   bool    load(const QString&);
+
+  // helper function that sets the node of the port to the same center as the port
+  bool setNodePortCenter(Port* p);
 
   // to hold track of the component appearance for saving and copying
   bool mirroredX;   // is it mirrored about X axis or not

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -1699,6 +1699,7 @@ bool Schematic::elementsOnGrid(Selection selection, bool doHeal)
         any_set = internal::snapLabelToGrid(this, label) || any_set;
     });
     std::ranges::for_each(selection.markers, onGridSetter);
+    // NOTE: when using setP1/setP2, connected nodes are also moved
     std::ranges::for_each(selection.wires, [&any_set, this](Wire* w) {
         auto p1_moved = w->setP1(setOnGrid(w->P1()));
         auto p2_moved = w->setP2(setOnGrid(w->P2()));
@@ -1773,7 +1774,8 @@ bool Schematic::rotateElements(Selection selection, bool doHeal)
     std::ranges::for_each(selection.diagrams, rotator);
     std::ranges::for_each(selection.labels, rotator);
     std::ranges::for_each(selection.markers, rotator);
-    std::ranges::for_each(selection.nodes, rotator);
+    // NOTE: nodes are synced through their owner (components/wires)
+    // std::ranges::for_each(selection.nodes, rotator);
 
     if (!any_rotated) return false;
 
@@ -1825,7 +1827,8 @@ bool Schematic::mirrorXComponents(Selection selection, bool doHeal)
     std::ranges::for_each(selection.diagrams, mirrorer);
     std::ranges::for_each(selection.labels, mirrorer);
     std::ranges::for_each(selection.markers, mirrorer);
-    std::ranges::for_each(selection.nodes, mirrorer);
+    // NOTE: nodes are synced through their owner (components/wires)
+    // std::ranges::for_each(selection.nodes, mirrorer);
 
     if (!any_mirrored) return false;
 
@@ -1876,7 +1879,8 @@ bool Schematic::mirrorYComponents(Selection selection, bool doHeal)
     std::ranges::for_each(selection.diagrams, mirrorer);
     std::ranges::for_each(selection.labels, mirrorer);
     std::ranges::for_each(selection.markers, mirrorer);
-    std::ranges::for_each(selection.nodes, mirrorer);
+    // NOTE: nodes are synced through their owner (components/wires)
+    // std::ranges::for_each(selection.nodes, mirrorer);
 
     if (!any_mirrored) return false;
 

--- a/qucs/schematic_selection.h
+++ b/qucs/schematic_selection.h
@@ -75,7 +75,8 @@ struct SchematicSelection {
       }
     }
     for (auto* pm : markers)      pm->moveCenter(dx, dy);
-    for (auto* pn : nodes)        pn->moveCenter(dx, dy);
+    // NOTE: nodes are synced through their owner (components/wires)
+    // for (auto* pn : nodes)        pn->moveCenter(dx, dy);
 
     // Move bounds
     bounds.moveCenter(QPoint(dx, dy));

--- a/qucs/wire.cpp
+++ b/qucs/wire.cpp
@@ -56,7 +56,28 @@ bool Wire::rotate() noexcept
     label()->moveRootTo(r.x(), r.y());
   }
 
+  // update node positions
+  updatePorts();
+
   return true;
+}
+
+bool Wire::mirrorX() noexcept {
+  std::swap(y1, y2);
+
+  // update node positions
+  updatePorts();
+
+  return y1 != y2;
+}
+
+bool Wire::mirrorY() noexcept {
+  std::swap(x1, x2);
+
+  // update node positions
+  updatePorts();
+
+  return x1 != x2;
 }
 
 // Lie x/y on wire ? 5 is the precision the coordinates have to fit.
@@ -218,15 +239,22 @@ QRect Wire::boundingRect() const noexcept
 
 bool Wire::moveCenter(int dx, int dy) noexcept
 {
-  Element::moveCenter(dx, dy);
-  x1 += dx;
-  y1 += dy;
-  x2 += dx;
-  y2 += dy;
-  if (hasLabel()) label()->moveRoot(dx, dy);
-  return dx != 0 || dy != 0;
-}
+  bool moved = Element::moveCenter(dx, dy);
+  if (moved) {
+    x1 += dx;
+    y1 += dy;
+    x2 += dx;
+    y2 += dy;
+    // move label root
+    if(hasLabel()) {
+      label()->moveRoot(dx, dy);
+    }
 
+    // update node positions
+    updatePorts();
+  }
+  return moved;
+}
 
 bool Wire::setP1(const QPoint& new_p1)
 {
@@ -249,6 +277,7 @@ bool Wire::setP1(const QPoint& new_p1)
   y1 = new_p1.y();
 
   updateCenter();
+  updateP1();
 
   return true;
 }
@@ -275,6 +304,7 @@ bool Wire::setP2(const QPoint& new_p2)
   y2 = new_p2.y();
 
   updateCenter();
+  updateP2();
 
   return true;
 }
@@ -318,3 +348,21 @@ inline void Wire::updateCenter() noexcept {
   cy = std::midpoint(y1, y2);
 }
 
+// sets Port1 center to (x1, y1)
+void Wire::updateP1() noexcept {
+  if (Port1 != nullptr) {
+    Port1->moveCenterTo(x1, y1);
+  }
+}
+
+// sets Port2 center to (x2, y2)
+void Wire::updateP2() noexcept {
+  if (Port2 != nullptr) {
+    Port2->moveCenterTo(x2, y2);
+  }
+}
+
+void Wire::updatePorts() noexcept {
+  updateP1();
+  updateP2();
+}

--- a/qucs/wire.h
+++ b/qucs/wire.h
@@ -41,8 +41,8 @@ public:
 
   bool rotate() noexcept override;
 
-  bool mirrorX() noexcept override { std::swap(y1, y2); return y1 != y2; }
-  bool mirrorY() noexcept override { std::swap(x1, x2); return x1 != x2; }
+  bool mirrorX() noexcept override;
+  bool mirrorY() noexcept override;
 
   QRect boundingRect() const noexcept override;
 
@@ -62,6 +62,9 @@ public:
 
 private:
   void updateCenter() noexcept;
+  void updateP1() noexcept;
+  void updateP2() noexcept;
+  void updatePorts() noexcept;
 };
 
 #endif


### PR DESCRIPTION
## What
Remove explicit node transformation logic from the schematic layer, 
nodes are now synced through their owner elements (components/wires).

## Why
When transforming without healing, nodes ended up at incorrect coordinates because components/wires 
transformed independently of nodes. Previously, the automatic healing masked this visual error.

By moving the sync logic to owners, nodes stay consistent with their connected elements.
In the case of multi-connected nodes, they may be moved/synced multiple times, 
but due to the all node movements being based on absolute positioning, they should end up at the same coordinate. 

## How

- Components:
  - Add helper function `setNodePortCenter()` to set the node connected to that port to the same (absolute) center.
  - Call the helper function whenever we move/transform; moveCenter, rotate, mirrorX and mirrorY
- Wires:
  - Add helper function `updateP1(), updateP2(), updatePorts()` to set their respective centers to (x1, y1) and (x2, y2), updatePorts sets both.
  - Use the helper function whenever we move/transform; moveCenter, rotate, mirrorX and mirrorY
  - Use the helper function when setting a new port coordinate; i.e. in setP1 and setP2
- Schematic:
  - Remove explicit node transformations
- Schematic_selection:
  - Remove explicit node movement
  
## Demo

**Current:**

[qucs_node_transform_current.webm](https://github.com/user-attachments/assets/8a7f9d6d-dfd9-48f9-badf-c53dd1d5c4f9)

Here we apply multiple transformations in a row, so you can see that the offset keeps increasing with every transform (mirrorX & mirrorY in this case)

**With this PR:**

[qucs_node_transform_pr.webm](https://github.com/user-attachments/assets/e54d44dd-059c-4080-8699-c14be3c6b7de)

Note: The "ghost" in the middle there is a different bug, fixed in a different branch :sweat_smile: 