### PR TITLE
feat(MouseActions): add keyboard driven move and move-and-stretch commands

### DIFF
--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1442,14 +1442,24 @@ void MouseActions::MReleaseMoving(Schematic *Doc, QMouseEvent* event)
     Doc->viewport()->update();
     Doc->releaseKeyboard(); // allow keyboard inputs again
 
+    // Clear move action
     QucsMain->MouseMoveAction = nullptr;
-    QucsMain->MousePressAction = &MouseActions::MPressSelect;
-    QucsMain->MouseReleaseAction = &MouseActions::MReleaseSelect;
-    QucsMain->MouseDoubleClickAction = &MouseActions::MDoubleClickSelect;
+
     QucsMain->editRotate->setChecked(false);
     QucsMain->editRotate->blockSignals(false);
     QucsMain->insLabel->blockSignals(false);
     QucsMain->setMarker->blockSignals(false);
+
+    // if we used drag 'n' drop, we might already be in select mode
+    // -> Manually re-enter select mode
+    if (QucsMain->activeAction == QucsMain->select) {
+        QucsMain->MousePressAction = &MouseActions::MPressSelect;
+        QucsMain->MouseReleaseAction = &MouseActions::MReleaseSelect;
+        QucsMain->MouseDoubleClickAction = &MouseActions::MDoubleClickSelect;
+        return;
+    }
+    // If we're in keyboard based movement, go back to select mode by slotting
+    QucsMain->slotEscape();
 }
 // -----------------------------------------------------------
 // Is called after move-free (move with disconnection) operation
@@ -1472,11 +1482,9 @@ void MouseActions::MReleaseMoveFree(Schematic *Doc, QMouseEvent *Event)
     QucsMain->MouseReleaseAction = nullptr;
     QucsMain->MouseDoubleClickAction = nullptr;
 
-    QucsMain->editMove->blockSignals(true);
-    QucsMain->editMove->setChecked(false);
-    QucsMain->editMove->blockSignals(false);
-
-    QucsMain->slotSelect(false);
+    // Go back to select mode
+    // NOTE: This turns off @activeAction
+    QucsMain->slotEscape();
 }
 
 // -----------------------------------------------------------

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1967,7 +1967,7 @@ void MouseActions::MPressTune(Schematic *Doc, QMouseEvent *Event, float fX, floa
 // **********                                                   **********
 // ***********************************************************************
 
-void MouseActions::mirrorXMovingElements(Schematic* Doc)
+void MouseActions::mirrorXMovingElements(Schematic* Doc, bool doPaint)
 {
     if (!movingState.selection.isValid()) {
         return;
@@ -1977,11 +1977,13 @@ void MouseActions::mirrorXMovingElements(Schematic* Doc)
     // Save transformation
     movingState.mirrorX = !movingState.mirrorX;
 
-    paintElementsScheme(Doc);
+    if (doPaint) {
+        paintElementsScheme(Doc);
+    }
     Doc->viewport()->update();
 }
 
-void MouseActions::mirrorYMovingElements(Schematic* Doc)
+void MouseActions::mirrorYMovingElements(Schematic* Doc, bool doPaint)
 {
     if (!movingState.selection.isValid()) {
         return;
@@ -1991,11 +1993,13 @@ void MouseActions::mirrorYMovingElements(Schematic* Doc)
     // Save transformation
     movingState.mirrorY = !movingState.mirrorY;
 
-    paintElementsScheme(Doc);
+    if (doPaint) {
+        paintElementsScheme(Doc);
+    }
     Doc->viewport()->update();
 }
 
-void MouseActions::rotateMovingElements(Schematic* Doc)
+void MouseActions::rotateMovingElements(Schematic* Doc, bool doPaint)
 {
     if (!movingState.selection.isValid()) {
         return;
@@ -2006,7 +2010,9 @@ void MouseActions::rotateMovingElements(Schematic* Doc)
     movingState.rotated++;
     movingState.rotated &= 3;
 
-    paintElementsScheme(Doc);
+    if (doPaint) {
+        paintElementsScheme(Doc);
+    }
     Doc->viewport()->update();
 }
 

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -352,6 +352,41 @@ void MouseActions::MMoveMoving2(Schematic *Doc, QMouseEvent *Event)
     Doc->displayMutations();
 }
 
+// -----------------------------------------------------------
+// Moves components and disconnects all components not connected to selection.
+void MouseActions::MMoveFree(Schematic *Doc, QMouseEvent *Event)
+{
+    // Initialize selection
+    auto selection = Doc->currentSelection();
+
+    // Disconnect all elements _not_ part of the selection
+    // Keeps alls node labels (labels connected straight to the port)
+    Doc->decoupleElements(selection, /*keepNodeLabel=*/true);
+
+    // Ensure clean slate, selection is re-done to avoid potential stale nodes deleted
+    // during decoupling.
+    movingState = {
+        .selection = Doc->currentSelection()
+    };
+
+    setPainter(Doc);
+    // initialize total movement
+    MAx3 = 0;
+    MAy3 = 0;
+
+    updateMouseMove(Doc, Event, /*onGrid=*/true);
+
+    QucsMain->MouseMoveAction = &MouseActions::MMoveFree2;
+    QucsMain->MouseReleaseAction = &MouseActions::MReleaseMoveFree;
+}
+
+void MouseActions::MMoveFree2(Schematic *Doc, QMouseEvent *Event)
+{
+    setPainter(Doc);
+    QPoint delta = updateMouseMove(Doc, Event, /*onGrid=*/true);
+    movingState.selection.moveCenter(delta.x(), delta.y());
+}
+
 /**
  * @brief MouseActions::MMovePaste Moves components after paste from clipboard.
  * @param Doc
@@ -1415,6 +1450,33 @@ void MouseActions::MReleaseMoving(Schematic *Doc, QMouseEvent* event)
     QucsMain->editRotate->blockSignals(false);
     QucsMain->insLabel->blockSignals(false);
     QucsMain->setMarker->blockSignals(false);
+}
+// -----------------------------------------------------------
+// Is called after move-free (move with disconnection) operation
+void MouseActions::MReleaseMoveFree(Schematic *Doc, QMouseEvent *Event)
+{
+    // Right-click rotates selection
+    if (Event->button() == Qt::RightButton) {
+        rotateMovingElements(Doc);
+        return;
+    }
+
+    if (Doc->healAfterMousyMutation() || MAx3 != 0 || MAy3 != 0) {
+        Doc->setChanged(true, true);
+    }
+    Doc->viewport()->update();
+
+    // Reset everything and go back to select mode
+    QucsMain->MouseMoveAction = nullptr;
+    QucsMain->MousePressAction = nullptr;
+    QucsMain->MouseReleaseAction = nullptr;
+    QucsMain->MouseDoubleClickAction = nullptr;
+
+    QucsMain->editMove->blockSignals(true);
+    QucsMain->editMove->setChecked(false);
+    QucsMain->editMove->blockSignals(false);
+
+    QucsMain->slotSelect(false);
 }
 
 // -----------------------------------------------------------

--- a/qucs/mouseactions.h
+++ b/qucs/mouseactions.h
@@ -136,9 +136,9 @@ public:
   void rightPressMenu(Schematic*, QMouseEvent*, float, float);
 
   // Transformation of moving elements
-  void mirrorXMovingElements(Schematic*);
-  void mirrorYMovingElements(Schematic*);
-  void rotateMovingElements(Schematic*);
+  void mirrorXMovingElements(Schematic*, bool doPaint=false);
+  void mirrorYMovingElements(Schematic*, bool doPaint=false);
+  void rotateMovingElements(Schematic*, bool doPaint=false);
 
   // Helper functions
   QPoint updateMouseMove(Schematic*, QMouseEvent*, bool onGrid=true);

--- a/qucs/mouseactions.h
+++ b/qucs/mouseactions.h
@@ -80,6 +80,8 @@ public:
   void MMoveWire2(Schematic*, QMouseEvent*);
   void MMoveMoving(Schematic*, QMouseEvent*);
   void MMoveMoving2(Schematic*, QMouseEvent*);
+  void MMoveFree(Schematic*, QMouseEvent*);
+  void MMoveFree2(Schematic*, QMouseEvent*);
   void MMovePaste(Schematic*, QMouseEvent*);
   void MMovePaste2(Schematic*, QMouseEvent*);
   void MMoveDelete(Schematic*, QMouseEvent*);
@@ -122,6 +124,7 @@ public:
   void MReleaseSelect2(Schematic*, QMouseEvent*);
   void MReleaseActivate(Schematic*, QMouseEvent*);
   void MReleaseMoving(Schematic*, QMouseEvent*);
+  void MReleaseMoveFree(Schematic*, QMouseEvent*);
   void MReleaseResizeDiagram(Schematic*, QMouseEvent*);
   void MReleasePaste(Schematic*, QMouseEvent*);
   void MReleaseResizePainting(Schematic*, QMouseEvent*);

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -367,7 +367,7 @@ public:
   void editFile(const QString&, bool reloadFile = false);
 
   QAction *insWire, *insLabel, *insGround, *insPort, *insEquation, *magPlus,
-          *editRotate, *editMirror, *editMirrorY, *editPaste, *select,
+          *editRotate, *editMirror, *editMirrorY, *editPaste, *select, *editStretch,
           *editActivate, *wire, *editDelete, *setMarker, *setDiagramLimits, *resetDiagramLimits, *showGrid, *onGrid, *moveText,
           *helpIndex, *helpGetStart, *callEditor, *callFilter, *callLine, *callActiveFilter,
           *showMsg, *showNet, *alignTop, *alignBottom, *alignLeft, *alignRight,
@@ -397,6 +397,7 @@ public slots:
   void slotEscape();
   void slotSelect(bool);
   void slotEditActivate(bool);
+  void slotEditStretch(bool); // move selection of components w/wire stretching
   void slotInsertLabel(bool);
   void slotSetMarker(bool);
   void slotSetDiagramLimits(bool);

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -367,7 +367,7 @@ public:
   void editFile(const QString&, bool reloadFile = false);
 
   QAction *insWire, *insLabel, *insGround, *insPort, *insEquation, *magPlus,
-          *editRotate, *editMirror, *editMirrorY, *editPaste, *select, *editStretch,
+          *editRotate, *editMirror, *editMirrorY, *editPaste, *select, *editStretch, *editMove,
           *editActivate, *wire, *editDelete, *setMarker, *setDiagramLimits, *resetDiagramLimits, *showGrid, *onGrid, *moveText,
           *helpIndex, *helpGetStart, *callEditor, *callFilter, *callLine, *callActiveFilter,
           *showMsg, *showNet, *alignTop, *alignBottom, *alignLeft, *alignRight,
@@ -398,6 +398,7 @@ public slots:
   void slotSelect(bool);
   void slotEditActivate(bool);
   void slotEditStretch(bool); // move selection of components w/wire stretching
+  void slotEditMove(bool);    // move selection of components and disconnect wires.
   void slotInsertLabel(bool);
   void slotSetMarker(bool);
   void slotSetDiagramLimits(bool);

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -143,7 +143,9 @@ void QucsApp::slotEditRotate(bool on)
 
     Schematic* Doc = dynamic_cast<Schematic*>(DocumentTab->currentWidget());
     if (Doc != nullptr) {
-      view->rotateMovingElements(Doc);
+      // enable painting in case we're in paste mode
+      bool doPaint = MouseMoveAction == &MouseActions::MMovePaste2;
+      view->rotateMovingElements(Doc, doPaint);
     }
     return;
   }
@@ -164,7 +166,9 @@ void QucsApp::slotEditMirrorX(bool on)
 
     Schematic* Doc = dynamic_cast<Schematic*>(DocumentTab->currentWidget());
     if (Doc != nullptr) {
-      view->mirrorXMovingElements(Doc);
+      // enable painting in case we're in paste mode
+      bool doPaint = MouseMoveAction == &MouseActions::MMovePaste2;
+      view->mirrorXMovingElements(Doc, doPaint);
     }
     return;
   }
@@ -185,7 +189,9 @@ void QucsApp::slotEditMirrorY(bool on)
 
     Schematic* Doc = dynamic_cast<Schematic*>(DocumentTab->currentWidget());
     if (Doc != nullptr) {
-      view->mirrorYMovingElements(Doc);
+      // enable painting in case we're in paste mode
+      bool doPaint = MouseMoveAction == &MouseActions::MMovePaste2;
+      view->mirrorYMovingElements(Doc, doPaint);
     }
     return;
   }

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -230,6 +230,24 @@ void QucsApp::slotEditDelete(bool on)
           &MouseActions::MMoveDelete, &MouseActions::MPressDelete);
 }
 
+// ------------------------------------------------------------------------
+// Is called if "Strech (move w/wiring)"-Button is pressed.
+void QucsApp::slotEditStretch(bool on)
+{
+  Schematic* Doc = dynamic_cast<Schematic*>(DocumentTab->currentWidget());
+  if(!on || Doc->currentSelection().isEmpty()) {
+    // Can't perform action without selection
+    editStretch->blockSignals(true);
+    editStretch->setChecked(false);
+    editStretch->blockSignals(false);
+    return;
+  }
+  // Add undo entry in case we cancel move action
+  Doc->setChanged(true, true);
+
+  performToggleAction(on, editStretch, nullptr,
+    &MouseActions::MMoveMoving, nullptr);
+}
 // -----------------------------------------------------------------------
 // Is called if "Wire"-Button is pressed.
 void QucsApp::slotSetWire(bool on)

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -134,8 +134,9 @@ void QucsApp::slotOnGrid(bool on)
 // Is called when the rotate toolbar button is pressed.
 void QucsApp::slotEditRotate(bool on)
 {
-  // If we're in paste mode, rotate moving elements instead of schematic elements
-  if (MouseMoveAction == &MouseActions::MMovePaste2) {
+  // If we're in paste mode or in move-mode, rotate moving elements instead of schematic elements
+  if (   MouseMoveAction == &MouseActions::MMovePaste2
+      || MouseMoveAction == &MouseActions::MMoveFree2) {
     editRotate->blockSignals(true);
     editRotate->setChecked(false);
     editRotate->blockSignals(false);
@@ -154,8 +155,9 @@ void QucsApp::slotEditRotate(bool on)
 // Is called when the mirror toolbar button is pressed.
 void QucsApp::slotEditMirrorX(bool on)
 {
-  // If we're in paste mode, mirror moving elements instead of schematic elements
-  if (MouseMoveAction == &MouseActions::MMovePaste2) {
+  // If we're in paste mode or move-mode, mirror moving elements instead of schematic elements
+  if (   MouseMoveAction == &MouseActions::MMovePaste2
+      || MouseMoveAction == &MouseActions::MMoveFree2) {
     editMirror->blockSignals(true);
     editMirror->setChecked(false);
     editMirror->blockSignals(false);
@@ -174,8 +176,9 @@ void QucsApp::slotEditMirrorX(bool on)
 // Is called when the mirror toolbar button is pressed.
 void QucsApp::slotEditMirrorY(bool on)
 {
-  // If we're in paste mode, mirror moving elements instead of schematic elements
-  if (MouseMoveAction == &MouseActions::MMovePaste2) {
+  // If we're in paste mode or move-mode, mirror moving elements instead of schematic elements
+  if (   MouseMoveAction == &MouseActions::MMovePaste2
+      || MouseMoveAction == &MouseActions::MMoveFree2) {
     editMirrorY->blockSignals(true);
     editMirrorY->setChecked(false);
     editMirrorY->blockSignals(false);
@@ -248,6 +251,24 @@ void QucsApp::slotEditStretch(bool on)
   performToggleAction(on, editStretch, nullptr,
     &MouseActions::MMoveMoving, nullptr);
 }
+
+// ------------------------------------------------------------------------
+// Is called if "Move (w/o wiring)"-Button is pressed.
+void QucsApp::slotEditMove(bool on)
+{
+  Schematic* Doc = dynamic_cast<Schematic*>(DocumentTab->currentWidget());
+  if(!on || Doc->currentSelection().isEmpty()) {
+    // Can't perform action without selection
+    editMove->blockSignals(true);
+    editMove->setChecked(false);
+    editMove->blockSignals(false);
+    return;
+  }
+
+  performToggleAction(on, editMove, nullptr,
+    &MouseActions::MMoveFree, nullptr);
+}
+
 // -----------------------------------------------------------------------
 // Is called if "Wire"-Button is pressed.
 void QucsApp::slotSetWire(bool on)

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -238,15 +238,18 @@ void QucsApp::slotEditDelete(bool on)
 void QucsApp::slotEditStretch(bool on)
 {
   Schematic* Doc = dynamic_cast<Schematic*>(DocumentTab->currentWidget());
-  if(!on || Doc->currentSelection().isEmpty()) {
-    // Can't perform action without selection
+  if (!on || Doc->currentSelection().isEmpty()) {
+    // if we were already on, or selection is empty
+    // cancel action and return to select mode
     editStretch->blockSignals(true);
     editStretch->setChecked(false);
     editStretch->blockSignals(false);
+
+    activeAction = nullptr;
+
+    slotEscape();
     return;
   }
-  // Add undo entry in case we cancel move action
-  Doc->setChanged(true, true);
 
   performToggleAction(on, editStretch, nullptr,
     &MouseActions::MMoveMoving, nullptr);
@@ -257,11 +260,16 @@ void QucsApp::slotEditStretch(bool on)
 void QucsApp::slotEditMove(bool on)
 {
   Schematic* Doc = dynamic_cast<Schematic*>(DocumentTab->currentWidget());
-  if(!on || Doc->currentSelection().isEmpty()) {
-    // Can't perform action without selection
+  if (!on || Doc->currentSelection().isEmpty()) {
+    // if we were already on, or selection is emtpy
+    // cancel action and return to select mode
     editMove->blockSignals(true);
     editMove->setChecked(false);
     editMove->blockSignals(false);
+
+    activeAction = nullptr;
+
+    slotEscape();
     return;
   }
 

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -435,6 +435,18 @@ void QucsApp::initActions()
   selectMarker->setWhatsThis(tr("Select Markers\n\nSelects all diagram markers of the document"));
   connect(selectMarker, SIGNAL(triggered()), SLOT(slotSelectMarker()));
 
+  // TODO: Add bitmap?
+  editStretch = new QAction(tr("Move and Stretch"), this);
+  editStretch->setShortcut(tr("M"));
+  editStretch->setStatusTip(tr("Move the selected components and stretch the connected wiring"));
+  editStretch->setWhatsThis(tr("Move selection (Stretching Wires)\n\n")
+                            + "Move the selected components. All connected wires will be "
+                            + "automatically stretched to maintain connections.\n\n"
+                            + "Same as the drag 'n' drop operation."
+                            );
+  editStretch->setCheckable(true);
+  connect(editStretch, SIGNAL(toggled(bool)), SLOT(slotEditStretch(bool)));
+
   editRotate = new QAction(QIcon(":/bitmaps/svg/rotate_ccw.svg"), tr("Rotate"), this);
   editRotate->setShortcut(tr("Ctrl+R"));
   editRotate->setStatusTip(tr("Rotates the selected component by 90\x00B0"));
@@ -764,6 +776,7 @@ void QucsApp::initMenuBar()
   editMenu->addAction(selectMarker);
   editMenu->addAction(editFind);
   editMenu->addAction(changeProps);
+  editMenu->addAction(editStretch);
   editMenu->addAction(editRotate);
   editMenu->addAction(editMirror);
   editMenu->addAction(editMirrorY);

--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -447,6 +447,17 @@ void QucsApp::initActions()
   editStretch->setCheckable(true);
   connect(editStretch, SIGNAL(toggled(bool)), SLOT(slotEditStretch(bool)));
 
+  // TODO: Add bitmap?
+  editMove = new QAction(tr("Move"), this);
+  editMove->setShortcut(tr("Shift+M"));
+  editMove->setStatusTip(tr("Move the selected components and disconnect wiring"));
+  editMove->setWhatsThis(tr("Move selection (Disconnecting Wires)\n\n")
+                        + "Move the selected components"
+                        + "Connected wires will be disconnected from the components.\n\n"
+                        );
+  editMove->setCheckable(true);
+  connect(editMove, SIGNAL(toggled(bool)), SLOT(slotEditMove(bool)));
+
   editRotate = new QAction(QIcon(":/bitmaps/svg/rotate_ccw.svg"), tr("Rotate"), this);
   editRotate->setShortcut(tr("Ctrl+R"));
   editRotate->setStatusTip(tr("Rotates the selected component by 90\x00B0"));
@@ -777,6 +788,7 @@ void QucsApp::initMenuBar()
   editMenu->addAction(editFind);
   editMenu->addAction(changeProps);
   editMenu->addAction(editStretch);
+  editMenu->addAction(editMove);
   editMenu->addAction(editRotate);
   editMenu->addAction(editMirror);
   editMenu->addAction(editMirrorY);

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -665,8 +665,10 @@ void Schematic::contentsMousePressEvent(QMouseEvent *Event)
 {
     a_App->editText->setHidden(true); // disable text edit of component property
     this->setFocus();
-    if (a_App->MouseReleaseAction == &MouseActions::MReleasePaste)
+    if (    a_App->MouseReleaseAction == &MouseActions::MReleasePaste
+        ||  a_App->MouseReleaseAction == &MouseActions::MReleaseMoveFree) {
         return;
+    }
 
     const QPoint inModel = contentsToModel(Event->pos());
 


### PR DESCRIPTION
## What
This PR adds two new keyboard shortcuts that adds keyboard driven movement.

1) Stretching, this is the same as the drag 'n' drop functionality, 
where the wires are still attached to the component, and hence gets "stretched" accordingly.
In the tooltip it's called "Move and Stretch", and it's currently mapped to the key `M`

2) Free movement, this disconnects all of the selection from the _other_ connections,
allowing you to move the selection freely.
In the tooltip it's called "Move", and it's currently mapped to `Shift+M`

## Demo

A short demo video:

[qucs_keyboard_move.webm](https://github.com/user-attachments/assets/dff0cbc4-b7c2-4352-a88e-e38f57e483f5)

The first move here is using the "stretch", while the others are using the "free move". 

## Notes

1. The visual bugs _should_ be fixed by #1523
2. Ideally, if the user cancels the movement, I would like it to reset to the previous state, however that needs additional work on the undo stack as far as I could see
    - Separate PR
    - Added to the issue tracker: #1525 
    
Resolves: #1500 