### PR TITLE
Fix crash when pasting zero-length wires in Schematic::installWire()

### DIFF
--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -2550,6 +2550,12 @@ std::pair<bool,Node*> Schematic::installWire(Wire* wire)
     assert(wire->Port1 == nullptr);
     assert(wire->Port2 == nullptr);
 
+    // Prevent crashes on zero-length wires
+    if (wire->P1() == wire->P2()) {
+        delete wire; // Prevent leak
+        return {false, nullptr};
+    }
+
     auto* port1 = provideNode(wire->P1());
     auto* port2 = provideNode(wire->P2());
 


### PR DESCRIPTION
**Problem**

Qucs-S crashes when the user pastes a schematic that contains wires whose start and end points are the same.
This can only happen by pasting text into Qucs-S. It doesn't happen when the user traces a wire in the schematic editor.

**Test schematic**

- Notice that the first wire has start=end.

- Qucs-S (current) crashes if this schematics is pasted. After a45e19285082014a76ac91ccc1c57d2328489794, Qucs-S doesn't crash anymore.

```
<Qucs Schematic 25.2.0>
<Components>
<GND * 1 140 290 0 0 0 0>
<Pac P1 1 140 260 18 -26 0 1 "1" 1 "50 Ohm" 1 "0 dBm" 0 "1 GHz" 0 "26.85" 0 "true" 0>
<GND * 1 420 290 0 0 0 0>
<Pac P2 1 420 260 18 -26 0 1 "2" 1 "50 Ohm" 1 "0 dBm" 0 "1 GHz" 0 "26.85" 0 "true" 0>
<MLIN MS1 1 290 170 -26 20 0 0 "RO4003C" 0 "1.1 mm" 1 "20 mm" 1 "Hammerstad" 0 "Kirschning" 0 "26.85" 0 "DC" 0>
</Components>
<Wires>
<140 0 140 0 "" 0 0 0 "">
<140 170 260 170 "" 0 0 0 "">
<420 170 420 230 "" 0 0 0 "">
<320 170 420 170 "" 0 0 0 "">
</Wires>
<Diagrams>
</Diagrams>
<Paintings>
</Paintings>
```