### PR TITLE
Fix issue #1518: Open sym files in Qucs-S

### DIFF
--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -2966,7 +2966,7 @@ void QucsApp::openFileFromProjectView(const QFileInfo &Info, const QString &note
    // Handle Qucs document types
   if (extName == "sch" || extName == "dpl" || extName == "vhdl" ||
       extName == "vhd" || extName == "v" || extName == "va" ||
-      extName == "m" || extName == "oct" || extName == "net") {
+      extName == "m" || extName == "oct" || extName == "net" || extName == "sym") {
 
     gotoPage(absolutePath);
     updateRecentFilesList(absolutePath);


### PR DESCRIPTION
This fixes issue #1518: if the user opens a sym file in the project editor, it's opened by the system text editor instead of being opened by the Qucs-S text editor.

The fix was already provided in the issue description.