### PR TITLE
fix(MouseActions): wire stretching by dragging node

### DIFF
--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <QString>
+#include <unordered_set>
 
 #include "components/vafile.h"
 #include "components/verilogfile.h"
@@ -1193,6 +1194,8 @@ Schematic::Selection Schematic::currentSelection() const {
         else if (pn->isSelected)
         {
             selection.nodes.push_back(pn);
+            // also add to seperate isolated nodes container
+            selection.isoNodes.push_back(pn);
             totalBounds = std::optional<QRect>{pn->boundingRect()};
         }
 
@@ -1235,6 +1238,7 @@ Schematic::Selection Schematic::currentSelection() const {
 Schematic::Selection Schematic::elementsToSelection(const std::list<Element*> &elements) const
 {
         std::optional<QRect> totalBounds = std::nullopt;
+        std::unordered_set<Node*> ownedNodes;
         Selection selection;
 
         // A helper to simplify uniting bounding boxes.
@@ -1250,8 +1254,15 @@ Schematic::Selection Schematic::elementsToSelection(const std::list<Element*> &e
 
             if (auto* pc = dynamic_cast<Component*>(element)) {
                 addElement(pc, selection.components);
+                // add all port nodes to ownedNodes set
+                for (auto* port : pc->Ports) {
+                    ownedNodes.emplace(port->Connection);
+                }
             } else if (auto* pw = dynamic_cast<Wire*>(element)) {
                 addElement(pw, selection.wires);
+                // add ports/nodes to ownedNodes set
+                ownedNodes.emplace(pw->Port1);
+                ownedNodes.emplace(pw->Port2);
             } else if (auto* pn = dynamic_cast<Node*>(element)) {
                 addElement(pn, selection.nodes);
             } else if (auto* pl = dynamic_cast<WireLabel*>(element)) {
@@ -1267,6 +1278,14 @@ Schematic::Selection Schematic::elementsToSelection(const std::list<Element*> &e
 
         if(!totalBounds) {
             return {};
+        }
+
+        // nodes that are not owned by either a component or a wire
+        // gets added to a separate @isoNodes container
+        for (auto* pn : selection.nodes) {
+            if (!ownedNodes.contains(pn)) {
+                selection.isoNodes.push_back(pn);
+            }
         }
 
         selection.bounds = *totalBounds;

--- a/qucs/schematic_selection.h
+++ b/qucs/schematic_selection.h
@@ -79,7 +79,8 @@ struct SchematicSelection {
     }
     for (auto* pm : markers)      pm->moveCenter(dx, dy);
     // NOTE: nodes are synced through their owner (components/wires)
-    // for (auto* pn : nodes)        pn->moveCenter(dx, dy);
+    // Special case: if we have isolated nodes, we move those
+    for (auto* pn : isoNodes)     pn->moveCenter(dx, dy);
 
     // Move bounds
     bounds.moveCenter(QPoint(dx, dy));

--- a/qucs/schematic_selection.h
+++ b/qucs/schematic_selection.h
@@ -21,6 +21,9 @@ struct SchematicSelection {
   std::vector<WireLabel*> labels;
   std::vector<Marker*> markers;
   std::vector<Node*> nodes;
+  // isolatedNodes, i.e. not owned by component/wire
+  // NOTE: they are also in @nodes, so don't use this for counting etc.
+  std::vector<Node*> isoNodes;
 
   // Return whether the selection is empty
   bool isEmpty() const {


### PR DESCRIPTION
## What

This reintroduces node movement in SchematicSelection, however only on isolated nodes (those whose owner component/wire is not in the selection), allowing them to be moved independently. 

## Why

Commit c21f8ae8 removed explicit node movement, breaking wire stretching by node dragging.
Isolated nodes have no owner (available in selection) to sync through and must be moved explicitly. 

Example
---
<img width="100%%" height="50%" alt="image" src="https://github.com/user-attachments/assets/c3664dcf-7362-4dee-bac4-07478053ce3a" />

Where I am moving the node from the arrow to my mouse cursor through dragging