### PR TITLE
fix(convertToQucsData): guard against out-of-bounds for `extra_vars_dims`

### DIFF
--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -1280,7 +1280,9 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
         }
         if (var_list.isEmpty()) continue; // nothing to convert
         normalizeVarsNames(var_list, dataset_prefix, isCustomPrefix);
+        // prepend indep to extra_vars and extra_vars_dims
         extra_vars.prepend(var_list.first());
+        extra_vars_dims.prepend(sim_points.count());
         normalizeVarsNames(extra_vars, dataset_prefix, isCustomPrefix);
 
         QString indep = var_list.first();
@@ -1324,16 +1326,22 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             ds_stream<<"</indep>\n";
         }
 
-        int var_idx = 0;
-        for(int i=1;i<var_list.count();i++) { // output dep var
-            bool is_extra_var = false;
+        for(int i = 1 ; i < var_list.count(); i++) { // output dep var
+            QString var = var_list.at(i);
+
             bool extra_indep = false; // For XSPICE digital vars or scalar
             bool is_scalar = false;
+            // Find the correct index in extra_vars to get the dimension
+            int current_extra_idx = extra_vars.indexOf(var);
+            bool is_extra_var = (current_extra_idx != -1);
+            // Get the extra_var length if any, otherwise fallback to sim_points
+            int var_length = (is_extra_var && current_extra_idx < extra_vars_dims.count())
+                  ? extra_vars_dims.at(current_extra_idx)
+                  : sim_points.count();
+
             if (indep.isEmpty()) {
               ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(var_list.at(i)).arg(sim_points.count());
             } else {
-              QString var = var_list.at(i);
-              is_extra_var = extra_vars.contains(var);
               if (is_extra_var && !var.endsWith("_steps")) { // XSPICE digital node
                 // requires another X-variable; not time
                 QString var2 = var + "_steps";
@@ -1352,15 +1360,14 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
                   if (hasParSweep) {
                     ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var).arg(swp_var);
                   } else {
-                    ds_stream<<QStringLiteral("<indep %1 %2>\n")
-                                     .arg(var).arg(extra_vars_dims.at(var_idx));
+                    ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(var).arg(var_length);
                     is_scalar = true;
                   }
                 }
               } else if (is_extra_var && var.endsWith("_steps") && // indep XSPICE digital var
                          !var.contains("(") && !var.contains(")")) {
                 extra_indep = true;
-                ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(var).arg(extra_vars_dims.at(var_idx));
+                ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(var).arg(var_length);
               } else {
                 ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var_list.at(i)).arg(indep);
               }
@@ -1369,18 +1376,17 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             int count  = 0;
             for (int idx = 0; idx < sim_points.count(); idx++) {
                 auto sim_point = sim_points.at(idx);
-                if (!extra_vars_dims.isEmpty()) {
+                if (is_extra_var) {
                   if (hasParSweep) {
-                    int var_length = extra_vars_dims.at(var_idx);
-                    if (is_extra_var && count >= var_length) {
+                    if (count >= var_length) {
                       // forward variables with dim= suffix
                       int indep_cnt = sim_points.count()/swp_var_val.count();
                       idx = idx + (indep_cnt - var_length - 1);
                       count = 0;
                       continue;
                     }
-                  } else {
-                    if (is_extra_var && idx >= extra_vars_dims.at(var_idx)) break;
+                  } else if (idx >= var_length){
+                    break;
                   }
                 }
                 if (isComplex) {
@@ -1402,7 +1408,6 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             } else {
               ds_stream<<"</dep>\n";
             }
-            if (is_extra_var) var_idx++;
         }
     }
 

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -272,7 +272,9 @@ void Ngspice::createNetlist(
             } else {  // Set Noise1 plot to output noise spectrum
                 spiceNetlist.append("setplot noise1\n");
             }
-            nods = "noise1.all";
+            // NOTE: if we set 'setplot noiseX', and we use 'all'
+            // it will be the equivalent of noiseX.all
+            nods = "all";
         } else if ( sim_typ == ".PZ" ) {
             pzSims++;
             spiceNetlist.append(pc->getSpiceNetlist());


### PR DESCRIPTION
## What

This PR addresses an out-of-bounds issue originally reported in #1526, where one would crash if one did a parametric sweep with a fixed (scalar) variable.

The reason that it crashes is that we always prepend the `indep` variable to the `extra_vars` list, and in that TB `beta` is an additional `extra_var`. When processing `indep` we increment `var_idx` , and then when we process `beta` in this particular case, we try to access: `extra_vars_dims(var_idx=1)`, however the size of `extra_vars_dims` is one less than `extra_vars`, since we only track the size of `beta`, causing an out-of-bounds error. Since there was an explicit guard for `!extra_vars_dims.empty()`, one would not see this unless one had a TB with `extra_vars`. 

## Changes

1. Rather than being dependent on tracking the `var_idx` correctly, we just use a simple name lookup to get the correct dimension.
2. The nodes for noise simulation got addressed by changing from a fixed `noise1.all` to the relative `all`. This fixes the N-duplicate data one would get when doing a parametric sweep of N-steps. 

## Example

<img width="1099" height="983" alt="image" src="https://github.com/user-attachments/assets/245beb89-e88b-4fb7-846e-9f9411c64a47" />

Testbench taken from: https://github.com/ra3xdh/qucs_s/issues/1526#issue-3666213634, modified to show that it works with PtsPerSummary as well. 

## TODOs

Note that when using `PtsPerSummary` feature on noise sweep, one end up getting duplicates of the "dependent" signals, I assume that the data is the same, but it's duplicated, as seen here:

<img width="843" height="168" alt="image" src="https://github.com/user-attachments/assets/782057d0-024d-4158-967b-81609d88c11c" />

The fix for this can probably be done outside this PR, since this fixes a crash.

Fixes: https://github.com/ra3xdh/qucs_s/issues/1526