### PR TITLE
Fix issue #1551: Duplicate and Rename actions disabled in Project view

### DIFF
--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -1202,7 +1202,7 @@ void QucsApp::slotShowContentMenu(const QPoint& pos)
   QModelIndex idx = Content->indexAt(pos);
   if (idx.isValid() && idx.parent().isValid()) {
     QItemSelectionModel *selectionModel = Content->selectionModel();
-    bool multipleSelected = selectionModel->selectedIndexes().count() > 1;
+    bool multipleSelected = selectionModel->selectedRows().count() > 1;
 
     ActionCMenuInsert->setVisible(
         idx.sibling(idx.row(), 1).data().toString().contains(tr("-port"))


### PR DESCRIPTION
## Description

As reported in issue #1551 , the "Duplicate" and "Rename" actions were disabled when the user selected a single schematic file in the project view panel.

The project widget contains two columns: the file name and a note. When the user selected a schematic file, the first and the second columns are automatically selected, so selectionModel->selectedIndexes().count() = 2. 

`bool multipleSelected = selectionModel->selectedIndexes().count() > 1;`

Consequently, "multipleSelected" = true, and the "Duplicate" and "Rename" actions were hidden.

The problem is fixed by using the "selectedRows()" function instead of "selectedIndexes()".

`bool multipleSelected = selectionModel->selectedRows().count() > 1;`


## After this PR

### Single file selection

<img width="405" height="466" alt="image" src="https://github.com/user-attachments/assets/940db7f4-86d1-4b47-ae48-ca5cfe98c6ec" />


### Multiple file selection
<img width="427" height="429" alt="image" src="https://github.com/user-attachments/assets/aea9220c-445b-4898-a19b-a3695b4f0059" />

