### PR TITLE
Add DIN A6 schematic frame

### DIFF
--- a/qucs/dialogs/settingsdialog.cpp
+++ b/qucs/dialogs/settingsdialog.cpp
@@ -199,16 +199,21 @@ SettingsDialog::SettingsDialog(Schematic *Doc_)
     Input_GridY->setText(QString::number(Doc->getGridY()));
 
     //////////////////////////////////////////////////////////////////////////
-    // Select index in combo according to the actual frame code in the document
-    int frameCode = Doc->getShowFrame();   // this is the <showFrame=...> value
-    int idxToSelect = 0;// default to "no Frame"
+    // Select index in combo according to the document's frame code
+    FrameSize docFrame = Doc->getShowFrame();  // <showFrame=...> value from document
+    int idxToSelect = 0;                       // default: "no Frame" (index 0)
+
     for (int i = 0; i < Combo_Frame->count(); ++i) {
-        if (Combo_Frame->itemData(i, Qt::UserRole).toInt() == frameCode) {
+        FrameSize itemFrame = static_cast<FrameSize>(
+            Combo_Frame->itemData(i, Qt::UserRole).toInt()
+            );
+        if (itemFrame == docFrame) {
             idxToSelect = i;
             break;
         }
     }
     Combo_Frame->setCurrentIndex(idxToSelect);
+
     //////////////////////////////////////////////////////////////////////////
 
     QString Text_;
@@ -313,12 +318,14 @@ void SettingsDialog::slotApply()
         changed = true;
     }
 
-    if(Doc->getShowFrame() != Combo_Frame->currentIndex())
-    {
-        int a_showFrame = Combo_Frame->itemData(Combo_Frame->currentIndex(), Qt::UserRole).toInt();
-        Doc->setShowFrame(a_showFrame);
+    FrameSize current = Doc->getShowFrame(); // Current frame
+    FrameSize selected = static_cast<FrameSize>(Combo_Frame->itemData(Combo_Frame->currentIndex(), Qt::UserRole).toInt()); // Selected frame
+
+    if (current != selected) {
+        Doc->setShowFrame(static_cast<int>(selected));
         changed = true;
     }
+
 
     QString t;
     encode_String(Input_Frame0->toPlainText(), t);

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -73,7 +73,7 @@ Schematic::Schematic(QucsApp *App_, const QString &Name_) :
     a_ViewY1(0),
     a_ViewX2(1),
     a_ViewY2(1),
-    a_showFrame(0), // don't show
+    a_showFrame(FrameSize::None),
     a_Frame_Text0(tr("Title")),
     a_Frame_Text1(tr("Drawn By:")),
     a_Frame_Text2(tr("Date:")),
@@ -308,26 +308,31 @@ bool Schematic::sizeOfFrame(int &xall, int &yall)
     // Values exclude border of 1.5cm at each side.
     switch (a_showFrame) {
     // DIN A STANDARD FORMATS
-    case 1:  xall = 1020; yall =  765; break; // DIN A5 landscape
-    case 2:  xall =  765; yall = 1020; break; // DIN A5 portrait
-    case 3:  xall = 1530; yall = 1020; break; // DIN A4 landscape
-    case 4:  xall = 1020; yall = 1530; break; // DIN A4 portrait
-    case 5:  xall = 2295; yall = 1530; break; // DIN A3 landscape
-    case 6:  xall = 1530; yall = 2295; break; // DIN A3 portrait
-    // These standard sizes were implemented later (2025), so the index need to be > 8 to avoid breaking backward compatibility with older versions of Qucs-S
-    case 9: xall =  660; yall =  465; break; // DIN A6 landscape
-    case 10: xall =  465; yall =  660; break; // DIN A6 portrait
+    case FrameSize::A5_Landscape: xall = 1020; yall =  765; break; // DIN A5 landscape
+    case FrameSize::A5_Portrait:  xall =  765; yall = 1020; break; // DIN A5 portrait
+    case FrameSize::A4_Landscape: xall = 1530; yall = 1020; break; // DIN A4 landscape
+    case FrameSize::A4_Portrait:  xall = 1020; yall = 1530; break; // DIN A4 portrait
+    case FrameSize::A3_Landscape: xall = 2295; yall = 1530; break; // DIN A3 landscape
+    case FrameSize::A3_Portrait:  xall = 1530; yall = 2295; break; // DIN A3 portrait
+
+    // These standard sizes were implemented later (2025), so the code values need to be > 8
+    // to avoid breaking backward compatibility with older versions of Qucs-S.
+    case FrameSize::A6_Landscape: xall =  660; yall =  465; break; // DIN A6 landscape
+    case FrameSize::A6_Portrait:  xall =  465; yall =  660; break; // DIN A6 portrait
     // A7 and above formats are too small and the title box doesn't fit in the frame
     // A0, A1, and A2 are huge
 
     // US letter format
-    case 7:  xall = 1414; yall = 1054; break; // letter landscape
-    case 8:  xall = 1054; yall = 1414; break; // letter portrait
+    case FrameSize::Letter_Landscape: xall = 1414; yall = 1054; break; // Letter landscape
+    case FrameSize::Letter_Portrait:  xall = 1054; yall = 1414; break; // Letter portrait
+
+    case FrameSize::None:
     default:
         return false;
     }
     return true;
 }
+
 
 
 void Schematic::paintFrame(QPainter* painter) {
@@ -718,7 +723,7 @@ void Schematic::print(QPrinter*, QPainter* painter, bool printAll,
 
     QRect printedArea = printAll ? allBoundingRect() : currentSelection().bounds;
 
-    if (printAll && a_showFrame) {
+    if (printAll && a_showFrame != FrameSize::None) {
         int frame_width, frame_height;
         sizeOfFrame(frame_width, frame_height);
         printedArea |= QRect{0, 0, frame_width, frame_height};
@@ -785,7 +790,7 @@ template <typename T> void draw_preserve_selection(T* elem, QPainter* p) {
 } // namespace
 
 void Schematic::paintSchToViewpainter(QPainter* painter, bool printAll) {
-    if (printAll && a_showFrame && !a_symbolMode) {
+    if (printAll && a_showFrame != FrameSize::None && !a_symbolMode) {
         paintFrame(painter);
     }
 

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -79,6 +79,26 @@ struct SubFile {
 };
 typedef QMap<QString, SubFile> SubMap;
 
+enum class FrameSize : int {
+    // No frame
+    None              = 0,
+
+    // DIN A formats
+    A6_Landscape      = 9,
+    A6_Portrait       = 10,
+    A5_Landscape      = 1,
+    A5_Portrait       = 2,
+    A4_Landscape      = 3,
+    A4_Portrait       = 4,
+    A3_Landscape      = 5,
+    A3_Portrait       = 6,
+
+    // US Letter
+    Letter_Landscape  = 7,
+    Letter_Portrait   = 8,
+};
+
+
 class Schematic : public Q3ScrollView, public QucsDoc {
   Q_OBJECT
 
@@ -220,8 +240,8 @@ public:
   void setFrame_Text2(const QString value) { a_Frame_Text2 = value; }
   QString getFrame_Text3() const { return a_Frame_Text3; }
   void setFrame_Text3(const QString value) { a_Frame_Text3 = value; }
-  int getShowFrame() const { return a_showFrame; }
-  void setShowFrame(int value) { a_showFrame = value; }
+  FrameSize getShowFrame() const { return a_showFrame; }
+  void setShowFrame(int value) {a_showFrame = static_cast<FrameSize>(value);}
   int getViewX1() const { return a_ViewX1; }
   int getViewY1() const { return a_ViewY1; }
   int getGridX() const { return a_GridX; }
@@ -274,7 +294,7 @@ private:
   int a_ViewX2;
   int a_ViewY2;
 
-  int a_showFrame;
+  FrameSize a_showFrame; // Frame format
   QString a_Frame_Text0;
   QString a_Frame_Text1;
   QString a_Frame_Text2;

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -703,7 +703,7 @@ int Schematic::saveDocument()
   stream << "  <OpenDisplay=" << a_SimOpenDpl << ">\n";
   stream << "  <Script=" << a_Script << ">\n";
   stream << "  <RunScript=" << a_SimRunScript << ">\n";
-  stream << "  <showFrame=" << a_showFrame << ">\n";
+  stream << "  <showFrame=" << static_cast<int>(a_showFrame) << ">\n";
 
   QString t;
   misc::convert2ASCII(t = a_Frame_Text0);
@@ -908,9 +908,15 @@ bool Schematic::loadProperties(QTextStream *stream)
     else if(cstr == "RunScript")
     if(nstr.toInt(&ok) == 0) a_SimRunScript = false;
     else a_SimRunScript = true;
-    else if(cstr == "showFrame")
-    a_showFrame = nstr.at(0).toLatin1() - '0';
-    else if(cstr == "FrameText0") misc::convert2Unicode(a_Frame_Text0 = nstr);
+    else if(cstr == "showFrame"){
+        bool ok = false;
+        int value = nstr.toInt(&ok);
+        if (ok) {
+            a_showFrame = static_cast<FrameSize>(value);
+        } else {
+            a_showFrame = FrameSize::None;  // Fallback
+        }
+    }else if(cstr == "FrameText0") misc::convert2Unicode(a_Frame_Text0 = nstr);
     else if(cstr == "FrameText1") misc::convert2Unicode(a_Frame_Text1 = nstr);
     else if(cstr == "FrameText2") misc::convert2Unicode(a_Frame_Text2 = nstr);
     else if(cstr == "FrameText3") misc::convert2Unicode(a_Frame_Text3 = nstr);


### PR DESCRIPTION
I have added the DIN A6 schematic frame to the selection of available frames.

This is because the DIN A5 frame leaves too much empty space for small circuits. I often use schematics with only text or subcircuits, and I think A6 is a good size for this. A7 and smaller are very impractical.

In order to put the DIN A6 format along with the other DIN Ax sizes, I needed to add a helper function and avoid using the Combobox::currentindex directly.

An enum was added to improve code readability.

I have tested compatibility with schematics from older versions of Qucs-S and it works fine.

<img width="367" height="452" alt="image" src="https://github.com/user-attachments/assets/62afe9ed-33d5-4421-8010-c323d1746249" />
