### PR TITLE
fix(mouseactions): properly deactivate action when releasing keyboard move

### DIFF
--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1450,16 +1450,20 @@ void MouseActions::MReleaseMoving(Schematic *Doc, QMouseEvent* event)
     QucsMain->insLabel->blockSignals(false);
     QucsMain->setMarker->blockSignals(false);
 
-    // if we used drag 'n' drop, we might already be in select mode
-    // -> Manually re-enter select mode
-    if (QucsMain->activeAction == QucsMain->select) {
+    QAction* action = QucsMain->activeAction;
+    if (action == nullptr || action == QucsMain->select) {
+        // if we used drag 'n' drop, we might already be in select mode
+        // -> Manually re-enter select mode
         QucsMain->MousePressAction = &MouseActions::MPressSelect;
         QucsMain->MouseReleaseAction = &MouseActions::MReleaseSelect;
         QucsMain->MouseDoubleClickAction = &MouseActions::MDoubleClickSelect;
-        return;
+    } else {
+        // If we're in keyboard based movement, cleanup and go back to select mode by slotting
+        action->blockSignals(true);
+        action->setChecked(false);
+        action->blockSignals(false);
+        QucsMain->slotEscape();
     }
-    // If we're in keyboard based movement, go back to select mode by slotting
-    QucsMain->slotEscape();
 }
 // -----------------------------------------------------------
 // Is called after move-free (move with disconnection) operation
@@ -1478,12 +1482,13 @@ void MouseActions::MReleaseMoveFree(Schematic *Doc, QMouseEvent *Event)
 
     // Reset everything and go back to select mode
     QucsMain->MouseMoveAction = nullptr;
-    QucsMain->MousePressAction = nullptr;
-    QucsMain->MouseReleaseAction = nullptr;
-    QucsMain->MouseDoubleClickAction = nullptr;
 
-    // Go back to select mode
-    // NOTE: This turns off @activeAction
+    // cleanup current action if any
+    if (QucsMain->activeAction != nullptr) {
+        QucsMain->activeAction->blockSignals(true);
+        QucsMain->activeAction->setChecked(false);
+        QucsMain->activeAction->blockSignals(false);
+    }
     QucsMain->slotEscape();
 }
 

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -242,15 +242,12 @@ void QucsApp::slotEditDelete(bool on) {
 // Is called if "Strech (move w/wiring)"-Button is pressed.
 void QucsApp::slotEditStretch(bool on) {
   Schematic *Doc = dynamic_cast<Schematic *>(DocumentTab->currentWidget());
-  if (!on || Doc->currentSelection().isEmpty()) {
-    // if we were already on, or selection is empty
-    // cancel action and return to select mode
+  // if we were already on and  selection is empty
+  // cancel action and return to select mode
+  if (on && Doc->currentSelection().isEmpty()) {
     editStretch->blockSignals(true);
     editStretch->setChecked(false);
     editStretch->blockSignals(false);
-
-    activeAction = nullptr;
-
     slotEscape();
     return;
   }
@@ -263,15 +260,12 @@ void QucsApp::slotEditStretch(bool on) {
 // Is called if "Move (w/o wiring)"-Button is pressed.
 void QucsApp::slotEditMove(bool on) {
   Schematic *Doc = dynamic_cast<Schematic *>(DocumentTab->currentWidget());
-  if (!on || Doc->currentSelection().isEmpty()) {
-    // if we were already on, or selection is emtpy
-    // cancel action and return to select mode
+  // if we were already on and selection is empty
+  // cancel action and return to select mode
+  if (on && Doc->currentSelection().isEmpty()) {
     editMove->blockSignals(true);
     editMove->setChecked(false);
     editMove->blockSignals(false);
-
-    activeAction = nullptr;
-
     slotEscape();
     return;
   }


### PR DESCRIPTION
This explicitly deactivates the current action in the case we are currently in a keyboard-move (i.e. either stretch or isolated move). Previously when this wasn't deactivated, one could enter a state where one wasn't in a _proper_ selection mode, making it seem like the GUI wasn't interactive anymore.

fixes: c76be4b5 ("fix(Mouseactions): return to select mode after keyboard-move")