### PR TITLE
(fix:qucs-s-spar-viewer) Refactor convert_MA_RI_to_dB to use references, be case-insensitive

### DIFF
--- a/qucs-s-spar-viewer/Misc/general.cpp
+++ b/qucs-s-spar-viewer/Misc/general.cpp
@@ -331,33 +331,37 @@ QString ConvertLengthFromM(QString units, double len) {
   return QString("");
 }
 
-void convert_MA_RI_to_dB(double *S_1, double *S_2, double *S_3, double *S_4,
+void convert_MA_RI_to_dB(double& S_1, double& S_2, double& S_3, double& S_4,
                          QString format) {
-  double S_dB = *S_1, S_ang = *S_2;
-  double S_re = *S_3, S_im = *S_4;
-  if (format == "MA") {
-    S_dB = 20 * log10(*S_1);
-    S_ang = *S_2;
-    S_re = *S_1 * std::cos(*S_2 * M_PI / 180);
-    S_im = *S_1 * std::sin(*S_2 * M_PI / 180);
-  } else {
-    if (format == "RI") {
-      S_dB = 20 * log10(sqrt((*S_1) * (*S_1) + (*S_2) * (*S_2)));
-      S_ang = atan2(*S_2, *S_1) * 180 / M_PI;
-      S_re = *S_1;
-      S_im = *S_2;
-    } else {
-      // DB format
-      double r = std::pow(10, *S_1 / 20.0);
-      double theta = *S_2 * M_PI / 180.0;
-      S_re = r * std::cos(theta);
-      S_im = r * std::sin(theta);
-    }
+  double S_dB = S_1;
+  double S_ang = S_2;
+  double S_re;// = S_3;
+  double S_im;// = S_4;
+  format = format.toLower();
+  if (format == "ma") {
+    S_dB = 20 * log10(S_1);
+    S_ang = S_2;
+    S_re = S_1 * std::cos(S_2 * M_PI / 180);
+    S_im = S_1 * std::sin(S_2 * M_PI / 180);
+  } else if (format == "ri") {
+      S_dB = 20 * log10(sqrt((S_1) * (S_1) + (S_2) * (S_2)));
+      S_ang = atan2(S_2, S_1) * 180 / M_PI;
+      S_re = S_1;
+      S_im = S_2;
+  } else if (format == "db"){
+    double r = std::pow(10, S_1 / 20.0);
+    double theta = S_2 * M_PI / 180.0;
+    S_re = r * std::cos(theta);
+    S_im = r * std::sin(theta);
   }
-  *S_1 = S_dB;
-  *S_2 = S_ang;
-  *S_3 = S_re;
-  *S_4 = S_im;
+  else {
+    // throw error
+    throw std::invalid_argument("Unexpected format is not ma, ri, or db");
+  }
+  S_1 = S_dB;
+  S_2 = S_ang;
+  S_3 = S_re;
+  S_4 = S_im;
 }
 
 double getFreqScale(QString frequency_unit) {

--- a/qucs-s-spar-viewer/Misc/general.h
+++ b/qucs-s-spar-viewer/Misc/general.h
@@ -69,8 +69,8 @@ QString ConvertLengthFromM(QString, double);
 /// @param[in,out] S_2 Angle (MA/DB) or Imaginary (RI) → angle output
 /// @param[out] S_3 Real part output
 /// @param[out] S_4 Imaginary part output
-/// @param format Input format: "MA", "RI", or "DB"
-void convert_MA_RI_to_dB(double* S_1, double* S_2, double* S_3, double* S_4,
+/// @param format Input format: "MA", "RI", or "DB" (case insensitive)
+void convert_MA_RI_to_dB(double& S_1, double& S_2, double& S_3, double& S_4,
                          QString format);
 
 /// @brief Gets frequency scale factor from unit string

--- a/qucs-s-spar-viewer/Misc/readTouchstone.cpp
+++ b/qucs-s-spar-viewer/Misc/readTouchstone.cpp
@@ -62,20 +62,21 @@ QMap<QString, QList<double>> readTouchstoneFile(const QString &filePath) {
 
       frequency_unit = frequency_unit.toLower();
 
+      // Default is already set to "hz"
       if (frequency_unit == "khz") {
         freq_scale = 1e3;
-      } else {
-        if (frequency_unit == "mhz") {
+      }
+      else if (frequency_unit == "mhz") {
           freq_scale = 1e6;
-        } else {
-          if (frequency_unit == "ghz") {
+      }
+      else if (frequency_unit == "ghz") {
             freq_scale = 1e9;
-          }
-        }
       }
 
+      // parameter: {S,Y,Z,H,G}
       parameter = info.at(2); // specifies what kind of network parameter data
                               // is contained in the file
+      // format: {DB, MA, RI} for dB-angle, magnitude-angle, and real-imaginary
       format = info.at(
           3); // Specifies the format of the network parameter data pairs
       Z0 = info.at(5).toDouble();
@@ -90,7 +91,9 @@ QMap<QString, QList<double>> readTouchstoneFile(const QString &filePath) {
 
     file_data["frequency"].append(values[0].toDouble() * freq_scale); // in Hz
 
-    double S_1, S_2, S_3, S_4;
+    // S_in1_becomes_dB and S_in2_becomes_angle are s-param args, e.g. mag angle
+    // They become dB and angle
+    double S_in1_becomes_dB, S_in2_becomes_angle, S_re, S_im;
     QString s1, s2, s3, s4;
     int index = 1, data_counter = 0;
 
@@ -102,15 +105,15 @@ QMap<QString, QList<double>> readTouchstoneFile(const QString &filePath) {
         s3 = s1.mid(0, s1.length() - 2).append("re");
         s4 = s1.mid(0, s1.length() - 2).append("im");
 
-        S_1 = values[index].toDouble();
-        S_2 = values[index + 1].toDouble();
+        S_in1_becomes_dB = values[index].toDouble();
+        S_in2_becomes_angle = values[index + 1].toDouble();
 
-        convert_MA_RI_to_dB(&S_1, &S_2, &S_3, &S_4, format);
+        convert_MA_RI_to_dB(S_in1_becomes_dB, S_in2_becomes_angle, S_re, S_im, format);
 
-        file_data[s1].append(S_1); // dB
-        file_data[s2].append(S_2); // ang
-        file_data[s3].append(S_3); // re
-        file_data[s4].append(S_4); // im
+        file_data[s1].append(S_in1_becomes_dB); // dB
+        file_data[s2].append(S_in2_becomes_angle); // ang
+        file_data[s3].append(S_re); // re
+        file_data[s4].append(S_im); // im
         index += 2;
         data_counter++;
 


### PR DESCRIPTION
The `readTouchstoneFile()` fails to parse files with lower-case format (DB, MA, RI) leading to incorrect results when plotting. The following changes have been made:
* Some comments have been added and variables renamed to be easier to review
* Some if...else statements were reformatted slightly to get rid of awkward nestings
* In `convert_MA_RI_to_dB`, and error `std::invalid_argument` is thrown in case the format is not "ma", "ri", or "db" to avoid errors like this in the future
* Raw pointers in `convert_MA_RI_to_dB` have been changed to references to align with modern C++ standards

I reformatted things as I came across them but didn't intend to change anything outside of the affected areas. None of these changes are necessary but they improve readability.