### PR TITLE
Add condition attribute to Text element in XML components

### DIFF
--- a/library/components/Component.xsd
+++ b/library/components/Component.xsd
@@ -199,6 +199,7 @@
                             <xs:attribute type="xs:double" name="size" use="optional" default="10.0"/>
                             <xs:attribute type="xs:double" name="cos" use="optional" default="1.0"/>
                             <xs:attribute type="xs:double" name="sin" use="optional" default="0.0"/>
+                            <xs:attribute type="xs:string" name="condition" use="optional" default=""/>
                           </xs:extension>
                         </xs:simpleContent>
                       </xs:complexType>

--- a/qucs/components/xml/XmlComponent.cpp
+++ b/qucs/components/xml/XmlComponent.cpp
@@ -287,6 +287,11 @@ void XmlComponent::createSymbol()
 
     foreach (const Text& textDef, a_texts)
     {
+        if (!evaluateConditionInclude(textDef.a_condition))
+        {
+            continue;
+        }
+
         ::Text* text(
                 new ::Text(
                     textDef.a_x,

--- a/qucs/components/xml/XmlComponent.h
+++ b/qucs/components/xml/XmlComponent.h
@@ -279,14 +279,16 @@ public:
                 const QString& color,
                 double size,
                 double cos,
-                double sin) :
+                double sin,
+                const QString& condition) :
             a_x(x),
             a_y(y),
             a_text(text),
             a_color(color),
             a_size(size),
             a_cos(cos),
-            a_sin(sin)
+            a_sin(sin),
+            a_condition(condition)
         {}
 
         int a_x;
@@ -296,6 +298,7 @@ public:
         double a_size;
         double a_cos;
         double a_sin;
+        QString a_condition;
     };
 
     XmlComponent(

--- a/qucs/module_xml.cpp
+++ b/qucs/module_xml.cpp
@@ -343,7 +343,8 @@ void Module::registerXmlComponents(const QString& componentPath)
                         QString::fromUtf8(it->color()),
                         it->size(),
                         it->cos(),
-                        it->sin()
+                        it->sin(),
+                        QString::fromUtf8(it->condition())
                 );
 
                 texts << text;
@@ -569,6 +570,7 @@ void Module::registerXmlComponents(const QString& componentPath)
                         << ", size:" << it->size()
                         << ", cos:" << it->cos()
                         << ", sin:" << it->sin()
+                        << ", condition:" << it->condition()
                         << std::endl;
                 }
 


### PR DESCRIPTION
Add the `condition` attribute to the `<Text>` symbol element, matching the pattern already used by `Line`,` Arc`,`Rectangle`,` Arrow`, and `PortSym`.

This enables conditional inclusion/exclusion of text drawing elements based on component name or property values, evaluated by `XmlComponent::evaluateConditionInclude().`

Changes:
- ` Component.xsd`: Add optional `condition ` attribute to `Text `element
- `XmlComponent.h`: Add condition parameter and member to  `Text`struct
- `XmlComponent.cpp`: Guard text rendering with `evaluateConditionInclude()`
- `module_xml.cpp`: Extract condition attribute when parsing XML