### PR TITLE
feat(createNetlist): filter out dangling nets

### DIFF
--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -316,40 +316,37 @@ void AbstractSpiceKernel::createSubNetlist(QTextStream &stream, bool lib)
 }
 
 /*!
- * \brief AbstractSpiceKernel::collectNamedNets gets all of the named nets in the schematic,
+ * \brief AbstractSpiceKernel::getNamedNets gets all of the named nets in the schematic,
  * where a named net is either a node or wire with a label.
- * \param vars QStringList that stores all of the named nets
  * \param dialect SpiceDialect whether or not this is for Xyce/NGSpice
+ * \return QSet of named nets
  */
-void AbstractSpiceKernel::collectNamedNets(QStringList &vars, spicecompat::SpiceDialect dialect)
+QSet<QString> AbstractSpiceKernel::getNamedNets(spicecompat::SpiceDialect dialect)
 {
+    QSet<QString> namedNets;
+
     // iterate over all nodes and save labels
     for (Node *pn : a_schematic->a_DocNodes) {
         if (pn->hasLabel()) {
-            if (!vars.contains(pn->label()->Name)) {
-                vars.append(pn->label()->Name);
-            }
+            namedNets.insert(pn->label()->Name);
         }
     }
 
     // iterate over all wires and save labels
     for (Wire *pw : a_schematic->a_DocWires) {
         if (pw->hasLabel()) {
-            if (!vars.contains(pw->label()->Name)) {
-                vars.append(pw->label()->Name);
-            }
+            namedNets.insert(pw->label()->Name);
         }
     }
 
     // iterate over all probes
     for (Component *pc : a_schematic->a_DocComps) {
         if (pc->isProbe) {
-            const QString var_pr = pc->getProbeVariable(dialect);
-            if (!vars.contains(var_pr)) {
-                vars.append(var_pr);
-            }
+            namedNets.insert(pc->getProbeVariable(dialect));
         }
     }
+
+    return namedNets;
 }
 
 /*!

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -316,6 +316,43 @@ void AbstractSpiceKernel::createSubNetlist(QTextStream &stream, bool lib)
 }
 
 /*!
+ * \brief AbstractSpiceKernel::collectNamedNets gets all of the named nets in the schematic,
+ * where a named net is either a node or wire with a label.
+ * \param vars QStringList that stores all of the named nets
+ * \param dialect SpiceDialect whether or not this is for Xyce/NGSpice
+ */
+void AbstractSpiceKernel::collectNamedNets(QStringList &vars, spicecompat::SpiceDialect dialect)
+{
+    // iterate over all nodes and save labels
+    for (Node *pn : a_schematic->a_DocNodes) {
+        if (pn->hasLabel()) {
+            if (!vars.contains(pn->label()->Name)) {
+                vars.append(pn->label()->Name);
+            }
+        }
+    }
+
+    // iterate over all wires and save labels
+    for (Wire *pw : a_schematic->a_DocWires) {
+        if (pw->hasLabel()) {
+            if (!vars.contains(pw->label()->Name)) {
+                vars.append(pw->label()->Name);
+            }
+        }
+    }
+
+    // iterate over all probes
+    for (Component *pc : a_schematic->a_DocComps) {
+        if (pc->isProbe) {
+            const QString var_pr = pc->getProbeVariable(dialect);
+            if (!vars.contains(var_pr)) {
+                vars.append(var_pr);
+            }
+        }
+    }
+}
+
+/*!
  * \brief AbstractSpiceKernel::slotSimulate Executes simulator
  */
 void AbstractSpiceKernel::slotSimulate()

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -316,12 +316,12 @@ void AbstractSpiceKernel::createSubNetlist(QTextStream &stream, bool lib)
 }
 
 /*!
- * \brief AbstractSpiceKernel::getNamedNets gets all of the named nets in the schematic,
+ * \brief AbstractSpiceKernel::getLabelledNets gets all of the named nets in the schematic,
  * where a named net is either a node or wire with a label.
  * \param dialect SpiceDialect whether or not this is for Xyce/NGSpice
  * \return QSet of named nets
  */
-QSet<QString> AbstractSpiceKernel::getNamedNets(spicecompat::SpiceDialect dialect)
+QSet<QString> AbstractSpiceKernel::getLabelledNets(spicecompat::SpiceDialect dialect)
 {
     QSet<QString> namedNets;
 
@@ -347,6 +347,67 @@ QSet<QString> AbstractSpiceKernel::getNamedNets(spicecompat::SpiceDialect dialec
     }
 
     return namedNets;
+}
+
+/*!
+ * \brief AbstractSpiceKernel::getActiveLabelledNets gets all of the named nets that is connected to
+ * an active or shorted component, in the schematic, where a named net is either a node or wire with a label.
+ * \param dialect SpiceDialect whether or not this is for Xyce/NGSpice
+ * \return QSet of named active nets
+ */
+QSet<QString> AbstractSpiceKernel::getActiveLabelledNets(spicecompat::SpiceDialect dialect)
+{
+    // helper function to add all nodes and wires assosciated with a given node
+    auto insertNodeLabels = [](QSet<QString> &set, Node *pn) {
+        if (!pn) return;
+        if (pn->hasLabel()) set.insert(pn->label()->Name);
+
+        // for wires, we want to add every single node available
+        for (Wire *pw : pn->wires()) {
+            if (pw->hasLabel())         set.insert(pw->label()->Name);
+            if (pw->Port1->hasLabel())  set.insert(pw->Port1->label()->Name);
+            if (pw->Port2->hasLabel())  set.insert(pw->Port2->label()->Name);
+        }
+    };
+    QSet<QString> activeNets;
+    for (Component *pc : a_schematic->a_DocComps) {
+        // we need to add both COMP_IS_SHORTED and COMP_IS_ACTIVE
+        // since COMP_IS_SHORTED adds (valid) resistors
+        if (pc->isActive == COMP_IS_OPEN) continue;
+        // we can't measure the actual probe unless active
+        if (pc->isProbe && pc->isActive == COMP_IS_ACTIVE) {
+            activeNets.insert(pc->getProbeVariable(dialect));
+        }
+        for (Port *pp : pc->Ports) {
+            insertNodeLabels(activeNets, pp->Connection);
+        }
+    }
+
+    return activeNets;
+}
+
+/*!
+ * \brief AbstractSpiceKernel::getValidNets takes the intersection between
+ * AbstractSpiceKernel::getNamedNets and abstractSpiceKernel::getActiveNets
+ * whereas, the discarded set is then the difference.
+ * \param dialect SpiceDialect whether or not this is for Xyce/NGSpice
+ * \return QSet of named active and valid nets
+ */
+QSet<QString> AbstractSpiceKernel::getValidNets(spicecompat::SpiceDialect dialect)
+{
+    QSet<QString> allNets = getLabelledNets(dialect);
+    QSet<QString> activeNets = getActiveLabelledNets(dialect);
+    QSet<QString> discardedNets = allNets - activeNets;
+
+    // log every discarded net for easier debug
+    if (!discardedNets.empty()) {
+        qDebug() << "Netlisting: filtering" << discardedNets.size() << "net(s) attached to disabled components.";
+        for (const QString &name : discardedNets) {
+            qDebug() << "    " << name;
+        }
+    }
+    // intersection between all and activeNets
+    return allNets & activeNets;
 }
 
 /*!

--- a/qucs/extsimkernels/abstractspicekernel.h
+++ b/qucs/extsimkernels/abstractspicekernel.h
@@ -80,6 +80,7 @@ protected:
     virtual void startNetlist(QTextStream& stream, spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
     virtual void createNetlist(QTextStream& stream, int NumPorts,QStringList& simulations,
                                QStringList& vars, QStringList &outputs);
+    void collectNamedNets(QStringList &vars, spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
     void removeAllSimulatorOutputs();
     bool checkGround();
     bool checkSimulations();

--- a/qucs/extsimkernels/abstractspicekernel.h
+++ b/qucs/extsimkernels/abstractspicekernel.h
@@ -80,7 +80,9 @@ protected:
     virtual void startNetlist(QTextStream& stream, spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
     virtual void createNetlist(QTextStream& stream, int NumPorts,QStringList& simulations,
                                QStringList& vars, QStringList &outputs);
-    QSet<QString> getNamedNets(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
+    virtual QSet<QString> getLabelledNets(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
+    virtual QSet<QString> getActiveLabelledNets(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
+    QSet<QString> getValidNets(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
     void removeAllSimulatorOutputs();
     bool checkGround();
     bool checkSimulations();

--- a/qucs/extsimkernels/abstractspicekernel.h
+++ b/qucs/extsimkernels/abstractspicekernel.h
@@ -80,7 +80,7 @@ protected:
     virtual void startNetlist(QTextStream& stream, spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
     virtual void createNetlist(QTextStream& stream, int NumPorts,QStringList& simulations,
                                QStringList& vars, QStringList &outputs);
-    void collectNamedNets(QStringList &vars, spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
+    QSet<QString> getNamedNets(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
     void removeAllSimulatorOutputs();
     bool checkGround();
     bool checkSimulations();

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -110,29 +110,7 @@ void Ngspice::createNetlist(
 
     // set variable names for named nodes and wires
     vars.clear();
-    for(Node *pn : a_schematic->a_DocNodes) {
-      if(pn->hasLabel()) {
-          if (!vars.contains(pn->label()->Name)) {
-            vars.append(pn->label()->Name);
-          }
-      }
-    }
-    for(Wire *pw : a_schematic->a_DocWires) {
-      if(pw->hasLabel()) {
-          if (!vars.contains(pw->label()->Name)) {
-              vars.append(pw->label()->Name);
-          }
-      }
-    }
-
-    for(Component *pc : a_schematic->a_DocComps) {
-        if (pc->isProbe) {
-            QString var_pr = pc->getProbeVariable();
-            if (!vars.contains(var_pr)) {
-                vars.append(var_pr);
-            }
-        }
-    }
+    collectNamedNets(vars);
     vars.sort();
 
     stream << "\n.control\n\n";          //execute simulations

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -109,8 +109,8 @@ void Ngspice::createNetlist(
     }
 
     // set variable names for named nodes and wires
-    QSet<QString> namedNets = getNamedNets();
-    vars = QStringList(namedNets.begin(), namedNets.end());
+    QSet<QString> validNets = getValidNets();
+    vars = QStringList(validNets.begin(), validNets.end());
     vars.sort();
 
     stream << "\n.control\n\n";          //execute simulations

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -109,8 +109,8 @@ void Ngspice::createNetlist(
     }
 
     // set variable names for named nodes and wires
-    vars.clear();
-    collectNamedNets(vars);
+    QSet<QString> namedNets = getNamedNets();
+    vars = QStringList(namedNets.begin(), namedNets.end());
     vars.sort();
 
     stream << "\n.control\n\n";          //execute simulations

--- a/qucs/extsimkernels/xyce.cpp
+++ b/qucs/extsimkernels/xyce.cpp
@@ -79,6 +79,75 @@ void Xyce::determineUsedSimulations(QStringList *sim_lst)
 }
 
 /*!
+ * \brief Xyce::getLabelledNets gets all of the named nets in the schematic,
+ * where a named net is either a node or wire with a label.
+ * \param[in] dialect SpiceDialect whether or not this is for Xyce/NGSpice
+ * \param[out] QSet of named nets
+ */
+QSet<QString> Xyce::getLabelledNets(spicecompat::SpiceDialect dialect/*=spicecompat::SPICEXyce*/)
+{
+    if (!a_DC_OP_only) {
+        return AbstractSpiceKernel::getLabelledNets(dialect);
+    }
+
+    // NOTE: DCOP is a special case since Xyce doesn't have a "print all"
+    // Add all remaining nodes, because XYCE has no equivalent for PRINT ALL
+    QSet<QString> namedNets;
+    for (Node* pn : *a_schematic->a_Nodes) {
+        if (pn->Name == "gnd") continue;
+        namedNets.insert(pn->Name);
+    }
+    for (Component *pc : a_schematic->a_DocComps) {
+        // Probes
+        if (pc->isProbe) {
+            namedNets.insert(pc->getProbeVariable(dialect));
+        }
+        // Add DC sources
+        if ((pc->Model == "S4Q_V") || (pc->Model == "Vdc")) {
+            namedNets.insert("I("+pc->Name+")");
+        }
+    }
+    return namedNets;
+}
+
+/*! \brief Xyce::getActiveLabelledNets gets all of the named nets that is connected to
+ * an active or shorted component, in the schematic, where a named net is either a node or wire with a label.
+ * \param[in] dialect SpiceDialect whether or not this is for Xyce/NGSpice
+ * \param[out] QSet of named active nets
+ */
+QSet<QString> Xyce::getActiveLabelledNets(spicecompat::SpiceDialect dialect/*=spicecompat::SPICEXyce*/)
+{
+
+    if (!a_DC_OP_only) {
+        return AbstractSpiceKernel::getActiveLabelledNets(dialect);
+    }
+
+    // NOTE: DCOP is a special case since Xyce doesn't have a "print all"
+    // Add all node names reachable from active (non-open) components,
+    QSet<QString>activeNets;
+    for (Component *pc : a_schematic->a_DocComps) {
+        // the probe/sources are only valid if active
+        if (pc->isActive != COMP_IS_ACTIVE) continue;
+        // Probes
+        if (pc->isProbe) {
+            activeNets.insert(pc->getProbeVariable(dialect));
+        }
+        // DC sources
+        if ((pc->Model == "S4Q_V") || (pc->Model == "Vdc")) {
+            activeNets.insert("I("+pc->Name+")");
+        }
+
+        // add every node name
+        for (Port *pp : pc->Ports) {
+            Node *pn = pp->Connection;
+            if (!pn || pn->Name == "gnd") continue;
+            activeNets.insert(pn->Name);
+        }
+    }
+    return activeNets;
+}
+
+/*!
  * \brief Xyce::createNetlist
  * \param[out] stream QTextStream that associated with spice netlist file
  * \param[in] simulations The list of simulations that need to included in netlist.
@@ -102,22 +171,8 @@ void Xyce::createNetlist(
     startNetlist(stream, spicecompat::SPICEXyce);
 
     // set variable names for named nodes and wires
-    QSet<QString> namedNets = getNamedNets(spicecompat::SPICEXyce);
-
-    if (a_DC_OP_only) {
-        // Add all remaining nodes, because XYCE has no equivalent for PRINT ALL
-        for(Node* pn : *a_schematic->a_Nodes) {
-            if(pn->Name == "gnd") continue;
-            namedNets.insert(pn->Name);
-        }
-        // Add DC sources
-        for(Component *pc : a_schematic->a_DocComps) {
-             if ((pc->Model == "S4Q_V") || (pc->Model == "Vdc")) {
-                 namedNets.insert("I("+pc->Name+")");
-             }
-        }
-    }
-    vars = QStringList(namedNets.begin(), namedNets.end());
+    QSet<QString> validNets = getValidNets(spicecompat::SPICEXyce);
+    vars = QStringList(validNets.begin(), validNets.end());
     vars.sort();
 
     //execute simulations

--- a/qucs/extsimkernels/xyce.cpp
+++ b/qucs/extsimkernels/xyce.cpp
@@ -103,34 +103,7 @@ void Xyce::createNetlist(
 
     // set variable names for named nodes and wires
     vars.clear();
-    for(Node *pn : a_schematic->a_DocNodes) {
-      if(pn->hasLabel()) {
-          if (!vars.contains(pn->label()->Name)) {
-              vars.append(pn->label()->Name);
-          }
-      }
-    }
-    for(Wire *pw : a_schematic->a_DocWires) {
-      if(pw->hasLabel()) {
-          if (!vars.contains(pw->label()->Name)) {
-              vars.append(pw->label()->Name);
-          }
-      }
-    }
-    for(Component *pc : a_schematic->a_DocComps) {
-        if (pc->isProbe) {
-            QString var_pr = pc->getProbeVariable(spicecompat::SPICEXyce);
-            if (!vars.contains(var_pr)) {
-                vars.append(var_pr);
-            }
-        }
-        /*if (pc->isEquation) {
-            Equation *eq = (Equation *)pc;
-            QStringList vars_eq;
-            eq->getDepVars(vars_eq);
-            vars.append(vars_eq);
-        }*/
-    }
+    collectNamedNets(vars, spicecompat::SPICEXyce);
 
     if (a_DC_OP_only) {
         // Add all remaining nodes, because XYCE has no equivalent for PRINT ALL

--- a/qucs/extsimkernels/xyce.cpp
+++ b/qucs/extsimkernels/xyce.cpp
@@ -102,24 +102,22 @@ void Xyce::createNetlist(
     startNetlist(stream, spicecompat::SPICEXyce);
 
     // set variable names for named nodes and wires
-    vars.clear();
-    collectNamedNets(vars, spicecompat::SPICEXyce);
+    QSet<QString> namedNets = getNamedNets(spicecompat::SPICEXyce);
 
     if (a_DC_OP_only) {
         // Add all remaining nodes, because XYCE has no equivalent for PRINT ALL
         for(Node* pn : *a_schematic->a_Nodes) {
-            if ((!vars.contains(pn->Name))&&(pn->Name!="gnd")) {
-                vars.append(pn->Name);
-            }
+            if(pn->Name == "gnd") continue;
+            namedNets.insert(pn->Name);
         }
         // Add DC sources
         for(Component *pc : a_schematic->a_DocComps) {
-             if ((pc->Model == "S4Q_V")||(pc->Model == "Vdc")) {
-                 vars.append("I("+pc->Name+")");
+             if ((pc->Model == "S4Q_V") || (pc->Model == "Vdc")) {
+                 namedNets.insert("I("+pc->Name+")");
              }
         }
     }
-
+    vars = QStringList(namedNets.begin(), namedNets.end());
     vars.sort();
 
     //execute simulations

--- a/qucs/extsimkernels/xyce.h
+++ b/qucs/extsimkernels/xyce.h
@@ -59,6 +59,8 @@ protected:
             QStringList& vars,
             QStringList& outputs);
 
+    QSet<QString> getLabelledNets(spicecompat::SpiceDialect dialect = spicecompat::SPICEXyce) override;
+    QSet<QString> getActiveLabelledNets(spicecompat::SpiceDialect dialect = spicecompat::SPICEXyce) override;
 protected slots:
     void slotFinished();
     void slotProcessOutput();


### PR DESCRIPTION
What
---

This filters out "dangling" (wires that are connected in the schematic, but not connected in the actual netlist, i.e. floating wires, wires connected only to disabled components etc) nets.

Why
---

Often times during debugging I like to disable sub-circuits, however currently that entails that I need to remove every named/labelled net that is connected to that now disabled sub-circuit.

This causes (IMO) a lot of unnecessary work just for a simple disable-to-debug kind of situation. 

Tests
---

I've done the following sanity checks to verify the functionality:

- NGSpice
  - Netlisting in general
  - Netlisting with disabled components
  - Netlisting with shorted components
- Xyce
  - Netlisting in general
  - Netlisting with disabled components
  - Netlisting with shorted component
  - Repeat the same for DCOP only case
    - Since this is a special case for Xyce

Example
---

Using the testbench:

<img width="1120" height="956" alt="image" src="https://github.com/user-attachments/assets/fe660a2d-743a-462f-af40-9e70407cf159" />

Where INV1 is driven regularly, INV2 is disabled (hence `out_b` is dangling) and INV3 is shorted. 

This netlists to:

```
.LIB cornerMOSlv.lib mos_tt
.INCLUDE sg13g2_stdcell.spice
XINV1 0 out_a in VDD 0 IHP_PDK_stdcells_sg13g2_inv_1
V2 VDD 0 DC 1.2

RINV30 out_c in 1e-12
RINV31 out_c VDD 1e-12
RINV32 out_c 0 1e-12
V1 in 0 DC 0 PULSE(0 1.2 5N 10P 10P {(10N)-(5N)-(10P)-(10P)}) AC 0
```

NOTE: there is no `out_b` here

### Currently

When trying to simulate, you get from NGSpice:

```
Warning from checkvalid: vector out_b is not available or has zero length.
Error during 'write': no writable vector found.
```

And we can confirm this by checking the `PRINT` statement in the netlist itself:

```
print v(VDD) v(in) v(out_a) v(out_b) v(out_c)   > spice4qucs.dc1.ngspice.dc.print
write spice4qucs.tr1.plot v(VDD) v(in) v(out_a) v(out_b) v(out_c)
```

### With this PR

When netlisting using NGSpice it works, and in the output log you get:

```
Debug: Netlisting: filtering 1 net(s) attached to disabled components. (/usr/src/debug/qucs-s-git/qucs-s-git/qucs/extsimkernels/abstractspicekernel.cpp:404, QSet<QString> AbstractSpiceKernel::getValidNets(spicecompat::SpiceDialect))
Debug:      "out_b" (/usr/src/debug/qucs-s-git/qucs-s-git/qucs/extsimkernels/abstractspicekernel.cpp:406, QSet<QString> AbstractSpiceKernel::getValidNets(spicecompat::SpiceDialect))
Debug:
```

And we can confirm that the save statement is changed relative to the current behavior above:

```
print v(VDD) v(in) v(out_a) v(out_c)   > spice4qucs.dc1.ngspice.dc.print
write spice4qucs.tr1.plot v(VDD) v(in) v(out_a) v(out_c)
``` 

NOTE/TODOs
---

Without going into it, there might be some additional checking/sanity checks that should be done for the dependent equations, where the case could now be that we filter the net, which then causes the equation to fail instead. 

I _think_ the behavior here is the same as on current, so this doesn't introduce any "breaking changes", but it should be noted as a weakness overall. 