### PR TITLE
Don't reload graph data on every interaction

### DIFF
--- a/qucs/diagrams/graph.cpp
+++ b/qucs/diagrams/graph.cpp
@@ -459,6 +459,10 @@ void Graph::drawLines(QPainter* painter) const {
   }
   painter->setPen(pen);
 
+  if ( ! linesCalculated.isValid()
+    || ! lastLoaded.isValid()
+    || lastLoaded > linesCalculated) {//Start lines (re)calculation
+
   // How graphs are drawn
   //
   // Graph object (this) contains a set of data points,
@@ -505,6 +509,7 @@ void Graph::drawLines(QPainter* painter) const {
   //
   // With this knowledge we can now calculate thresholds for our dataset.
 
+
   constexpr double min_pixels = 1.0;  // I can be wrong here, but I believe these are pixels…
   const double x_threshold = std::abs(min_pixels / painter->transform().m11());
   const double y_threshold = std::abs(min_pixels / painter->transform().m22());
@@ -519,7 +524,7 @@ void Graph::drawLines(QPainter* painter) const {
   QPointF segment_start;
   QPointF segment_end;
 
-  QList<QLineF> lines, *drawLines = &lines;
+  lines.clear();
 
   for (const auto& point : *this) {
     // No more data points
@@ -603,11 +608,15 @@ void Graph::drawLines(QPainter* painter) const {
       }
     }
 
-    printf("GRAPH: reduced: %d -> %d lines\n", (int)lines.size(), (int)joint_lines.size());
-    drawLines = &joint_lines; // Switch to optimized list of lines
+    qDebug() << QString("GRAPH: reduced: %1 -> %2 lines\n").arg(lines.size()).arg(joint_lines.size());
+    lines = QList<QLineF>(std::begin(joint_lines), std::end(joint_lines)); // Switch to optimized list of lines
   }
 
-  painter->drawLines(*drawLines);
+  linesCalculated = QDateTime::currentDateTime();
+
+  }//finish lines calculation
+
+  painter->drawLines(lines);
   painter->restore();
 }
 

--- a/qucs/diagrams/graph.h
+++ b/qucs/diagrams/graph.h
@@ -146,7 +146,7 @@ public:
   QVector<DataX*>& mutable_axes(){return cPointsX;} // HACK
 
   void clear(){ScrPoints.resize(0);}
-  void resizeScrPoints(size_t s){assert(s>=ScrPoints.size()); ScrPoints.resize(s);}
+  void resizeScrPoints(size_t s){assert(s>=ScrPoints.size()); ScrPoints.resize(s); linesInvalidate();}
   iterator begin(){return ScrPoints.begin();}
   iterator end(){return ScrPoints.end();}
   const_iterator begin() const{return ScrPoints.begin();}
@@ -179,6 +179,10 @@ private:
   QVector<DataX*>  cPointsX;
   std::vector<ScrPt> ScrPoints; // data in screen coordinates
   Diagram const* diagram;
+
+  mutable QList<QLineF> lines;
+  mutable QDateTime     linesCalculated;
+  void linesInvalidate() {linesCalculated = QDateTime();} //Set to 'null' date
 };
 
 #endif


### PR DESCRIPTION
I have received a patch providing a fix for #1598 by email. This PR reloads graph data only if it was changes.  