### PR TITLE
feat(Xyce): expand environment variables when using 'include', 'lib' and 'include script'

### DIFF
--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -194,7 +194,7 @@ void AbstractSpiceKernel::startNetlist(QTextStream &stream, spicecompat::SpiceDi
         for(Component *pc : a_schematic->a_DocComps) {
             if ((pc->SpiceModel==".FUNC")||
                 (pc->SpiceModel=="INCLSCR")) {
-                s = pc->getExpression();
+                s = pc->getExpression(dialect);
                 stream<<s;
             }
         }

--- a/qucs/misc.cpp
+++ b/qucs/misc.cpp
@@ -379,6 +379,38 @@ QString misc::properName(const QString& Name)
 }
 
 // #########################################################################
+// Takes a string and expands all $VAR/${VAR} environment variables
+// NOTE: This doesn't do recursive expansion.
+QString misc::expandEnvVars(const QString& input)
+{
+  QString result = input;
+  // Group 1: ${VAR} (braces), Group 2: $VAR (alphanumeric/underscore)
+  static const QRegularExpression envVarRegex(R"(\$\{([^}]+)\}|\$([A-Za-z_]\w*))");
+
+  QList<QRegularExpressionMatch> matches;
+  auto it = envVarRegex.globalMatch(result);
+  while (it.hasNext()) {
+      matches.append(it.next());
+  }
+
+  // Iterate from back of the string, to maintain valid string offsets during replacement
+  for (int i = matches.size() - 1; i >= 0; --i) {
+      const auto& match = matches.at(i);
+
+      // Check if either brace (Group 1) or alphanumeric group (Group 2) matched
+      QString varName = match.captured(1).isEmpty() ? match.captured(2) : match.captured(1);
+      QString envValue = qEnvironmentVariable(varName.toUtf8());
+
+      // Replace captured group with expanded value of environment variable (only if it exists)
+      if (!envValue.isNull()) {
+          result.replace(match.capturedStart(), match.capturedLength(), envValue);
+      }
+  }
+
+  return result;
+}
+
+// #########################################################################
 // Creates and returns delay time for VHDL entities.
 bool misc::VHDL_Delay(QString& td, const QString& Name)
 {

--- a/qucs/misc.h
+++ b/qucs/misc.h
@@ -48,6 +48,7 @@ namespace misc {
   bool    Verilog_Delay(QString&, const QString&);
   QString Verilog_Param(const QString);
   bool    checkVersion(QString&);
+  QString expandEnvVars(const QString&);
 
   inline const QColor getWidgetForegroundColor(const QWidget *q)
   { return q->palette().color(q->foregroundRole()); }

--- a/qucs/spicecomponents/incl_script.cpp
+++ b/qucs/spicecomponents/incl_script.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 #include "incl_script.h"
 #include "main.h"
+#include "misc.h"
 #include <QFontInfo>
 #include <QFontMetrics>
 
@@ -81,5 +82,12 @@ QString InclScript::getExpression(spicecompat::SpiceDialect dialect /* = spiceco
 {
     if (isActive != COMP_IS_ACTIVE || dialect == spicecompat::CDL)
         return QString();
-    return Props.at(0)->Value+"\n";
+
+    QString includeCode = Props.at(0)->Value;
+
+    // manually replace environment variables when using Xyce.
+    if (dialect == spicecompat::SPICEXyce) {
+      includeCode = misc::expandEnvVars(includeCode);
+    }
+    return includeCode + "\n";
 }

--- a/qucs/spicecomponents/sp_func.cpp
+++ b/qucs/spicecomponents/sp_func.cpp
@@ -77,7 +77,7 @@ QString SpiceFunc::getExpression(spicecompat::SpiceDialect dialect /* = spicecom
     QString s;
     s.clear();
     for (Property *pp : Props) {
-        if (QucsSettings.DefaultSimulator==spicecompat::simXyce)
+        if (dialect == spicecompat::SPICEXyce)
             s += QStringLiteral(".FUNC %1 %2\n").arg(pp->Name).arg(pp->Value);
         else s += QStringLiteral(".FUNC %1 = %2\n").arg(pp->Name).arg(pp->Value);
     }

--- a/qucs/spicecomponents/sp_include.cpp
+++ b/qucs/spicecomponents/sp_include.cpp
@@ -84,6 +84,10 @@ QString S4Q_Include::getSpiceLibrary()
     for (Property *pp : Props) {
         QString val = pp->Value;
         if (!val.isEmpty()) {
+            // manually expand env. vars for Xyce
+            if (QucsSettings.DefaultSimulator == spicecompat::simXyce) {
+              val = misc::expandEnvVars(val);
+            }
             val = misc::properAbsFileName(val, containingSchematic);
             switch (QucsSettings.DefaultSimulator) {
             case spicecompat::simSpiceOpus: // Spice Opus doesn't support quotes

--- a/qucs/spicecomponents/sp_lib.cpp
+++ b/qucs/spicecomponents/sp_lib.cpp
@@ -79,6 +79,10 @@ QString S4Q_Lib::getSpiceLibrary()
 
   QString file = getProperty("File")->Value;
   if ( !file.isEmpty() ){
+    // manually expand env. vars for Xyce
+    if (QucsSettings.DefaultSimulator == spicecompat::simXyce) {
+      file = misc::expandEnvVars(file);
+    }
     file = misc::properAbsFileName(file, containingSchematic);
     QString sec = getProperty("Section")->Value;
     s += QStringLiteral("%1 \"%2\" %3\n").arg(SpiceModel).arg(file).arg(sec);


### PR DESCRIPTION
## What

Expands environment variables when using Xyce as the default simulator and in the case where one uses either '.INCLUDE', '.LIB' and 'include script' blocks in Qucs-S.

## Why

This is to make the schematics slightly more portable, by allowing for env. variables rather than using absolute paths.
This also makes it closer to what NGSpice currently supports (natively).

## Example

Using the [IHP PDK](https://github.com/IHP-GmbH/IHP-Open-PDK) as a reference in this case, when using an include script such as:

<img width="50%" height="363" alt="image" src="https://github.com/user-attachments/assets/fd51d6e2-cf03-4a08-a71f-eb47e536eee9" />

 And when looking at the netlist, I now get: 
 
 ```
.LIB /home/torleif/git/OSIC/IHP-Open-PDK/ihp-sg13g2/libs.tech/xyce/models/cornerMOSlv.lib mos_tt
.LIB /home/torleif/git/OSIC/IHP-Open-PDK/ihp-sg13g2/libs.tech/xyce/models/cornerMOShv.lib mos_tt
.LIB /home/torleif/git/OSIC/IHP-Open-PDK/ihp-sg13g2/libs.tech/xyce/models/cornerHBT.lib hbt_typ
.LIB /home/torleif/git/OSIC/IHP-Open-PDK/ihp-sg13g2/libs.tech/xyce/models/cornerRES.lib res_typ
.LIB /home/torleif/git/OSIC/IHP-Open-PDK/ihp-sg13g2/libs.tech/xyce/models/cornerCAP.lib cap_typ
.LIB /home/torleif/git/OSIC/IHP-Open-PDK/ihp-sg13g2/libs.tech/xyce/models/cornerDIO.lib dio_tt

.INCLUDE /home/torleif/git/OSIC/IHP-Open-PDK/ihp-sg13g2/libs.ref/sg13g2_stdcell/spice/sg13g2_stdcell.spice
 ```
 
 where:
 
 - `$PDK_ROOT=/home/torleif/git/OSIC/IHP-Open-PDK/`
 - `$PDK=ihp-sg13g2`
 
 In `current` this wouldn't  be able to be simulated in Xyce, since it doesn't expand environment variables natively (unlike NGSpice).
 
This is also tested on `.LIB` and `.INCLUDE` blocks:

<img width="50%" height="305" alt="image" src="https://github.com/user-attachments/assets/0b88a2d2-7187-4c67-9e3d-217fd0c965d3" />
