### PR TITLE
fix(port): handle empty case (terminated port)

### DIFF
--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -71,6 +71,8 @@ Source_ac::Source_ac()
         QObject::tr("simulation temperature in degree Celsius")));
   Props.append(new Property("EnableTran", "true", false,
     QObject::tr("enable transient model as sine source [true,false]")));
+  Props.append(new Property("LoadOnly", "false", false,
+    QObject::tr("disable as a source (AC and transient), passive termination only [true,false]")));
 
   rotate();  // fix historical flaw
 }
@@ -120,8 +122,9 @@ QString Source_ac::ngspice_netlist()
     // Check if P is a symbolic parameter (not a numeric dBm literal)
     bool isNumeric = false;
     spicecompat::normalize_value(pVal).toDouble(&isNumeric);
+    // if user has explicitly set LoadOnly OR
     // if P is empty (unset), the port acts as a terminated port (a passive load).
-    bool isTermination = pVal.isEmpty();
+    bool isTermination = (getProperty("LoadOnly")->Value == "true") || pVal.isEmpty();
 
     QString vamp;
     if (isTermination) {
@@ -179,8 +182,9 @@ QString Source_ac::xyce_netlist()
     // Check if P is a symbolic parameter (not a numeric dBm literal)
     bool isNumeric = false;
     double p = spicecompat::normalize_value(pVal).toDouble(&isNumeric);
+    // if user has explicitly set LoadOnly OR
     // if P is empty (unset), the port acts as a terminated port (a passive load).
-    bool isTermination = pVal.isEmpty();
+    bool isTermination = (getProperty("LoadOnly")->Value == "true") || pVal.isEmpty();
 
     QString vamp;
     if (isTermination) {

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -120,9 +120,14 @@ QString Source_ac::ngspice_netlist()
     // Check if P is a symbolic parameter (not a numeric dBm literal)
     bool isNumeric = false;
     spicecompat::normalize_value(pVal).toDouble(&isNumeric);
+    // if P is empty (unset), the port acts as a terminated port (a passive load).
+    bool isTermination = pVal.isEmpty();
 
     QString vamp;
-    if (isNumeric) {
+    if (isTermination) {
+      // Terminated port: set Vamp to 0
+      s += QStringLiteral(" dc 0 ac 0");
+    } else if (isNumeric) {
       // Original behaviour: pre-compute amplitude
       double p = spicecompat::normalize_value(pVal).toDouble();
       double vrms = sqrt(z0/1000.0) * pow(10, p/20.0);
@@ -174,9 +179,14 @@ QString Source_ac::xyce_netlist()
     // Check if P is a symbolic parameter (not a numeric dBm literal)
     bool isNumeric = false;
     double p = spicecompat::normalize_value(pVal).toDouble(&isNumeric);
+    // if P is empty (unset), the port acts as a terminated port (a passive load).
+    bool isTermination = pVal.isEmpty();
 
     QString vamp;
-    if (isNumeric) {
+    if (isTermination) {
+      // Terminated port: set Vamp to 0
+      vamp = QString::number(0);
+    } else if (isNumeric) {
       // Fixed value (not part of a parametric simulation)
       double vrms = sqrt(z0 / 1000.0) * pow(10.0, p / 20.0);
       double vamp_val = 2.0 * vrms * sqrt(2.0);
@@ -191,7 +201,7 @@ QString Source_ac::xyce_netlist()
 
     s += QStringLiteral(" z0=%1 ").arg(s_z0);
     s += QStringLiteral(" AC %1 ").arg(vamp);
-    if (en_tran) {
+    if (en_tran && !isTermination) {
         s += QStringLiteral(" SIN 0 %1 %2").arg(vamp, f);
     }
     s += "\n";


### PR DESCRIPTION
## What

This allows to netlist ports when power is unset.
The assumption is that the user then wants a terminated (passive) load, i.e. we set the AC (and transient) voltage to 0 V.

## Why

Since the changes #1617, if we have an unset power parameter, we hit the "symbolic" branch of the power calculation, giving us an expression where we are dependent on the power value/parameter.

However, that is unset in this particular case, causing a netlisting error.

## Example

Take this simple testbench:

<img width="1094" height="1031" alt="image" src="https://github.com/user-attachments/assets/2e9d88ca-e38b-4ae9-9d45-fbed5e2b5492" />

Where P1 has a set power, and P2 has an unset power.

### Current

If I try to netlist this using NGSpice I end up with:

```
VP1 _net0 0 dc 0 ac 2 portnum 1 z0 50
VP2 _net1 0 dc 0 ac '2*sqrt(2)*sqrt(50/1000)*pow(10,()/20)' portnum 2 z0 50
                                                    ^^^
                                           Empty pow parameter
```

### This PR

```
VP1 _net0 0 dc 0 ac 2 portnum 1 z0 50
VP2 _net1 0 dc 0 ac 0 portnum 2 z0 50
```

Here I am explicitly setting AC voltage to 0 V (and transient voltage if that was part of the schematic), and NGSpice can run on this netlist.

Note: Also verified the behavior on Xyce