### PR TITLE
fix(SpiceLibComp): pin parsing and dialog input validation

### DIFF
--- a/qucs/extsimkernels/spicecompat.cpp
+++ b/qucs/extsimkernels/spicecompat.cpp
@@ -302,6 +302,7 @@ int spicecompat::getPins(const QString &file, const QString &compname, QStringLi
                 break;
               } else {
                 pin_names.append(pin);
+                r++;
               }
             }
           } else {
@@ -325,10 +326,9 @@ int spicecompat::getPins(const QString &file, const QString &compname, QStringLi
                 if (!s1.contains('=') &&
                    (pp.toLower() != "params:")) {
                     pin_names.append(s1);
+                    r++;
                 }
             }
-            r = pin_names.count();
-            //break;
         }
     }
 

--- a/qucs/spicecomponents/spicelibcomp.cpp
+++ b/qucs/spicecomponents/spicelibcomp.cpp
@@ -230,9 +230,26 @@ QString SpiceLibComp::spice_netlist(spicecompat::SpiceDialect dialect /* = spice
       s += " " + spicecompat::normalize_node_name(p1->Connection->Name);
     }
   } else {
-    QStringList pin_nums = pins.split(";");
-    for (int i = 0; i < pin_nums.count(); i++) {
-      int pn = pin_nums.at(i).toInt();
+    // Sanitize input from dialog
+    QStringList pin_nums = pins.split(";", Qt::SkipEmptyParts);
+    int pinCount = pin_nums.count();
+    int portCount = Ports.count();
+
+    if (pinCount != portCount) {
+      qWarning() << "pinCount=" << pinCount << " != portCount=" << portCount << ", malformed input?";
+    }
+
+    for (int i = 0; i < pinCount; i++) {
+      bool isNumber = false;
+      int pn = pin_nums.at(i).trimmed().toInt(&isNumber);
+      if (!isNumber) {
+        qWarning() << "Invalid pin number:" << pin_nums.at(i) << "; skipping";
+        continue;
+      }
+      if (pn < 1 || pn > portCount) {
+        qWarning() << "Pin number out of range:" << pn << "; skipping";
+        continue;
+      }
       Port *pp = Ports.at(pn-1);
       s += " " + spicecompat::normalize_node_name(pp->Connection->Name);
     }


### PR DESCRIPTION
## What

- `spicecompat::getPins`: Fixes incorrect pin counting when subcircuits span multiple lines.
- `SpiceLibComp::spice_netlist`: input sanitation and validation, to handle malformed dialog input. 

## Why

- `getPins` previously only updated the pin count based on the initial definition line, even though all pins were correctly added to the list. This caused a mismatch between the reported pin count and the actual list of pins. 
- `spice_netlist` triggered a crash (SIGABRT) when encountering empty or invalid pin inputs from the dialog. Duplicate separators caused the split logic to produce empty strings, leading to an out-of-bounds access (`Ports.at(-1)`)

## How

- `getPins`: Switched to incrementing the pin counter on every append.

- `SpiceLibComp::spice_netlist`:
  - Split input using `Qt::SkipEmptyParts` to avoid duplicated separators
  - Added bounds checking, and type validation before trying to access `Ports`.
  - Added logging through `qWarning` in case we see any "malformed" inputs.
  
## Example

Using the same setup as in #1632, it now parses the ports correctly and we now get:

<img width="1260" height="920" alt="image" src="https://github.com/user-attachments/assets/3e0f5a10-54ff-4e7d-b9ff-a249c0bffde0" />

  
  
fixes: #1632 