### PR TITLE
fix(saveAs): append '.sym' for symbol files

### DIFF
--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -1919,8 +1919,14 @@ bool QucsApp::saveAs()
       // if no extension was specified or is unknown
       if (!isTextDocument (w))
       {
-        // assume it is a schematic
-        s += ".sch";
+        // if it's a symbol, we add .sym
+        Schematic *sch = dynamic_cast<Schematic*>(Doc);
+        if (sch != nullptr && sch->getIsSymbolOnly()) {
+          s += ".sym";
+        } else {
+          // otherwise assume it is a schematic
+          s += ".sch";
+        }
       }
     }
 


### PR DESCRIPTION
For symbols, append `.sym` rather than using the default `.sch`.
This also matches the symbol filter that is shown to the user.

## Test

1. Open a new symbol file
2. Save as -> new file without any extension
3. Check that the new file has `.sym`