### PR TITLE
fix(Xyce): prevent segfault when netlisting without simulations

### DIFF
--- a/qucs/extsimkernels/xyce.cpp
+++ b/qucs/extsimkernels/xyce.cpp
@@ -198,10 +198,15 @@ void Xyce::createNetlist(
         return;
     }
 
-    QString sim = simulations.first();
+    // In case we want to save the netlist, the simulations list might be empty,
+    // guard against that case.
+    QString sim = simulations.isEmpty() ? QString() : simulations.first();
     QStringList spar_vars;
     for(Component *pc : a_schematic->a_DocComps) { // Xyce can run
        if(pc->isSimulation && pc->isActive == COMP_IS_ACTIVE) {                        // only one simulations per time.
+           // if we don't have any active simulations, skip the netlisting here
+           if (sim.isEmpty()) continue;
+
            QString sim_typ = pc->Model;              // Multiple simulations are forbidden.
            QString s = pc->getSpiceNetlist(spicecompat::SPICEXyce);
            if ((sim_typ==".AC")&&(sim=="ac")) stream<<s;
@@ -259,6 +264,12 @@ void Xyce::createNetlist(
            }
            if ((sim_typ==".DC")) stream<<s;
        }
+    }
+
+    // In the case we have no simulations, end the netlisting here
+    if (sim.isEmpty()) {
+        stream<<".END\n";
+        return;
     }
 
     if (sim.startsWith("XYCESCR")) {


### PR DESCRIPTION
When generating an Xyce netlist for a schematic without active simulation components, the simulations list is empty. Accessing `simulations.first()` caused a crash. 

This patch adds a safety guard and ensures the netlist is still validly terminated with `.END`.

NOTE: This segfault is only seen when trying to do `Simulation->Save netlist`, not in the regular "netlist and run" case, since that has an explicit check for empty simulation list. 

## Test case

A simple test case would be to add a subcircuit and then trying to save the netlist, e.g.:

<img width="1142" height="774" alt="image" src="https://github.com/user-attachments/assets/e32ab8af-426a-4b84-a45e-c802093f12c3" />

Then going to `Simulation->Save netlist` and try to save the netlist.

### Current

In `current`, this will segfault with:

```
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
#1  0x00007ffff5ea7af3 in __pthread_kill_internal (threadid=<optimized out>, signo=6) at pthread_kill.c:89
#2  0x00007ffff5e4d1a0 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007ffff5e345fe in __GI_abort () at abort.c:77
#4  0x00007ffff6496814 in qAbort () at /usr/src/debug/qt6-base/qtbase/src/corelib/global/qassert.cpp:46
#5  qt_maybe_message_fatal<QString&> (msgType=QtFatalMsg, context=<optimized out>, message=...) at /usr/src/debug/qt6-base/qtbase/src/corelib/global/qlogging.cpp:2169
#6  qt_message(QtMsgType, const QMessageLogContext &, const char *, typedef __va_list_tag __va_list_tag *)
    (msgType=msgType@entry=QtFatalMsg, context=..., msg=msg@entry=0x7ffff68a2d00 "ASSERT: \"%s\" in file %s, line %d", ap=ap@entry=0x7fffffffa888)
    at /usr/src/debug/qt6-base/qtbase/src/corelib/global/qlogging.cpp:412
#7  0x00007ffff64975d8 in QMessageLogger::fatal (this=<optimized out>, msg=0x7ffff68a2d00 "ASSERT: \"%s\" in file %s, line %d")
    at /usr/src/debug/qt6-base/qtbase/src/corelib/global/qlogging.cpp:901
#8  0x00007ffff6494bb6 in qt_assert (assertion=<optimized out>, file=<optimized out>, line=<optimized out>) at /usr/src/debug/qt6-base/qtbase/src/corelib/global/qassert.cpp:117
#9  0x0000555555611625 in QList<QString>::first (this=0x555555ceec60) at /usr/include/qt6/QtCore/qlist.h:715
#10 0x0000555555a6147c in Xyce::createNetlist (this=0x555555ceeb80, stream=..., simulations=..., vars=..., outputs=...)
--Type <RET> for more, q to quit, c to continue without paging--c
    at /usr/src/debug/qucs-s-git/qucs-s-git/qucs/extsimkernels/xyce.cpp:201
#11 0x0000555555a640a3 in Xyce::SaveNetlist (this=0x555555ceeb80, filename=..., netlist2Console=false) at /usr/src/debug/qucs-s-git/qucs-s-git/qucs/extsimkernels/xyce.cpp:409
#12 0x0000555555a3b509 in ExternSimDialog::slotSaveNetlist (this=0x7fffffffb788) at /usr/src/debug/qucs-s-git/qucs-s-git/qucs/extsimkernels/externsimdialog.cpp:320
#13 0x000055555561ad47 in QucsApp::slotSaveNetlist (this=0x5555562e44b0) at /usr/src/debug/qucs-s-git/qucs-s-git/qucs/qucs.cpp:3750
```

where `Frame #10` is the culprit with:

```
#10 0x0000555555a6147c in Xyce::createNetlist (this=0x555555ceeb80, stream=..., simulations=..., vars=..., outputs=...)
    at /usr/src/debug/qucs-s-git/qucs-s-git/qucs/extsimkernels/xyce.cpp:201
201	    QString sim = simulations.first();
```

### This PR

With this PR I am able to save the netlist as:

```
* Qucs 26.1.0  /home/torleif/QucsWorkspace/test_prj/nor3.sch

.SUBCKT IHP_PDK_stdcells_sg13g2_nor3_2  gnd Y A B C VDD VSS 
Xnor3_2 Y A B C VDD VSS sg13g2_nor3_2
.ENDS
  
XNOR1 0 y a b c vdd vss IHP_PDK_stdcells_sg13g2_nor3_2
.END
```

Note: Tested this for NGSpice as well, and that works "as is"