### PR TITLE
feat(frames): Add large frames; A2, A1 and A0

### DIFF
--- a/qucs/dialogs/settingsdialog.cpp
+++ b/qucs/dialogs/settingsdialog.cpp
@@ -124,37 +124,37 @@ SettingsDialog::SettingsDialog(Schematic *Doc_)
     // versions.
     // It makes sense to put all the DIN A standard formats together, so a function is needed to
     // decouple the frame index from the frame combobox
-    auto addFrameItem = [this](QComboBox* cb, const QString& text, int code) {
+    auto addFrameItem = [this](QComboBox* cb, const QString& text, FrameSize code) {
         cb->addItem(text);
         int idx = cb->count() - 1;
-        cb->setItemData(idx, code, Qt::UserRole); // code == a_showFrame / <showFrame>
+        cb->setItemData(idx, static_cast<int>(code), Qt::UserRole); // code == a_showFrame / <showFrame>
     };
 
 
     // Visual order: all DIN A paper formats, then Letter
 
     // No frame
-    addFrameItem(Combo_Frame, tr("no Frame"),          0);
+    addFrameItem(Combo_Frame, tr("no Frame"),          FrameSize::None);
 
     // DIN A formats
-    addFrameItem(Combo_Frame, tr("DIN A0 landscape"), 15);
-    addFrameItem(Combo_Frame, tr("DIN A0 portrait"),  16);
-    addFrameItem(Combo_Frame, tr("DIN A1 landscape"), 13);
-    addFrameItem(Combo_Frame, tr("DIN A1 portrait"),  14);
-    addFrameItem(Combo_Frame, tr("DIN A2 landscape"), 11);
-    addFrameItem(Combo_Frame, tr("DIN A2 portrait"),  12);
-    addFrameItem(Combo_Frame, tr("DIN A3 landscape"),  5);
-    addFrameItem(Combo_Frame, tr("DIN A3 portrait"),   6);
-    addFrameItem(Combo_Frame, tr("DIN A4 landscape"),  3);
-    addFrameItem(Combo_Frame, tr("DIN A4 portrait"),   4);
-    addFrameItem(Combo_Frame, tr("DIN A5 landscape"),  1);
-    addFrameItem(Combo_Frame, tr("DIN A5 portrait"),   2);
-    addFrameItem(Combo_Frame, tr("DIN A6 landscape"), 9);
-    addFrameItem(Combo_Frame, tr("DIN A6 portrait"),  10);
+    addFrameItem(Combo_Frame, tr("DIN A0 landscape"), FrameSize::A0_Landscape);
+    addFrameItem(Combo_Frame, tr("DIN A0 portrait"),  FrameSize::A0_Portrait);
+    addFrameItem(Combo_Frame, tr("DIN A1 landscape"), FrameSize::A1_Landscape);
+    addFrameItem(Combo_Frame, tr("DIN A1 portrait"),  FrameSize::A1_Portrait);
+    addFrameItem(Combo_Frame, tr("DIN A2 landscape"), FrameSize::A2_Landscape);
+    addFrameItem(Combo_Frame, tr("DIN A2 portrait"),  FrameSize::A2_Portrait);
+    addFrameItem(Combo_Frame, tr("DIN A3 landscape"), FrameSize::A3_Landscape);
+    addFrameItem(Combo_Frame, tr("DIN A3 portrait"),  FrameSize::A3_Portrait);
+    addFrameItem(Combo_Frame, tr("DIN A4 landscape"), FrameSize::A4_Landscape);
+    addFrameItem(Combo_Frame, tr("DIN A4 portrait"),  FrameSize::A4_Portrait);
+    addFrameItem(Combo_Frame, tr("DIN A5 landscape"), FrameSize::A5_Landscape);
+    addFrameItem(Combo_Frame, tr("DIN A5 portrait"),  FrameSize::A5_Portrait);
+    addFrameItem(Combo_Frame, tr("DIN A6 landscape"), FrameSize::A6_Landscape);
+    addFrameItem(Combo_Frame, tr("DIN A6 portrait"),  FrameSize::A6_Portrait);
 
     // US Letter format
-    addFrameItem(Combo_Frame, tr("Letter landscape"),  7);
-    addFrameItem(Combo_Frame, tr("Letter portrait"),   8);
+    addFrameItem(Combo_Frame, tr("Letter landscape"),  FrameSize::Letter_Landscape);
+    addFrameItem(Combo_Frame, tr("Letter portrait"),   FrameSize::Letter_Portrait);
 
     gp3->addWidget(Combo_Frame, 0, 0, 1, 2);
 

--- a/qucs/dialogs/settingsdialog.cpp
+++ b/qucs/dialogs/settingsdialog.cpp
@@ -137,6 +137,12 @@ SettingsDialog::SettingsDialog(Schematic *Doc_)
     addFrameItem(Combo_Frame, tr("no Frame"),          0);
 
     // DIN A formats
+    addFrameItem(Combo_Frame, tr("DIN A0 landscape"), 15);
+    addFrameItem(Combo_Frame, tr("DIN A0 portrait"),  16);
+    addFrameItem(Combo_Frame, tr("DIN A1 landscape"), 13);
+    addFrameItem(Combo_Frame, tr("DIN A1 portrait"),  14);
+    addFrameItem(Combo_Frame, tr("DIN A2 landscape"), 11);
+    addFrameItem(Combo_Frame, tr("DIN A2 portrait"),  12);
     addFrameItem(Combo_Frame, tr("DIN A3 landscape"),  5);
     addFrameItem(Combo_Frame, tr("DIN A3 portrait"),   6);
     addFrameItem(Combo_Frame, tr("DIN A4 landscape"),  3);

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -320,7 +320,13 @@ bool Schematic::sizeOfFrame(int &xall, int &yall)
     case FrameSize::A6_Landscape: xall =  660; yall =  465; break; // DIN A6 landscape
     case FrameSize::A6_Portrait:  xall =  465; yall =  660; break; // DIN A6 portrait
     // A7 and above formats are too small and the title box doesn't fit in the frame
-    // A0, A1, and A2 are huge
+    // NOTE: A0, A1, and A2 are very large formats
+    case FrameSize::A2_Landscape: xall = 3315; yall = 2295; break; // DIN A2 landscape
+    case FrameSize::A2_Portrait:  xall = 2295; yall = 3315; break; // DIN A2 portrait
+    case FrameSize::A1_Landscape: xall = 5100; yall = 3315; break; // DIN A1 landscape
+    case FrameSize::A1_Portrait:  xall = 3315; yall = 5100; break; // DIN A1 portrait
+    case FrameSize::A0_Landscape: xall = 7650; yall = 5100; break; // DIN A0 landscape
+    case FrameSize::A0_Portrait:  xall = 5100; yall = 7650; break; // DIN A0 portrait
 
     // US letter format
     case FrameSize::Letter_Landscape: xall = 1414; yall = 1054; break; // Letter landscape

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -84,6 +84,8 @@ enum class FrameSize : int {
     None              = 0,
 
     // DIN A formats
+    // A6 format was added later, so its index must be >8 to guarantee backward compatibility with older Qucs-S
+    // versions.
     A6_Landscape      = 9,
     A6_Portrait       = 10,
     A5_Landscape      = 1,
@@ -92,6 +94,12 @@ enum class FrameSize : int {
     A4_Portrait       = 4,
     A3_Landscape      = 5,
     A3_Portrait       = 6,
+    A2_Landscape      = 11,
+    A2_Portrait       = 12,
+    A1_Landscape      = 13,
+    A1_Portrait       = 14,
+    A0_Landscape      = 15,
+    A0_Portrait       = 16,
 
     // US Letter
     Letter_Landscape  = 7,


### PR DESCRIPTION
## What

This adds DIN A{2,1,0} frames

## Why

I have some massive subcircuits, where A3 was too small...

## How

The dimensions were derived by multiplying the previous format's dimensions by sqrt(2) (approx. 1.5) and rounding up to the nearest column/row step size (to avoid partial columns/rows at the frame edge), giving: 

- (already implemented) `A3_landscape`: 9 columns
- `A2_landscape`:  13 columns
- `A1_landscape`:  20 columns
- `A0_landscape`: 30 columns

**Refactor**

Refactored `addFrameItem` helper function such that we pass `FrameSize` enum values directly instead of manually specifying raw integer values.