### PR TITLE
System Command component: Add terminal emulator field

### DIFF
--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -411,6 +411,15 @@ ComponentDialog::ComponentDialog(Component* schematicComponent, Schematic* schem
       checkLayout->addWidget(cmdHoldCheck);
       checkLayout->addStretch();
       editorLayout->addLayout(checkLayout);
+
+
+      QHBoxLayout* terminalLayout = new QHBoxLayout;
+      terminalLayout->addWidget(new QLabel(tr("Terminal emulator:"), this));
+      cmdTerminalEdit = new QLineEdit(this);
+      cmdTerminalEdit->setPlaceholderText(tr("Leave empty for auto-detection"));
+      terminalLayout->addWidget(cmdTerminalEdit);
+      editorLayout->addLayout(terminalLayout);
+
     } else if (!paramsHiddenBySim["Export"].contains(component->Model)) {
       QHBoxLayout* exportLayout = new QHBoxLayout;
       eqnExportCheck = new QCheckBox(tr("Put result in dataset"), this);
@@ -759,6 +768,9 @@ void ComponentDialog::updateEqnEditor()
       if (prop->Name == "hold" && cmdHoldCheck) {
         cmdHoldCheck->setCheckState(prop->Value == "yes" ? Qt::Checked : Qt::Unchecked);
       }
+      if (prop->Name == "terminal" && cmdTerminalEdit) {
+        cmdTerminalEdit->setText(prop->Value);
+      }
     }
     return;
   }
@@ -800,6 +812,9 @@ void ComponentDialog::writeEquation()
       }
       if (prop->Name == "hold" && cmdHoldCheck){
         prop->Value = cmdHoldCheck->checkState() == Qt::Checked ? "yes" : "no";
+      }
+      if (prop->Name == "terminal" && cmdTerminalEdit) {
+        prop->Value = cmdTerminalEdit->text().trimmed();
       }
     }
     return;

--- a/qucs/components/componentdialog.h
+++ b/qucs/components/componentdialog.h
@@ -76,6 +76,7 @@ private:
   QCheckBox* eqnExportCheck = nullptr;
   QCheckBox* cmdConsoleCheck = nullptr;  // CMD console toggle
   QCheckBox* cmdHoldCheck = nullptr;     // CMD hold toggle
+  QLineEdit* cmdTerminalEdit;            // CMD component: Specify terminal emulator
 
   Component* component;
   Schematic* document;

--- a/qucs/components/systemcommand.cpp
+++ b/qucs/components/systemcommand.cpp
@@ -42,6 +42,7 @@ SystemCommand::SystemCommand()
   Props.append(new Property("cmd", "", true, "System command to run after simulation"));
   Props.append(new Property("console", "yes", true, "Open console window [yes, no]"));
   Props.append(new Property("hold", "no", false, "Keep terminal open after execution [yes, no]"));
+  Props.append(new Property("terminal", "", false, "Terminal emulator to use (e.g. xterm, gnome-terminal). Leave empty for auto-detection"));
 }
 
 SystemCommand::~SystemCommand()

--- a/qucs/components/systemcommand.h
+++ b/qucs/components/systemcommand.h
@@ -23,6 +23,8 @@
 ///                user can see live output.
 /// - @c hold    — if @c yes, the terminal window stays open after the command finishes,
 ///                allowing the user to inspect the output before closing manually.
+/// - @c terminal — the terminal emulator.
+///                 If empty Qucs-S falls back to its built-in auto-detection logic.
 ///
 /// @note The component is intentionally excluded from netlist generation so that no
 ///       simulation backend ever sees it.

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -4007,6 +4007,8 @@ void QucsApp::runPostSimCommands(Schematic* sch)
     QString console = c->Props.count() > 1 ? c->Props.at(1)->Value.trimmed() : "no";
     // Keep the terminal open after execution
     QString hold    = c->Props.count() > 2 ? c->Props.at(2)->Value.trimmed() : "no";
+    // Terminal emulator
+    QString terminal = c->Props.count() > 3 ? c->Props.at(3)->Value.trimmed() : "";
     if (cmd.isEmpty()) {
       continue;
     }
@@ -4045,7 +4047,12 @@ void QucsApp::runPostSimCommands(Schematic* sch)
             QProcess::startDetached("osascript", {"-e", script});
       #else
       // Linux: try common terminal emulators in order of preference
-      QStringList terms = {"konsole", "gnome-terminal", "xfce4-terminal", "lxterminal", "xterm"};
+      QStringList terms;
+      if (!terminal.isEmpty()){
+        terms.append(terminal);
+      } else {
+        terms = {"konsole", "gnome-terminal", "xfce4-terminal", "lxterminal", "xterm", "qterminal", "ptyxis"};
+      }
       bool launched = false;
       for (const QString& term : terms) {
         QString exe = QStandardPaths::findExecutable(term);
@@ -4068,9 +4075,17 @@ void QucsApp::runPostSimCommands(Schematic* sch)
         }
       }
       if (!launched) {
-        QMessageBox::warning(nullptr, tr("System Command"),
-                             tr("Could not find a terminal emulator. Tried: xterm, konsole, gnome-terminal.\n"
-                                "Install one or run without console mode."));
+        if (!terminal.isEmpty()){
+          // User-defined terminal emulator. If it reaches this point, it didn't work
+          QMessageBox::warning(nullptr, tr("System Command"),
+                               tr("Could not launch the specified terminal emulator '%1'.\n"
+                                  "Check the 'terminal' property or leave it empty for auto-detection.").arg(terminal));
+        } else {
+          // Mo terminal specified
+          QMessageBox::warning(nullptr, tr("System Command"),
+                               tr("Could not find a terminal emulator. Tried: xterm, konsole, gnome-terminal, qterminal.\n"
+                                  "Install one or run without console mode."));
+        }
       }
 #endif
     } else {


### PR DESCRIPTION
On Linux, when a system command component is used, Qucs-S searches a hardcoded list of terminal emulators and uses the first one available [1]. In Lubuntu and Fedora, this fails because the terminal emulator shipped with those distros are not in the list:

<img width="503" height="540" alt="image" src="https://github.com/user-attachments/assets/12c556aa-88f0-46c4-8fbc-ccd12155f5f4" />


This PR adds a new property field to specify which terminal emulator to use. If left blank, Qucs-S falls back to trying the hardcoded list, as before.

<img width="653" height="506" alt="image" src="https://github.com/user-attachments/assets/e02ced6f-04e0-4156-a0bd-387c1bacbf1b" />

Two terminal emulators were added to the default hardcoded search list:

- Qterminal, shipped with Lubuntu
- Ptyxis, shipped with Fedora

[1] https://github.com/ra3xdh/qucs_s/blob/current/qucs/qucs.cpp#L4048