### PR TITLE
Tuner usability enchancements

### DIFF
--- a/qucs/dialogs/simmessage.h
+++ b/qucs/dialogs/simmessage.h
@@ -54,6 +54,7 @@ signals:
 
 public slots:
   void slotClose();
+  void AbortSim();
 
 private slots:
   void slotDisplayMsg();
@@ -62,7 +63,6 @@ private slots:
   void slotStateChanged(QProcess::ProcessState newState);
   void slotSimEnded(int exitCode, QProcess::ExitStatus exitStatus);
   void slotDisplayButton();
-  void AbortSim();
 
   void slotReadSpiceNetlist();
   void slotFinishSpiceNetlist(int status);

--- a/qucs/dialogs/tuner.cpp
+++ b/qucs/dialogs/tuner.cpp
@@ -21,6 +21,15 @@
 #include "extsimkernels/spicecompat.h"
 
 #include <QCloseEvent>
+#include <QMap>
+
+// Persistent range storage: key = "componentName|propertyName"
+struct TunerRangeState {
+    float min;
+    float max;
+    float step;
+};
+static QMap<QString, TunerRangeState> s_tunerRangeMap;
 
 bool isPropertyTunable(Component* propertyOwner, Property* property) {
   // Simulation parameters
@@ -242,6 +251,26 @@ tunerElement::tunerElement(QWidget *parent, Component *component, Property *pp, 
     maxValue = numValue*1.15;// max = initial_value + 15%
     minValue = numValue*0.85;// min = initial_value - 15%
     stepValue = (maxValue-minValue)/20;//20 steps between minimum and maximum
+
+    // Restore previously saved range for this component property, if any
+    m_rangeKey = component->Name + "|" + pp->Name;
+    if (s_tunerRangeMap.contains(m_rangeKey)) {
+        const TunerRangeState &state = s_tunerRangeMap[m_rangeKey];
+        // state stores absolute values; numValue/maxValue/minValue/stepValue are in display units
+        // (i.e. divided by getScale(magnitudeIndex)). Convert back to display units for the UI.
+        float displayScale = getScale(magnitudeIndex);
+        float absNumValue = numValue * displayScale;
+        float restoredMax = state.max;
+        float restoredMin = state.min;
+        float restoredStep = state.step;
+        // Widen range if current value has moved outside it
+        if (absNumValue > restoredMax) restoredMax = absNumValue * 1.15f;
+        if (absNumValue < restoredMin) restoredMin = absNumValue * 0.85f;
+        maxValue = restoredMax / displayScale;
+        minValue = restoredMin / displayScale;
+        stepValue = restoredStep / displayScale;
+    }
+
     maximum->setText(QString::number(maxValue));
     minimum->setText(QString::number(minValue));
     value->setText(QString::number(numValue));
@@ -391,6 +420,7 @@ void tunerElement::slotMaxValueChanged()
     }
     qDebug() << "tunerElement::slotMaxValueChanged() " << v;
 
+    saveRange();
     updateSlider();
     maximum->blockSignals(false);
     MaxUnitsCombobox->blockSignals(false);
@@ -433,6 +463,7 @@ void tunerElement::slotMinValueChanged()
 
     qDebug() << "slotMinValueChanged() " << v;
 
+    saveRange();
     updateSlider();
     minimum->blockSignals(false);
     MinUnitsCombobox->blockSignals(false);
@@ -461,6 +492,7 @@ void tunerElement::slotStepChanged()
     }
 
     stepValue = v;
+    saveRange();
 }
 
 
@@ -639,6 +671,12 @@ float tunerElement::getMinValue(bool &ok)
 float tunerElement::getStep(bool &ok)
 {
    return step->text().toFloat(&ok)*getScale(StepUnitsCombobox->currentIndex());
+}
+
+// Persists the current min/max/step range for this element
+void tunerElement::saveRange()
+{
+    s_tunerRangeMap[m_rangeKey] = { minValue, maxValue, stepValue };
 }
 
 tunerElement::~tunerElement()

--- a/qucs/dialogs/tuner.cpp
+++ b/qucs/dialogs/tuner.cpp
@@ -22,6 +22,7 @@
 
 #include <QCloseEvent>
 #include <QMap>
+#include <QSet>
 #include <QTimer>
 
 // Persistent range storage: key = "componentName|propertyName"
@@ -31,6 +32,9 @@ struct TunerRangeState {
     float step;
 };
 static QMap<QString, TunerRangeState> s_tunerRangeMap;
+
+// Persistent set of active tuner parameters: "schematicPath|componentName|propertyName"
+static QSet<QString> s_tunerActiveElements;
 
 bool isPropertyTunable(Component* propertyOwner, Property* property) {
   // Simulation parameters
@@ -797,6 +801,9 @@ void TunerDialog::addTunerElement(tunerElement *element)
 
     if (!currentProps.contains(element->getElementProperty()))
     {
+        // Remember this element across open/close cycles
+        s_tunerActiveElements.insert(
+            element->schematicName + "|" + element->c->Name + "|" + element->getElementProperty()->Name);
         splitter->addWidget(element);
         currentProps.append(element->getElementProperty());
         currentElements.append(element);
@@ -827,6 +834,9 @@ void TunerDialog::slotComponentDeleted(Component *c)
 void TunerDialog::slotRemoveTunerElement(tunerElement *e)
 {
     qDebug() << "Tuner::slotRemoveTunerElement()";
+    // User explicitly removed this element — forget it
+    s_tunerActiveElements.remove(
+        e->schematicName + "|" + e->c->Name + "|" + e->getElementProperty()->Name);
     currentProps.removeAll(e->getElementProperty());
     currentElements.removeAll(e);//This will also destroy the element in QSplitter: https://stackoverflow.com/questions/371599/how-to-remove-qwidgets-from-qsplitter
     delete e;
@@ -970,6 +980,30 @@ void TunerDialog::showEvent(QShowEvent *e)
     {
         if (currentElements.at(i)->getElementProperty() == nullptr)
             currentElements.removeAt(i);
+    }
+
+    // Auto-restore previously selected tuner parameters
+    if (s_tunerActiveElements.isEmpty() || !w)
+        return;
+    Schematic *sch = dynamic_cast<Schematic*>(w);
+    if (!sch)
+        return;
+    QString schPath = sch->getDocName();
+    for (Component *comp : *sch->a_Components) {
+        if (!comp) continue;
+        for (int idx = 0; idx < comp->Props.size(); ++idx) {
+            Property *pp = comp->Props.at(idx);
+            QString key = schPath + "|" + comp->Name + "|" + pp->Name;
+            if (!s_tunerActiveElements.contains(key))
+                continue;
+            if (containsProperty(pp))
+                continue; // already loaded
+            if (!isPropertyTunable(comp, pp))
+                continue;
+            tunerElement *elem = new tunerElement(this, comp, pp, idx);
+            elem->schematicName = schPath;
+            addTunerElement(elem);
+        }
     }
 }
 

--- a/qucs/dialogs/tuner.cpp
+++ b/qucs/dialogs/tuner.cpp
@@ -22,6 +22,7 @@
 
 #include <QCloseEvent>
 #include <QMap>
+#include <QTimer>
 
 // Persistent range storage: key = "componentName|propertyName"
 struct TunerRangeState {
@@ -734,8 +735,9 @@ TunerDialog::TunerDialog(QWidget *_w, QWidget *parent) :
     gbox->addWidget(splitter,0, 1, Qt::AlignRight);
 
     progressBar = new QProgressBar();
-    progressBar->setMaximum(100);
-    progressBar->setVisible(false);
+    progressBar->setRange(0, 100);
+    progressBar->setValue(0);
+    progressBar->setTextVisible(false);
     gbox->addWidget(progressBar, 2, 0);
 
     info->showMessage(tr("Please select a component to tune"));
@@ -748,6 +750,12 @@ TunerDialog::TunerDialog(QWidget *_w, QWidget *parent) :
     //Management of the Esc shortcut. Otherwise, it will exit the tuner and leave the toogle button activated
     QShortcut *shortcut_Esc = new QShortcut(Qt::Key_Escape, this);
     QObject::connect(shortcut_Esc, SIGNAL(activated()), this, SLOT(close()));
+
+    // Timer: if a sim takes > 1 s after a new change arrives, abort and restart
+    m_killTimer = new QTimer(this);
+    m_killTimer->setSingleShot(true);
+    m_killTimer->setInterval(1000);
+    connect(m_killTimer, &QTimer::timeout, this, &TunerDialog::slotKillTimerFired);
 }
 
 void TunerDialog::slotUpdateProgressBar(int value)
@@ -836,8 +844,10 @@ void TunerDialog::slotElementValueUpdated()
 {
     qDebug() << "Tuner::slotElementValueUpdated()";
 
-    progressBar->setVisible(true);
-    this->setEnabled(false);
+    if (m_simulating) { m_pendingUpdate = true; m_killTimer->start(); return; } // retry after current sim ends
+    m_simulating = true;
+    m_pendingUpdate = false;
+    progressBar->setRange(0, 0); // indeterminate busy indicator
 
     switch (QucsSettings.DefaultSimulator) {
     case spicecompat::simQucsator:
@@ -856,10 +866,25 @@ void TunerDialog::SimulationEnded()
 {
     qDebug() << "Tuner::SimulationEnded()";
 
-    this->setEnabled(true);
-    progressBar->setVisible(false);
+    progressBar->setRange(0, 100);
+    progressBar->setValue(0);
+    m_simulating = false;
+    m_killTimer->stop();
+    if (m_pendingUpdate) {
+        m_pendingUpdate = false;
+        slotElementValueUpdated();
+    }
 }
 
+
+void TunerDialog::slotKillTimerFired()
+{
+    qDebug() << "Tuner::slotKillTimerFired() - aborting slow simulation";
+    // Simulation is still running after 1 s; abort it.
+    // SimulationEnded() will be called by the abort path and will trigger
+    // a new simulation since m_pendingUpdate is still true.
+    QucsMain->slotAbortTuningSimulation();
+}
 
 bool TunerDialog::checkChanges()
 {

--- a/qucs/dialogs/tuner.h
+++ b/qucs/dialogs/tuner.h
@@ -91,6 +91,9 @@ class tunerElement : public QWidget
         float minValue;
         float maxValue;
         float stepValue;
+        QString m_rangeKey;
+
+        void saveRange();
 
     private slots:
 

--- a/qucs/dialogs/tuner.h
+++ b/qucs/dialogs/tuner.h
@@ -139,12 +139,16 @@ private:
     QProgressBar *progressBar;
     QPushButton *updateValues, *resetValues;//They're private in order to make enable or disable them
 
+    bool m_simulating = false;
+    bool m_pendingUpdate = false;
+    QTimer *m_killTimer = nullptr;
     void blockInput(bool enabled);
     void closeEvent(QCloseEvent *event);
     void infoMsg(const QString msg);
 
 private slots:
     void slotElementValueUpdated();
+    void slotKillTimerFired();
     void slotRemoveTunerElement(tunerElement*);
     void slotUpdateValues();
     void slotResetValues();

--- a/qucs/extsimkernels/externsimdialog.h
+++ b/qucs/extsimkernels/externsimdialog.h
@@ -72,13 +72,13 @@ signals:
 public slots:
     void slotSaveNetlist();
     void slotStart();
+    void slotStop();
 
 private slots:
     void slotProcessOutput();
     //void slotProcessXyceOutput();
     void slotNgspiceStarted();
     void slotNgspiceStartError(QProcess::ProcessError err);
-    void slotStop();
     void slotSetSimulator();
     void slotExit();
 };

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -147,6 +147,7 @@ QucsApp::QucsApp(bool netlist2Console) :
   // instance of small text search dialog
   SearchDia = new SearchDialog(this);
   TuningMode = false;
+  sim = nullptr;
 
   // creates a document called "untitled"
   Schematic *d = new Schematic(this, "");
@@ -2736,6 +2737,7 @@ void QucsApp::slotSimulate(QWidget *w)
     this, SLOT(slotChangePage(QString&, QString&)));
 
   if (TuningMode == true) {
+      this->sim = sim; // store for potential abort
       connect(sim, SIGNAL(progressBarChanged(int)), tunerDia, SLOT(slotUpdateProgressBar(int)));
   } else { //It doesn't make sense to connect the slot outside the tuning mode
       sim->show();
@@ -2757,7 +2759,8 @@ void QucsApp::slotAfterSimulation(int Status, SimMessage *sim)
 
   if(Status != 0) { // errors ocurred ?
       if (TuningMode) {
-          sim->show();
+          if (!m_tunerAbortForRerun) sim->show();
+          m_tunerAbortForRerun = false;
           tunerDia->SimulationEnded();
       }
       return;
@@ -3675,6 +3678,19 @@ void QucsApp::slotSimSettings()
     fillSimulatorsComboBox();
 }
 
+void QucsApp::slotAbortTuningSimulation()
+{
+    m_tunerAbortForRerun = true;
+    switch (QucsSettings.DefaultSimulator) {
+    case spicecompat::simQucsator:
+        if (sim) sim->AbortSim();
+        break;
+    default: // ngspice, xyce, spiceOpus
+        if (a_tunerExternSimDlg) a_tunerExternSimDlg->slotStop();
+        break;
+    }
+}
+
 void QucsApp::slotSimulateWithSpice()
 {
     if (!isTextDocument(DocumentTab->currentWidget()))
@@ -3714,6 +3730,7 @@ void QucsApp::slotSimulateWithSpice()
 
         if (TuningMode || schematic->getShowBias() == 0)
         {
+            a_tunerExternSimDlg = SimDlg; // store for potential abort
             SimDlg->slotStart();
         }
         else
@@ -3830,7 +3847,10 @@ void QucsApp::slotAfterSpiceSimulation(ExternSimDialog *SimDlg)
     disconnect(SimDlg,SIGNAL(warnings()),this,SLOT(slotShowWarnings()));
     disconnect(SimDlg,SIGNAL(success()),this,SLOT(slotResetWarnings()));
     if (TuningMode && SimDlg->hasError()) {
-        SimDlg->show();
+        if (!m_tunerAbortForRerun) SimDlg->show();
+        m_tunerAbortForRerun = false;
+        a_tunerExternSimDlg = nullptr;
+        tunerDia->SimulationEnded();
         return;
     }
     if (SimDlg->wasSimulated()) {
@@ -3859,6 +3879,8 @@ void QucsApp::slotAfterSpiceSimulation(ExternSimDialog *SimDlg)
       octave->runOctaveScript(sch->getScript());
     }
     if (TuningMode) {
+        m_tunerAbortForRerun = false;
+        a_tunerExternSimDlg = nullptr;
         tunerDia->SimulationEnded();
     }
     if (sch->getShowBias()>0 || QucsMain->TuningMode) SimDlg->close();

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -2593,6 +2593,7 @@ void QucsApp::slotTune(bool checked)
         MouseReleaseAction = nullptr; //While Tune is active release is not needed. This puts Press Action back to normal select
 
         tunerDia->show();
+        tunerDia->move(this->geometry().topLeft());
     }
     else
     {

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -116,6 +116,8 @@ public:
   SearchDialog *SearchDia; // global in order to keep values
   TunerDialog *tunerDia;   // global in order to keep values
   SimMessage *sim;         // global in order to keep values
+  ExternSimDialog *a_tunerExternSimDlg = nullptr;
+  bool m_tunerAbortForRerun = false;
 
   // current mouse methods
   void (MouseActions::*MouseMoveAction)(Schematic *, QMouseEvent *);
@@ -192,6 +194,7 @@ public slots:
 
   void slotSimulate(QWidget *w = nullptr);
   void slotSimulateWithSpice();
+  void slotAbortTuningSimulation();
   void slotTune(bool checked);
 
 private slots:


### PR DESCRIPTION
This pull request introduces several improvements to the Tuner dialog and simulation abort handling, with a focus on enhancing the user experience during parameter tuning and simulation reruns. The main changes include persistent storage and restoration of tuner parameters and ranges, improved simulation progress feedback, and robust logic to abort and restart simulations when tuning parameters are changed rapidly.

**Tuner dialog enhancements:**

* Persistent storage of tuner parameter ranges and active elements, allowing the Tuner dialog to remember user selections and value ranges across open/close cycles. (`tuner.cpp`, `tuner.h`) [[1]](diffhunk://#diff-317eb63e4d15dc773cb928997d630a522ad44631afd6e2ccb2ee87852def2501R24-R37) [[2]](diffhunk://#diff-317eb63e4d15dc773cb928997d630a522ad44631afd6e2ccb2ee87852def2501R259-R278) [[3]](diffhunk://#diff-317eb63e4d15dc773cb928997d630a522ad44631afd6e2ccb2ee87852def2501R804-R806) [[4]](diffhunk://#diff-317eb63e4d15dc773cb928997d630a522ad44631afd6e2ccb2ee87852def2501R837-R839) [[5]](diffhunk://#diff-317eb63e4d15dc773cb928997d630a522ad44631afd6e2ccb2ee87852def2501R984-R1007) [[6]](diffhunk://#diff-8e97fec1430f20bde7e56afbd0588b0386d6cec4427dba58c92454a5a3e7715cR94-R96)
* Automatic restoration of previously selected tuner parameters and their value ranges when reopening the Tuner dialog. (`tuner.cpp`)
* Persistent saving of min/max/step values when the user changes them, ensuring their values are not lost. (`tuner.cpp`) [[1]](diffhunk://#diff-317eb63e4d15dc773cb928997d630a522ad44631afd6e2ccb2ee87852def2501R428) [[2]](diffhunk://#diff-317eb63e4d15dc773cb928997d630a522ad44631afd6e2ccb2ee87852def2501R471) [[3]](diffhunk://#diff-317eb63e4d15dc773cb928997d630a522ad44631afd6e2ccb2ee87852def2501R500) [[4]](diffhunk://#diff-317eb63e4d15dc773cb928997d630a522ad44631afd6e2ccb2ee87852def2501R681-R686)

**Simulation progress and abort logic:**

* Improved progress bar handling: switches to an indeterminate "busy" state during simulation, resets after completion, and disables/enables UI appropriately. (`tuner.cpp`) [[1]](diffhunk://#diff-317eb63e4d15dc773cb928997d630a522ad44631afd6e2ccb2ee87852def2501L699-R744) [[2]](diffhunk://#diff-317eb63e4d15dc773cb928997d630a522ad44631afd6e2ccb2ee87852def2501L801-R860) [[3]](diffhunk://#diff-317eb63e4d15dc773cb928997d630a522ad44631afd6e2ccb2ee87852def2501L821-R898)
* Introduced a timer to abort and restart simulations if a new parameter change arrives while a simulation is running, preventing lag and ensuring the latest parameter is always simulated. (`tuner.cpp`, `tuner.h`) [[1]](diffhunk://#diff-317eb63e4d15dc773cb928997d630a522ad44631afd6e2ccb2ee87852def2501R757-R762) [[2]](diffhunk://#diff-317eb63e4d15dc773cb928997d630a522ad44631afd6e2ccb2ee87852def2501L801-R860) [[3]](diffhunk://#diff-8e97fec1430f20bde7e56afbd0588b0386d6cec4427dba58c92454a5a3e7715cR142-R151)
* Added logic to explicitly abort running simulations via a new `slotAbortTuningSimulation` method in `QucsApp`, supporting both internal and external simulators. (`qucs.cpp`, `qucs.h`, `simmessage.h`, `externsimdialog.h`) [[1]](diffhunk://#diff-1782ec067f634f72e33d9c774e87da3c7596700706ab39398fbb94cfe80d3009R3682-R3694) [[2]](diffhunk://#diff-1782ec067f634f72e33d9c774e87da3c7596700706ab39398fbb94cfe80d3009R2741) [[3]](diffhunk://#diff-1782ec067f634f72e33d9c774e87da3c7596700706ab39398fbb94cfe80d3009R3734) [[4]](diffhunk://#diff-1782ec067f634f72e33d9c774e87da3c7596700706ab39398fbb94cfe80d3009L3833-R3854) [[5]](diffhunk://#diff-1782ec067f634f72e33d9c774e87da3c7596700706ab39398fbb94cfe80d3009R3883-R3884) [[6]](diffhunk://#diff-1bc294859571d504b8d62c28f8df0dac6ccdbe7c34d629827af8925b394a51baR119-R120) [[7]](diffhunk://#diff-1bc294859571d504b8d62c28f8df0dac6ccdbe7c34d629827af8925b394a51baR197) [[8]](diffhunk://#diff-2e5356535a152a0d73e18265734d4fe5403455bcf323446e8d80fa73a1bf3556R57) [[9]](diffhunk://#diff-2e5356535a152a0d73e18265734d4fe5403455bcf323446e8d80fa73a1bf3556L65) [[10]](diffhunk://#diff-6c3116cc2dee5dbe78ffbcd4062ec20c601d2117a29ef09d6acd5b524823fb74R75-L81)

**Other improvements:**

* The Tuner dialog now opens at the top-left of the main window for better visibility. (`qucs.cpp`)

These changes collectively make the Tuner dialog more robust and user-friendly, especially during rapid parameter adjustments and simulation reruns.