### PR TITLE
Fix Shortcut Manager persistance

### DIFF
--- a/qucs/qucs_init.cpp
+++ b/qucs/qucs_init.cpp
@@ -1638,4 +1638,6 @@ void QucsApp::setDefaultShortcut() {
 
   mgr.registerCommand("Help.AboutQt", "Help", "About Qt", helpAboutQt,
                       QKeySequence());
+
+  mgr.loadFromSettings();
 }

--- a/qucs/qucsshortcutmanager.cpp
+++ b/qucs/qucsshortcutmanager.cpp
@@ -394,6 +394,8 @@ void QucsShortcutManager::saveToSettings() const {
   for (const auto &cmd : m_commands) {
     if (cmd->isModified()) {
       settings.setValue(cmd->id(), cmd->currentKeySequence().toString());
+    } else {
+      settings.remove(cmd->id());
     }
   }
 


### PR DESCRIPTION
As reported here https://github.com/ra3xdh/qucs_s/discussions/1651, the shortcuts settings do not hold for the next Qucs-S session.

After inspecting the code, Qucs-S is not loading the user shortcuts from qucs_s.conf. Once this was fixed, it was observed that it didn't save the shortcuts when they're reseted to default.

**Fixes**

- Call loadFromSettings() at the end of setDefaultShortcut(), after all commands have been registered, so saved overrides are applied correctly on startup

- Remove QSettings keys for commands reset to default, preventing stale overrides from being reapplied on next launch
