### PR TITLE
Fix README and MAC package

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,8 @@ env:
   QT_VERSION: 6.10.3
   QUCS_MACOS_BIN: ${{github.workspace}}/build/qucs/qucs-s.app/Contents/MacOS/bin
   QUCS_MACOS_RESOURCES: ${{github.workspace}}/build/qucs/qucs-s.app/Contents/MacOS/share/qucs-s
-  NGSPICE_URL: https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/46/ngspice-46_64.7z
+  #NGSPICE_URL: https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/46/ngspice-46_64.7z
+  NGSPICE_URL: https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/old-releases/45.2/ngspice-45.2_64.7z
 
 jobs:
   setup:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -217,6 +217,7 @@ jobs:
           mkdir -p ${{ env.QUCS_MACOS_BIN }}
           mkdir -p ${{ env.QUCS_MACOS_RESOURCES }}/examples
           mkdir -p ${{ env.QUCS_MACOS_RESOURCES }}/library
+          mkdir -p ${{ env.QUCS_MACOS_RESOURCES }}/library/spicelibrary
           mkdir -p ${{ env.QUCS_MACOS_RESOURCES }}/symbols
           mkdir -p ${{ env.QUCS_MACOS_RESOURCES }}/lang
           cp -pR ${{ github.workspace }}/build/qucs-activefilter/qucs-sactivefilter.app ${{ env.QUCS_MACOS_BIN }}
@@ -231,6 +232,7 @@ jobs:
           cp -pR ${{ github.workspace }}/examples/* ${{ env.QUCS_MACOS_RESOURCES }}/examples
           cp -pR ${{ github.workspace }}/library/*.lib ${{ env.QUCS_MACOS_RESOURCES }}/library
           cp -pR ${{ github.workspace }}/library/*.blacklist ${{ env.QUCS_MACOS_RESOURCES }}/library
+          cp -pR ${{ github.workspace }}/library/spicelibrary/*.cir ${{ env.QUCS_MACOS_RESOURCES }}/library/spicelibrary
           cp -pR ${{ github.workspace }}/library/symbols/* ${{ env.QUCS_MACOS_RESOURCES }}/symbols
           cp -pR ${{ github.workspace }}/build/translations/*.qm ${{ env.QUCS_MACOS_RESOURCES }}/lang
           macdeployqt ${{ github.workspace }}/build/qucs/qucs-s.app

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ Here are some examples for the popular Linux distributions.
 ~~~
 sudo apt-get install ngspice build-essential git cmake flex bison gperf dos2unix
 sudo apt-get install qt6-base-dev qt6-tools-dev qt6-tools-dev-tools libglx-dev linguist-qt6
-sudo apt-get install qt6-l10n-tools libqt6svg6-dev libgl1-mesa-dev qt6-charts-dev libqt6opengl6-dev
+sudo apt-get install qt6-l10n-tools libqt6svg6-dev libgl1-mesa-dev libqt6opengl6-dev
 ~~~
 
 #### Fedora
 
 ~~~
 sudo dnf install gcc-c++ cmake git flex bison gperf dos2unix ngspice
-sudo dnf install qt6-qtbase-devel cmake qt6-qtsvg-devel qt6-qttools-devel qt6-qtcharts-devel
+sudo dnf install qt6-qtbase-devel cmake qt6-qtsvg-devel qt6-qttools-devel
 ~~~
 
 ### Compiling


### PR DESCRIPTION
* Fixed README as pointed by #1645 
* Spicelibrary subdirectory contents added in MAC package #1653 
* Ngspice version bundled in Windows installer downgraded to 45.2 #1650 