### PR TITLE
Fix Xyce HB for multi-tone simulations

### DIFF
--- a/qucs/components/hb_sim.cpp
+++ b/qucs/components/hb_sim.cpp
@@ -67,13 +67,26 @@ QString HB_Sim::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
 {
     QString s="";
     if (dialect == spicecompat::SPICEXyce) {  // Only in Xyce
-        s += QStringLiteral(".options hbint numfreq=%1 STARTUPPERIODS=2\n").arg(Props.at(1)->Value);
+        // Get frequency list from the properties
         QStringList freqs = Props.at(0)->Value.split(QRegularExpression("\\s+(?=[0-9])"));
+
+        // Build the NUMFREQ QString for N fundamental frequencies
+        QString NUMFREQ = Props.at(1)->Value; // Number of harmonics to be calculated for each tone
+        QString numfreqs = NUMFREQ;
+        int N = freqs.count(); // Number of fundamental frequencies
+        if (N > 1){
+          // Multitone input
+          for (int i = 0; i < N-1; ++i) {
+            numfreqs.append(QString(",%1").arg(NUMFREQ));
+          }
+        }
+
         // split frequencyes list by space before digit
         for (QStringList::iterator it = freqs.begin();it != freqs.end(); it++) {
             (*it) = spicecompat::normalize_value(*it);
         }
         s += QStringLiteral(".HB %1\n").arg(freqs.join(" "));
+        s += QStringLiteral(".options hbint numfreq=%1 STARTUPPERIODS=2\n").arg(numfreqs);
     }
     return s;
 }

--- a/qucs/components/hb_sim.cpp
+++ b/qucs/components/hb_sim.cpp
@@ -68,7 +68,7 @@ QString HB_Sim::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
     QString s="";
     if (dialect == spicecompat::SPICEXyce) {  // Only in Xyce
         // Get frequency list from the properties
-        QStringList freqs = Props.at(0)->Value.split(QRegularExpression("\\s+(?=[0-9])"));
+        QStringList freqs = Props.at(0)->Value.split(QRegularExpression("\\s*[,;]\\s*|\\s+(?=[0-9])"), Qt::SkipEmptyParts);
 
         // Build the NUMFREQ QString for N fundamental frequencies
         QString NUMFREQ = Props.at(1)->Value; // Number of harmonics to be calculated for each tone


### PR DESCRIPTION
A colleague reported to me that multitone HB simulations do not work with the Xyce backend. This happens because *numfreqs* requires the same number of arguments as the HB frequencies. (See [Xyce Reference Guide,](https://xyce.sandia.gov/documentation-tutorials/) section 2.1.25.17)

<img width="911" height="418" alt="image" src="https://github.com/user-attachments/assets/1f40970a-57ee-49f3-b8d7-806c559f1b9c" />

**Example**

<img width="825" height="512" alt="image" src="https://github.com/user-attachments/assets/89b430a6-010b-4492-b7d2-e6b6ca648ba0" />

<img width="493" height="544" alt="image" src="https://github.com/user-attachments/assets/b5f8fd78-059a-4970-b921-04338d0107a8" />


This is how the Xyce netlist looks like now:
<img width="556" height="269" alt="image" src="https://github.com/user-attachments/assets/1f99325e-1435-4814-bf68-2ab5cdb9fa86" />

After this PR

<img width="598" height="349" alt="image" src="https://github.com/user-attachments/assets/56e7c8cc-55e9-425c-bfbd-3923ec28a339" />

Now it simulates without errors:

<img width="1242" height="890" alt="image" src="https://github.com/user-attachments/assets/d064473b-7c23-42fb-a0e6-f9a605be2655" />

It works with N carriers
<img width="1302" height="769" alt="image" src="https://github.com/user-attachments/assets/0e222bc5-aaed-42f5-8260-3630a7763090" />


Here it is the workspace I used for testing this: [Xyce_Multitone_HB_prj.zip](https://github.com/user-attachments/files/28024844/Xyce_Multitone_HB_prj.zip)
I need to polish somethings on this project. Then, I think I would be worthy of adding it to the examples.