### PR TITLE
feat(SpiceOptions): add Xyce option package dropdown

### DIFF
--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -35,6 +35,8 @@
 #include "misc.h"
 #include "fillfromspicedialog.h"
 #include "selfromlibdialog.h"
+// For Xyce Options
+#include "spicecomponents/sp_options.h"
 
 #include <cmath>
 
@@ -374,6 +376,111 @@ ComponentDialog::ComponentDialog(Component* schematicComponent, Schematic* schem
   // Setup the dialog according to the component kind.
   if (isEquation || isPlainText)
   {
+    // SpiceOptions: add XyceOptionPackage combo above editor
+    if (component->Model == "SpiceOptions")
+    {
+      // Make a Xyce Option Package group
+      QGroupBox *xyceGroup = new QGroupBox(tr("Xyce Option Package"));
+      QVBoxLayout *xyceGroupLayout = new QVBoxLayout(xyceGroup);
+
+      // build xycePkgOption input
+      QHBoxLayout* xycePkgLayout = new QHBoxLayout;
+      xycePkgCombo = new QComboBox(this);
+      xycePkgCombo->setEditable(true);
+      xycePkgCombo->setToolTip(tr("Xyce option package (e.g., DEVICE, DIAGNOSTIC)"));
+
+      // add label for validation icon
+      QLabel *xycePkgIconLabel = new QLabel(this);
+      xycePkgIconLabel->setFixedSize(24, 24);
+
+      // Register all known XycePkgOptions
+      QMap<QString, QString> pkgInfo = SpiceOptions::getXycePackageOptions();
+      for (auto it = pkgInfo.begin(); it != pkgInfo.end(); ++it) {
+        xycePkgCombo->addItem(it.key());
+        int index = xycePkgCombo->findText(it.key());
+        xycePkgCombo->setItemData(index, it.value(), Qt::ToolTipRole);
+      }
+
+      // Set current value from component property if it exists.
+      Property* prop = component->getProperty("XyceOptionPackage");
+      if (prop) {
+        xycePkgCombo->setCurrentText(prop->Value.trimmed().toUpper());
+      }
+
+      // Disable when not using Xyce
+      bool isXyce = (QucsSettings.DefaultSimulator == spicecompat::simXyce);
+      xycePkgCombo->setEnabled(isXyce);
+      xycePkgIconLabel->setVisible(isXyce);
+      if (!isXyce) {
+        xycePkgCombo->setToolTip(tr("Only available when using Xyce as simulator"));
+      }
+
+      // add the different layout/widgets
+      xycePkgLayout->addWidget(xycePkgCombo, 1);
+      xycePkgLayout->addWidget(xycePkgIconLabel);
+      xyceGroupLayout->addLayout(xycePkgLayout);
+      static_cast<QVBoxLayout*>(layout())->addWidget(xyceGroup, 0);
+
+      // input validation lambda
+      // colorize green border and show checkmark icon if using known package,
+      // otherwise show a yellow border and warning icon if user input and unknown
+      auto validateXycePkgCombo = [this, xycePkgIconLabel]() {
+        // NOTE: getXycePackageOptions is static
+        const auto& pkgOptions = SpiceOptions::getXycePackageOptions();
+        QString text = xycePkgCombo->currentText();
+        QString normalized = text.trimmed().toUpper();
+        bool isValid = pkgOptions.contains(normalized);
+
+        QString borderColor;
+        int borderSize       = QucsSettings.hasDarkTheme ? 2 : 3;
+
+        // set tooltip and pick color
+        if (isValid) {
+          xycePkgCombo->setToolTip(pkgOptions.value(normalized));
+          // green color if valid
+          borderColor = QucsSettings.hasDarkTheme ? "#28a745" : "#198754";
+        } else {
+          xycePkgCombo->setToolTip(
+            tr("'%1' is not a recognized Xyce option package.\n"
+               "Xyce will silently skip invalid options.")
+              .arg(normalized)
+          );
+          // Yellow-ish color if invalid
+          borderColor = QucsSettings.hasDarkTheme ? "#ffc107" : "#eab308";
+        }
+
+        // set border style
+        xycePkgCombo->setStyleSheet(
+          QStringLiteral("QComboBox { border: %1px solid %2; }")
+            .arg(borderSize)
+            .arg(borderColor)
+        );
+
+        // set icon
+        QIcon icon = QApplication::style()->standardIcon(
+          isValid ? QStyle::SP_DialogApplyButton : QStyle::SP_MessageBoxWarning
+        );
+        xycePkgIconLabel->setPixmap(icon.pixmap(24, 24));
+        // update icon to have the same tooltip as the combo-box
+        xycePkgIconLabel->setToolTip(xycePkgCombo->toolTip());
+
+        // set the normalized input
+        if (text != normalized) {
+          xycePkgCombo->blockSignals(true);
+          xycePkgCombo->setEditText(normalized);
+          xycePkgCombo->blockSignals(false);
+        }
+      };
+
+      // Validate input
+      connect(xycePkgCombo, &QComboBox::editTextChanged, this, validateXycePkgCombo);
+
+      // initialize input validation if using Xyce
+      if (isXyce) {
+        validateXycePkgCombo();
+      }
+    }
+
     // Create the equation editor.
     QGroupBox* editorGroup = new QGroupBox(tr("Equation Editor"));
     static_cast<QVBoxLayout*>(layout())->addWidget(editorGroup, 2);
@@ -785,6 +892,8 @@ void ComponentDialog::updateEqnEditor()
     else if (eqnExportCheck && property->Name == "Export")
       eqnExportCheck->setCheckState(property->Value == "yes" ? Qt::Checked : Qt::Unchecked);
 
+    else if (xycePkgCombo && property->Name == "XyceOptionPackage")
+      xycePkgCombo->setCurrentText(property->Value.trimmed().toUpper());
     else
       eqnList.append(property->Name + " = " + property->Value + "\n");
   }
@@ -823,6 +932,21 @@ void ComponentDialog::writeEquation()
   // Clear all old properties and free their memory.
   qDeleteAll(component->Props.begin(), component->Props.end());
   component->Props.clear();
+
+  // SpiceOptions: save XyceOptionPackage from current combo state.
+  if (xycePkgCombo)
+  {
+    QString pkgName = xycePkgCombo->currentText().trimmed().toUpper();
+    // NOTE: Since the property is freed above, we need to recreate it here
+    Property *p = Property::Builder()
+      .name("XyceOptionPackage")
+      .value(pkgName)
+      .desc(tr("Xyce option package"))
+      .visible()
+      .simulator(spicecompat::simXyce)
+      .buildNew();
+    component->Props.append(p);
+  }
   
   // Note: the description needs to be written as "Simulation name" because this is used when saving the file.
   if (eqnSimCombo)

--- a/qucs/components/componentdialog.h
+++ b/qucs/components/componentdialog.h
@@ -26,6 +26,7 @@
 #include <QTextEdit>
 
 class Schematic;
+class SpiceOptions;
 
 class QValidator;
 class QIntValidator;
@@ -77,6 +78,7 @@ private:
   QCheckBox* cmdConsoleCheck = nullptr;  // CMD console toggle
   QCheckBox* cmdHoldCheck = nullptr;     // CMD hold toggle
   QLineEdit* cmdTerminalEdit;            // CMD component: Specify terminal emulator
+  QComboBox* xycePkgCombo = nullptr;     // Xyce options package for use in SpiceOptions
 
   Component* component;
   Schematic* document;

--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -35,6 +35,7 @@
 #include "textdoc.h"
 #include "schematic.h"
 #include "settings.h"
+#include "../misc.h"
 
 #include <QWidget>
 #include <QLabel>
@@ -678,6 +679,8 @@ void QucsSettingsDialog::slotApply()
         if (style) {
           QApplication::setStyle(style);
           _settings::Get().setItem<QString>("AppStyle",  selectedStyle);
+          // update cached variable
+          QucsSettings.hasDarkTheme = misc::isDarkTheme();
           changed = true;  
         } 
     }

--- a/qucs/spicecomponents/sp_options.cpp
+++ b/qucs/spicecomponents/sp_options.cpp
@@ -48,8 +48,8 @@ SpiceOptions::SpiceOptions()
   Model = "SpiceOptions";
   Name  = "SpiceOptions";
 
-  Props.append(new Property("XyceOptionPackage", "DEVICE", false,
-        QObject::tr("Xyce option package name")));
+  Props.append(new Property("XyceOptionPackage", "DEVICE", true,
+        QObject::tr("Xyce option package name"), Property::Type::Value, spicecompat::simXyce));
   Props.append(new Property("GMIN", "1e-12", true));
 }
 
@@ -91,3 +91,30 @@ QString SpiceOptions::getExpression(spicecompat::SpiceDialect dialect /* = spice
     return s;
 }
 
+// Xyce Package options <pkgName, description>
+const QMap<QString, QString>& SpiceOptions::getXycePackageOptions() {
+    // Based on Xyce v7.10 Reference Guide
+    static const QMap<QString, QString> pkgInfo = {
+      {"DEVICE",          QObject::tr("Device Model")},
+      {"DIAGNOSTIC",      QObject::tr("Diagnostic Simulation Output")},
+      {"TIMEINT",         QObject::tr("Time Integration")},
+      {"NONLIN",          QObject::tr("Nonlinear Solver")},
+      {"NONLIN-TRAN",     QObject::tr("Transient Nonlinear Solver")},
+      {"NONLIN-HB",       QObject::tr("HB Nonlinear Solver")},
+      {"LOCA",            QObject::tr("Continuation/Bifurcation Tracking")},
+      {"LINSOL",          QObject::tr("Linear Solver")},
+      {"LINSOL-HB",       QObject::tr("HB Linear Solver")},
+      {"LINSOL-AC",       QObject::tr("AC Linear Solver")},
+      {"OUTPUT",          QObject::tr("Output")},
+      {"RESTART",         QObject::tr("Restart")},
+      {"SAMPLES",         QObject::tr("Sampling analysis and non-intrusive Polynomial Chaos (PCE)")},
+      {"EMBEDDEDSAMPLES", QObject::tr("EmbeddedSampling and non-intrusive Polynomial Chaos (PCE)")},
+      {"PCES",            QObject::tr("Fully intrusive Polynomial Chaos (PCE)")},
+      {"SENSITIVITY",     QObject::tr("Direct and Adjoint sensitivities")},
+      {"HBINT",           QObject::tr("Harmonic Balance (HB)")},
+      {"DIST",            QObject::tr("Distribution")},
+      {"MEASURE",         QObject::tr("Measure")},
+      {"PARSER",          QObject::tr("Parsing")}
+    };
+    return pkgInfo;
+}

--- a/qucs/spicecomponents/sp_options.h
+++ b/qucs/spicecomponents/sp_options.h
@@ -31,6 +31,9 @@ public:
   static void splitEqn(QString &eqn, QStringList &tokens);
   QString getExpression(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
 
+  // Xyce Package options <pkgName, description>
+  static const QMap<QString, QString>& getXycePackageOptions();
+
 protected:
   QString vhdlCode(int) { return QString(); }
   QString verilogCode(int) { return QString(); }


### PR DESCRIPTION
##  What

Adds an editable combobox to the SpiceOptions dialog for Xyce option packages, pre-filled with all packages from Xyce v7.10 reference guide, with descriptions. Valid selections show a green checkmark/border; invalid ones show a yellow warning (Xyce silently skips invalid packages). The control is hidden/disabled when using non-Xyce simulators.

Also fixes `hasDarkTheme` cache not updating on style change in QucsSettingsDialog.

## Why

Currently, it feels a bit weird having to have the XycePkgOption enforced as the first line, even when using NGSpice, hence I felt this would be a more consistent experience (in the case when using Xyce), for NGSpice/Non-Xyce users, the change should be invisible. 

NOTE: This should not break any pre-existing options, since one is using the same parameters as previously used.

## Examples

### Schematic Entry

<img width="2060" height="1180" alt="qucs_options_schematic" src="https://github.com/user-attachments/assets/8b936eae-4564-4ac4-ba6d-b85d841568d4" />

Where one can see that the `XyceOptionPackage` is now hidden for NGSpice.

### Dialog

| NGSpice | Xyce |
|-----------|-------|
| <img height="748" alt="image" src="https://github.com/user-attachments/assets/c0d9e65c-43e8-4f66-8186-6e053e8d7f24" /> |  <img height="744" alt="image" src="https://github.com/user-attachments/assets/7b0b6edb-7faa-4000-8c27-1320bc5d15a3" /> |



Showing that NGSpice disables the combo-box, while Xyce is currently showing an invalid option

### Dropdown options

<img width="1723" height="767" alt="image" src="https://github.com/user-attachments/assets/b6eb2f52-8472-4e9d-862a-9e6913b293d3" />

### Input validation

| Valid | Invalid/Unknown |
|-------|--------------------|
| <img height="745" alt="image" src="https://github.com/user-attachments/assets/f2760b02-d452-4d31-94a1-1fbeb1efc208" /> |  <img height="737" alt="image" src="https://github.com/user-attachments/assets/02fd415c-d9a9-4af1-bc44-39e8bbfe8a99" /> | 

### Light vs Dark Theme

|   Input  | Adwaita (light) | Adwaita-dark |
|---------|------------------|----------------|
| Invalid | <img height="747" alt="image" src="https://github.com/user-attachments/assets/ebf07209-ca0a-4e3e-8215-72259b75f6e3" />| <img height="746" alt="image" src="https://github.com/user-attachments/assets/b7c2babf-d32b-42b4-b790-15f805ff9f07" /> |
| Valid    |<img width="1724" height="742" alt="image" src="https://github.com/user-attachments/assets/2da50cca-ac3c-469d-9865-915dc846515f" /> | <img width="1725" height="745" alt="image" src="https://github.com/user-attachments/assets/9ad33c81-2b15-4d8f-a91e-6b6217daf841" /> |

Thanks!