### PR TITLE
Multitone AC power sources

### DIFF
--- a/qucs/components/hb_sim.cpp
+++ b/qucs/components/hb_sim.cpp
@@ -90,3 +90,22 @@ QString HB_Sim::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
     }
     return s;
 }
+
+QString HB_Sim::netlist()
+{
+  QString fVal = Props.at(0)->Value.trimmed();
+
+  // qucsator reads tone frequencies directly from PAC excitation components.
+  // Its f property is PROP_REAL and cannot parse a comma-separated list —
+  // omit it when multiple tones are specified; the PAC chain handles it.
+  bool isMultitone = fVal.contains(',') || fVal.contains(';');
+
+  QString s = Model + ":" + Name;
+  for (int i = 0; i < Props.count() - 1; i++) {
+    const Property *p = Props.at(i);
+    if (p->Name == "f" && isMultitone)
+      continue;
+    s += " " + p->Name + "=\"" + p->Value + "\"";
+  }
+  return s + '\n';
+}

--- a/qucs/components/hb_sim.h
+++ b/qucs/components/hb_sim.h
@@ -29,6 +29,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
 protected:
   QString spice_netlist(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
+  QString netlist();
 };
 
 #endif

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -253,7 +253,7 @@ QString Source_ac::xyce_netlist()
       const QString pVal  = powers.isEmpty() ? QString() : powers.first();
       const QString freq  = freqs.isEmpty()  ? QString() : spicecompat::normalize_value(freqs.first());
       const QString phase = phases.isEmpty() ? QStringLiteral("0") : phases.first();
-      return singletone_xyce(s, z0, pVal, freq, phase, en_tran, isTermination);
+      return singletone_xyce(s, z0, freq, pVal, phase, en_tran, isTermination);
     }
 
 }

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -67,6 +67,9 @@ Source_ac::Source_ac()
                 QObject::tr("(available) ac power in dBm")));
   Props.append(new Property("f", "1 MHz", false,
                 QObject::tr("frequency in Hertz")));
+  Props.append(new Property("Phase", "0", false,
+                            QObject::tr("initial phase in degrees")));
+
   Props.append(new Property("Temp", "26.85", false,
         QObject::tr("simulation temperature in degree Celsius")));
   Props.append(new Property("EnableTran", "true", false,
@@ -109,6 +112,7 @@ QString Source_ac::ngspice_netlist()
     double z0 = spicecompat::normalize_value(getProperty("Z")->Value).toDouble();
     QString pVal = getProperty("P")->Value.trimmed();
     QString f = spicecompat::normalize_value(getProperty("f")->Value);
+    QString phase = spicecompat::normalize_value(getProperty("Phase")->Value);
 
     bool en_tran = true;
     if (getProperty("EnableTran")->Value == "true") {
@@ -137,7 +141,7 @@ QString Source_ac::ngspice_netlist()
       double vamp = 2.0 * vrms * sqrt(2.0);
       s += QStringLiteral(" dc 0 ac %1").arg(vamp);
       if (en_tran)
-        s += QStringLiteral(" SIN(0 %1 %2)").arg(vamp).arg(f);
+        s += QStringLiteral(" SIN(0 %1 %2 0 0 %3)").arg(vamp).arg(f, phase);
     } else {
       // P is a parameter name — emit a .PARAM expression and reference it
       // vamp = 2*sqrt(2) * sqrt(z0/1000) * 10^(P/20)
@@ -145,7 +149,7 @@ QString Source_ac::ngspice_netlist()
                  .arg(z0).arg(pVal);
       s += QStringLiteral(" dc 0 ac %1").arg(vamp);
       if (en_tran){
-        s += QStringLiteral(" SIN(0 %1 %2 0 0)").arg(vamp, f);
+        s += QStringLiteral(" SIN(0 %1 %2 0 0 %3)").arg(vamp, f, phase);
       }
     }
 
@@ -204,9 +208,9 @@ QString Source_ac::xyce_netlist()
     }
 
     s += QStringLiteral(" z0=%1 ").arg(s_z0);
-    s += QStringLiteral(" AC %1 ").arg(vamp);
+    s += QStringLiteral(" AC %1 ACPHASE %2 ").arg(vamp, phase);
     if (en_tran && !isTermination) {
-        s += QStringLiteral(" SIN 0 %1 %2").arg(vamp, f);
+        s += QStringLiteral(" SIN 0 %1 %2 0 0 %3").arg(vamp, f, phase);
     }
     s += "\n";
     return s;

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -173,6 +173,7 @@ QString Source_ac::xyce_netlist()
     double z0 = s_z0.toDouble();
     QString pVal = getProperty("P")->Value.trimmed();
     QString f = spicecompat::normalize_value(getProperty("f")->Value);
+    QString phase = getProperty("Phase")->Value.trimmed();
 
     bool en_tran = true;
     if (getProperty("EnableTran")->Value == "true") {
@@ -186,10 +187,16 @@ QString Source_ac::xyce_netlist()
     // Check if P is a symbolic parameter (not a numeric dBm literal)
     bool isNumeric = false;
     double p = spicecompat::normalize_value(pVal).toDouble(&isNumeric);
+
+    // Check if phase is numeric
+    bool isPhaseNumeric = false;
+    phase.toDouble(&isPhaseNumeric);
+
     // if user has explicitly set LoadOnly OR
     // if P is empty (unset), the port acts as a terminated port (a passive load).
     bool isTermination = (getProperty("LoadOnly")->Value == "true") || pVal.isEmpty();
 
+    // Calculate voltage amplitude
     QString vamp;
     if (isTermination) {
       // Terminated port: set Vamp to 0
@@ -207,11 +214,19 @@ QString Source_ac::xyce_netlist()
                       .arg(z0).arg(pVal);
     }
 
+    // Build netlist line
     s += QStringLiteral(" z0=%1 ").arg(s_z0);
-    s += QStringLiteral(" AC %1 ACPHASE %2 ").arg(vamp, phase);
+
+    // AC phase (must be numeric for Xyce)
+    const QString acPhase = isPhaseNumeric ? phase : "0";
+    s += QStringLiteral(" AC %1 %2 ").arg(vamp, acPhase);
+
+    // Transient analysis SIN source
     if (en_tran && !isTermination) {
-        s += QStringLiteral(" SIN 0 %1 %2 0 0 %3").arg(vamp, f, phase);
+      const QString transPhase = isPhaseNumeric ? phase : ("{" + phase + "}");
+      s += QStringLiteral(" SIN 0 %1 %2 0 0 %3").arg(vamp, f, transPhase);
     }
+
     s += "\n";
     return s;
 }
@@ -230,7 +245,7 @@ QString Source_ac::netlist()
     QString s = Model+":"+Name;
 
     // output all node names
-    for (Port *p1 : Ports)
+    for (Port *p1 : std::as_const(Ports))
       s += " "+p1->Connection->Name;   // node names
 
     // output all properties

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -360,18 +360,55 @@ QString Source_ac::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
 
 QString Source_ac::netlist()
 {
-    QString s = Model+":"+Name;
+  // Get the source parameters
+  const QStringList freqs  = parseList(getProperty("f")->Value);
+  const QStringList powers = parseList(getProperty("P")->Value);
+  const QStringList phases = parseList(getProperty("Phase")->Value);
+  const QString z    = getProperty("Z")->Value;
+  const QString num  = getProperty("Num")->Value;
+  const QString temp = getProperty("Temp")->Value;
 
-    // output all node names
+
+  const bool isTermination = (getProperty("LoadOnly")->Value == "true")
+                             || (powers.isEmpty() || powers.first().isEmpty());
+
+  // Single-tone: original format
+  if (freqs.size() <= 1 || isTermination) {
+    QString s = Model + ":" + Name;
     for (Port *p1 : std::as_const(Ports))
-      s += " "+p1->Connection->Name;   // node names
-
-    // output all properties
-    for(int i=0; i <= Props.count()-2; i++)
-      if(Props.at(i)->Name != "EnableTran")
-        s += " "+Props.at(i)->Name+"=\""+Props.at(i)->Value+"\"";
-
+      s += " " + p1->Connection->Name;
+    for (int i = 0; i <= Props.count() - 2; i++) {
+      const Property *p = Props.at(i);
+      if (p->Name != "EnableTran")
+        s += " " + p->Name + "=\"" + p->Value + "\"";
+    }
     return s + '\n';
+  }
+
+  // Broadcast a single-entry list to all tones, fall back to default if absent
+  auto pick = [](const QStringList &list, int i, const QString &fallback) -> QString {
+    if (list.isEmpty())   return fallback;
+    if (list.size() == 1) return list.first();
+    return (i < list.size()) ? list.at(i) : fallback;
+  };
+
+  const int N = freqs.size();
+  const QString nodePos = Ports.at(0)->Connection->Name;
+  const QString nodeNeg = Ports.at(1)->Connection->Name;
+
+  // Build the netlist
+  QString s;
+  for (int i = 0; i < N; ++i) {
+    const QString nodeAbove = (i == 0)     ? nodePos : QStringLiteral("%1_n%2").arg(Name).arg(i);
+    const QString nodeBelow = (i == N - 1) ? nodeNeg : QStringLiteral("%1_n%2").arg(Name).arg(i + 1);
+
+    s += QStringLiteral("%1:%2_t%3 %4 %5 Num=\"%6\" Z=\"%7\" P=\"%8\" f=\"%9\" Phase=\"%10\" Temp=\"%11\"\n")
+             .arg(Model, Name).arg(i + 1)
+             .arg(nodeAbove, nodeBelow)
+             .arg(num.toInt() + i)
+             .arg(z, pick(powers, i, "0"), freqs.at(i), pick(phases, i, "0"), temp);
+  }
+  return s;
 }
 
 QStringList Source_ac::parseList(const QString &raw) const

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -131,26 +131,11 @@ QString Source_ac::ngspice_netlist()
     if (freqs.size() > 1 && !isTermination) {
       return multitone_ngspice(z0, freqs, powers, phases, en_tran);
     } else {
-      // Single-tone setup — extract scalar values from the first index in the list
+      // Single-tone setup
       const QString pVal  = powers.isEmpty() ? QString() : powers.first();
       const QString f     = freqs.isEmpty()  ? QString() : spicecompat::normalize_value(freqs.first());
       const QString phase = phases.isEmpty() ? QStringLiteral("0") : phases.first();
-
-      const QString vamp = resolveVamp(pVal, z0, spicecompat::SPICEDefault);
-
-      if (isTermination) {
-        s += QStringLiteral(" dc 0 ac 0");
-      } else {
-        s += QStringLiteral(" dc 0 ac %1").arg(vamp);
-        if (en_tran)
-          s += QStringLiteral(" SIN(0 %1 %2 0 0 %3)").arg(vamp, f, phase);
-    }
-
-      s += QStringLiteral(" portnum %1").arg(getProperty("Num")->Value);
-      s += QStringLiteral(" z0 %1").arg(z0);
-      s += "\n";
-      return s;
-
+      return singletone_ngspice(s, z0, f, pVal, phase, en_tran, isTermination);
     }
 }
 
@@ -208,6 +193,29 @@ QString Source_ac::multitone_ngspice(double z0,
     s += '\n';
   }
 
+  return s;
+}
+
+
+QString Source_ac::singletone_ngspice(const QString &nodeString, double z0,
+                                      const QString &freq, const QString &pVal,
+                                      const QString &phase,
+                                      bool enTran, bool isTermination)
+{
+  QString s = nodeString;
+  const QString vamp = resolveVamp(pVal, z0, spicecompat::SPICEDefault);
+
+  if (isTermination) {
+    s += QStringLiteral(" dc 0 ac 0");
+  } else {
+    s += QStringLiteral(" dc 0 ac %1").arg(vamp);
+    if (enTran)
+      s += QStringLiteral(" SIN(0 %1 %2 0 0 %3)").arg(vamp, freq, phase);
+  }
+
+  s += QStringLiteral(" portnum %1").arg(getProperty("Num")->Value);
+  s += QStringLiteral(" z0 %1").arg(z0);
+  s += "\n";
   return s;
 }
 

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -229,68 +229,125 @@ QString Source_ac::xyce_netlist()
         s += " "+ nam;   // node names
     }
     s += QStringLiteral(" port=%1 ").arg(getProperty("Num")->Value);
+
     // Get source parameters
     QString s_z0 = spicecompat::normalize_value(getProperty("Z")->Value);
     double z0 = s_z0.toDouble();
-    QString pVal = getProperty("P")->Value.trimmed();
-    QString f = spicecompat::normalize_value(getProperty("f")->Value);
-    QString phase = getProperty("Phase")->Value.trimmed();
 
-    bool en_tran = true;
-    if (getProperty("EnableTran")->Value == "true") {
-      en_tran = true;
-    } else {
-      en_tran = false;
-    }
+    const QStringList freqs  = parseList(getProperty("f")->Value);
+    const QStringList powers = parseList(getProperty("P")->Value);
+    const QStringList phases = parseList(getProperty("Phase")->Value);
 
-    // Calculate the power
-    // The power may come explicitly in the "Power" field of the component (literal value) or be part of a sweep simulation (symbolic variable).
-    // Check if P is a symbolic parameter (not a numeric dBm literal)
-    bool isNumeric = false;
-    double p = spicecompat::normalize_value(pVal).toDouble(&isNumeric);
-
-    // Check if phase is numeric
-    bool isPhaseNumeric = false;
-    phase.toDouble(&isPhaseNumeric);
+    const bool en_tran       = (getProperty("EnableTran")->Value == "true");
 
     // if user has explicitly set LoadOnly OR
     // if P is empty (unset), the port acts as a terminated port (a passive load).
-    bool isTermination = (getProperty("LoadOnly")->Value == "true") || pVal.isEmpty();
+    const bool isTermination = (getProperty("LoadOnly")->Value == "true")
+                               || (powers.isEmpty() || powers.first().isEmpty());
 
-    // Calculate voltage amplitude
-    QString vamp;
-    if (isTermination) {
-      // Terminated port: set Vamp to 0
-      vamp = QString::number(0);
-    } else if (isNumeric) {
-      // Fixed value (not part of a parametric simulation)
-      double vrms = sqrt(z0 / 1000.0) * pow(10.0, p / 20.0);
-      double vamp_val = 2.0 * vrms * sqrt(2.0);
-      vamp = QString::number(vamp_val, 'g', 8);
+    if (freqs.size() > 1 && !isTermination) {
+      // Multi-tone
+      return multitone_xyce(z0, freqs, powers, phases, en_tran);
     } else {
-      // P is a symbolic variable (.PARAM)
-      // The dBm to V is embedded directly in the netlist line of the AC power source
-      // This is evaluated at each step
-      vamp = QStringLiteral("{2*sqrt(2)*sqrt(%1/1000)*pow(10,(%2)/20)}")
-                      .arg(z0).arg(pVal);
+      // Single-tone
+      const QString pVal  = powers.isEmpty() ? QString() : powers.first();
+      const QString freq  = freqs.isEmpty()  ? QString() : spicecompat::normalize_value(freqs.first());
+      const QString phase = phases.isEmpty() ? QStringLiteral("0") : phases.first();
+      return singletone_xyce(s, z0, pVal, freq, phase, en_tran, isTermination);
     }
 
-    // Build netlist line
-    s += QStringLiteral(" z0=%1 ").arg(s_z0);
-
-    // AC phase (must be numeric for Xyce)
-    const QString acPhase = isPhaseNumeric ? phase : "0";
-    s += QStringLiteral(" AC %1 %2 ").arg(vamp, acPhase);
-
-    // Transient analysis SIN source
-    if (en_tran && !isTermination) {
-      const QString transPhase = isPhaseNumeric ? phase : ("{" + phase + "}");
-      s += QStringLiteral(" SIN 0 %1 %2 0 0 %3").arg(vamp, f, transPhase);
-    }
-
-    s += "\n";
-    return s;
 }
+
+QString Source_ac::singletone_xyce(const QString &nodeString, double z0,
+                                   const QString &freq, const QString &pVal,
+                                   const QString &phase,
+                                   bool enTran, bool isTermination)
+{
+  const QString s_z0 = QString::number(z0, 'g', 8);
+  QString s = nodeString;
+  const QString vamp = resolveVamp(pVal, z0, spicecompat::SPICEXyce);
+
+  // ACPHASE on the Xyce PORT device must be a numeric literal;
+  // a parametric phase is wrapped in {...} only for the SIN transient source.
+  bool isPhaseNumeric = false;
+  phase.toDouble(&isPhaseNumeric);
+  const QString acPhase    = isPhaseNumeric ? phase : QStringLiteral("0");
+  const QString transPhase = isPhaseNumeric ? phase : ('{' + phase + '}');
+
+  s += QStringLiteral(" z0=%1 ").arg(s_z0);
+  s += QStringLiteral(" AC %1 %2 ").arg(vamp, acPhase);
+  if (enTran && !isTermination)
+    s += QStringLiteral(" SIN 0 %1 %2 0 0 %3").arg(vamp, freq, transPhase);
+
+  s += "\n";
+  return s;
+}
+
+
+QString Source_ac::multitone_xyce(double z0,
+                                  const QStringList &freqs,
+                                  const QStringList &powers,
+                                  const QStringList &phases,
+                                  bool enTran){
+  const QString s_z0 = QString::number(z0, 'g', 8);
+  const int N = freqs.size();
+
+  auto nodeName = [](Port *p) {
+    QString n = p->Connection->Name;
+    return (n == "gnd") ? QStringLiteral("0") : n;
+  };
+  const QString nodePos = nodeName(Ports.at(0));
+  const QString nodeNeg = nodeName(Ports.at(1));
+  auto intNode = [&](int k) {
+    return QStringLiteral("%1_n%2").arg(Name).arg(k);
+  };
+
+  QString s;
+
+  // Series impedance resistor
+  s += QStringLiteral("R_%1 %2 %3 %4\n")
+           .arg(Name, nodePos, intNode(0), s_z0);
+
+  // One voltage source per tone
+  // Helper: pick list[i] if available, broadcast list[0] if list has one entry, else fallback
+  auto pick = [](const QStringList &list, int i, const QString &fallback) -> QString {
+    if (list.isEmpty())       return fallback;
+    if (list.size() == 1)     return list.at(0);   // broadcast single entry to all tones
+    if (i < list.size())      return list.at(i);
+    return fallback;
+  };
+
+  for (int i = 0; i < N; ++i) {
+    const QString pVal  = pick(powers, i, QStringLiteral("0"));
+    const QString freq  = spicecompat::normalize_value(freqs.at(i));
+    const QString phase = pick(phases, i, QStringLiteral("0"));
+    const QString vamp  = resolveVamp(pVal, z0, spicecompat::SPICEXyce);
+
+    const QString nodeAbove = intNode(i);
+    const QString nodeBelow = (i == N - 1) ? nodeNeg : intNode(i + 1);
+
+    // ACPHASE must be a numeric literal on Xyce PORT device;
+    // for SIN, a parametric phase is wrapped in {...} to force expression evaluation.
+    bool isPhaseNumeric = false;
+    phase.toDouble(&isPhaseNumeric);
+    const QString acPhase    = isPhaseNumeric ? phase : QStringLiteral("0");
+    const QString transPhase = isPhaseNumeric ? phase : ('{' + phase + '}');
+
+    s += QStringLiteral("V_%1_t%2 %3 %4 DC 0 AC %5 %6")
+             .arg(Name).arg(i + 1)
+             .arg(nodeAbove, nodeBelow, vamp, acPhase);
+    if (enTran) {
+      s += QStringLiteral(" SIN 0 %1 %2 0 0 %3").arg(vamp, freq, transPhase);
+    }
+    s += '\n';
+  }
+
+  s += '\n';
+
+  return s;
+}
+
+
 
 QString Source_ac::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::SPICEDefault */)
 {

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -360,54 +360,134 @@ QString Source_ac::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
 
 QString Source_ac::netlist()
 {
-  // Get the source parameters
+  // Get source parameters
   const QStringList freqs  = parseList(getProperty("f")->Value);
   const QStringList powers = parseList(getProperty("P")->Value);
   const QStringList phases = parseList(getProperty("Phase")->Value);
+
   const QString z    = getProperty("Z")->Value;
-  const QString num  = getProperty("Num")->Value;
   const QString temp = getProperty("Temp")->Value;
 
+  const bool isTermination =
+      (getProperty("LoadOnly")->Value == "true")
+      || (powers.isEmpty() || powers.first().isEmpty());
 
-  const bool isTermination = (getProperty("LoadOnly")->Value == "true")
-                             || (powers.isEmpty() || powers.first().isEmpty());
+  // Parse Z0
+  double Z0, scale;
+  QString unit;
 
-  // Single-tone: original format
-  if (freqs.size() <= 1 || isTermination) {
-    QString s = Model + ":" + Name;
-    for (Port *p1 : std::as_const(Ports))
-      s += " " + p1->Connection->Name;
-    for (int i = 0; i <= Props.count() - 2; i++) {
-      const Property *p = Props.at(i);
-      if (p->Name != "EnableTran")
-        s += " " + p->Name + "=\"" + p->Value + "\"";
-    }
-    return s + '\n';
+  misc::str2num(z, Z0, unit, scale);
+  Z0 *= scale;
+
+  // Passive termination only
+  if (isTermination) {
+
+    const QString nodePos =
+        Ports.at(0)->Connection->Name;
+
+    const QString nodeNeg =
+        Ports.at(1)->Connection->Name;
+
+    return QStringLiteral(
+               "R:R_%1 %2 %3 "
+               "R=\"%4 Ohm\" "
+               "Temp=\"%5\"\n")
+        .arg(Name,
+             nodePos,
+             nodeNeg,
+             QString::number(Z0, 'g', 12),
+             temp);
   }
 
-  // Broadcast a single-entry list to all tones, fall back to default if absent
-  auto pick = [](const QStringList &list, int i, const QString &fallback) -> QString {
-    if (list.isEmpty())   return fallback;
-    if (list.size() == 1) return list.first();
+  // Always synthesize Thévenin equivalent, as done with Xyce and ngspice. Don't rely on the qucastor AC power source
+  return multitone_qucsator(
+      Z0,
+      freqs,
+      powers,
+      phases,
+      temp);
+}
+
+QString Source_ac::multitone_qucsator(double z0,
+                                      const QStringList &freqs,
+                                      const QStringList &powers,
+                                      const QStringList &phases,
+                                      const QString &temp)
+{
+  auto pick = [](const QStringList &list,
+                 int i,
+                 const QString &fallback) -> QString {
+    if (list.isEmpty())
+      return fallback;
+
+    if (list.size() == 1)
+      return list.first();
+
     return (i < list.size()) ? list.at(i) : fallback;
   };
 
   const int N = freqs.size();
+
   const QString nodePos = Ports.at(0)->Connection->Name;
   const QString nodeNeg = Ports.at(1)->Connection->Name;
 
-  // Build the netlist
-  QString s;
-  for (int i = 0; i < N; ++i) {
-    const QString nodeAbove = (i == 0)     ? nodePos : QStringLiteral("%1_n%2").arg(Name).arg(i);
-    const QString nodeBelow = (i == N - 1) ? nodeNeg : QStringLiteral("%1_n%2").arg(Name).arg(i + 1);
+  auto intNode = [&](int k) {
+    return QStringLiteral("%1_n%2").arg(Name).arg(k);
+  };
 
-    s += QStringLiteral("%1:%2_t%3 %4 %5 Num=\"%6\" Z=\"%7\" P=\"%8\" f=\"%9\" Phase=\"%10\" Temp=\"%11\"\n")
-             .arg(Model, Name).arg(i + 1)
-             .arg(nodeAbove, nodeBelow)
-             .arg(num.toInt() + i)
-             .arg(z, pick(powers, i, "0"), freqs.at(i), pick(phases, i, "0"), temp);
+  QString s;
+
+  // Single explicit source resistance
+  s += QStringLiteral(
+           "R:R_%1 %2 %3 R=\"%4 Ohm\" Temp=\"%5\"\n")
+           .arg(Name,
+                nodePos,
+                intNode(0),
+                QString::number(z0, 'g', 12),
+                temp);
+
+  // One ideal sinusoidal voltage source per tone
+  for (int i = 0; i < N; ++i) {
+
+    const QString freq  = freqs.at(i);
+    const QString power = pick(powers, i, QStringLiteral("0"));
+    const QString phase = pick(phases, i, QStringLiteral("0"));
+
+    // Convert dBm -> peak voltage
+    bool ok = false;
+    double p_dbm = spicecompat::normalize_value(power).toDouble(&ok);
+
+    double vamp = 0.0;
+
+    if (ok) {
+      // Vrms from dBm into z0
+      const double vrms =
+          std::sqrt(z0 / 1000.0) *
+          std::pow(10.0, p_dbm / 20.0);
+
+      vamp = 2 * vrms * std::sqrt(2.0); // peak amplitude [V -> R] -> R (same as with ngspice and xyce)
+    }
+
+    const QString nodeAbove = intNode(i);
+    const QString nodeBelow =
+        (i == N - 1) ? nodeNeg : intNode(i + 1);
+
+    s += QStringLiteral(
+             "Vac:V_%1_t%2 %3 %4 "
+             "U=\"%5 V\" "
+             "f=\"%6\" "
+             "Phase=\"%7\" "
+             "Theta=\"0\" "
+             "T=\"0\"\n")
+             .arg(Name)
+             .arg(i + 1)
+             .arg(nodeAbove,
+                  nodeBelow,
+                  QString::number(vamp, 'g', 12),
+                  freq,
+                  phase);
   }
+
   return s;
 }
 

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -108,11 +108,12 @@ QString Source_ac::ngspice_netlist()
         s += " "+ nam;   // node names
     }
 
-    // Get source parameters
+    // Get source parameters (as lists)
     double z0 = spicecompat::normalize_value(getProperty("Z")->Value).toDouble();
-    QString pVal = getProperty("P")->Value.trimmed();
-    QString f = spicecompat::normalize_value(getProperty("f")->Value);
-    QString phase = spicecompat::normalize_value(getProperty("Phase")->Value);
+    const QStringList freqs   = parseList(getProperty("f")->Value);
+    const QStringList powers  = parseList(getProperty("P")->Value);
+    const QStringList phases  = parseList(getProperty("Phase")->Value);
+
 
     bool en_tran = true;
     if (getProperty("EnableTran")->Value == "true") {
@@ -121,43 +122,95 @@ QString Source_ac::ngspice_netlist()
         en_tran = false;
     }
 
-    // Calculate the power
-    // The power may come explicitly in the "Power" field of the component (literal value) or be part of a sweep simulation (symbolic variable).
-    // Check if P is a symbolic parameter (not a numeric dBm literal)
-    bool isNumeric = false;
-    spicecompat::normalize_value(pVal).toDouble(&isNumeric);
-    // if user has explicitly set LoadOnly OR
-    // if P is empty (unset), the port acts as a terminated port (a passive load).
-    bool isTermination = (getProperty("LoadOnly")->Value == "true") || pVal.isEmpty();
+    // if user has explicitly set LoadOnly OR if P is empty (unset), the port acts as a terminated port (a passive load).
+    const bool isTermination = (getProperty("LoadOnly")->Value == "true")
+                               || (powers.isEmpty() || powers.first().isEmpty());
 
-    QString vamp;
-    if (isTermination) {
-      // Terminated port: set Vamp to 0
-      s += QStringLiteral(" dc 0 ac 0");
-    } else if (isNumeric) {
-      // Original behaviour: pre-compute amplitude
-      double p = spicecompat::normalize_value(pVal).toDouble();
-      double vrms = sqrt(z0/1000.0) * pow(10, p/20.0);
-      double vamp = 2.0 * vrms * sqrt(2.0);
-      s += QStringLiteral(" dc 0 ac %1").arg(vamp);
-      if (en_tran)
-        s += QStringLiteral(" SIN(0 %1 %2 0 0 %3)").arg(vamp).arg(f, phase);
+
+    // Multi-tone setup
+    if (freqs.size() > 1 && !isTermination) {
+      return multitone_ngspice(z0, freqs, powers, phases, en_tran);
     } else {
-      // P is a parameter name — emit a .PARAM expression and reference it
-      // vamp = 2*sqrt(2) * sqrt(z0/1000) * 10^(P/20)
-      vamp = QStringLiteral("'2*sqrt(2)*sqrt(%1/1000)*pow(10,(%2)/20)'")
-                 .arg(z0).arg(pVal);
-      s += QStringLiteral(" dc 0 ac %1").arg(vamp);
-      if (en_tran){
-        s += QStringLiteral(" SIN(0 %1 %2 0 0 %3)").arg(vamp, f, phase);
-      }
+      // Single-tone setup — extract scalar values from the first index in the list
+      const QString pVal  = powers.isEmpty() ? QString() : powers.first();
+      const QString f     = freqs.isEmpty()  ? QString() : spicecompat::normalize_value(freqs.first());
+      const QString phase = phases.isEmpty() ? QStringLiteral("0") : phases.first();
+
+      const QString vamp = resolveVamp(pVal, z0, spicecompat::SPICEDefault);
+
+      if (isTermination) {
+        s += QStringLiteral(" dc 0 ac 0");
+      } else {
+        s += QStringLiteral(" dc 0 ac %1").arg(vamp);
+        if (en_tran)
+          s += QStringLiteral(" SIN(0 %1 %2 0 0 %3)").arg(vamp, f, phase);
     }
 
-    s += QStringLiteral(" portnum %1").arg(getProperty("Num")->Value);
-    s += QStringLiteral(" z0 %1").arg(z0);
-    s += "\n";
-    return s;
+      s += QStringLiteral(" portnum %1").arg(getProperty("Num")->Value);
+      s += QStringLiteral(" z0 %1").arg(z0);
+      s += "\n";
+      return s;
+
+    }
 }
+
+QString Source_ac::multitone_ngspice(double z0,
+                                     const QStringList &freqs,
+                                     const QStringList &powers,
+                                     const QStringList &phases,
+                                     bool enTran)
+{
+  // Resolve external node names
+  auto toSpiceNode = [](Port *p) {
+    const QString n = p->Connection->Name;
+    return (n == "gnd") ? QStringLiteral("0") : n;
+  };
+  const QString nodePos = toSpiceNode(Ports.at(0));
+  const QString nodeNeg = toSpiceNode(Ports.at(1));
+
+  // Nodes between the series sources: "P1_n0", "P1_n1", ...
+  auto junctionNode = [&](int k) {
+    return QStringLiteral("%1_n%2").arg(Name).arg(k);
+  };
+
+  // Broadcast a single-entry list to all tones
+  // Falls back to a default if the list is empty or shorter than the tone index.
+  auto pick = [](const QStringList &list, int i, const QString &fallback) -> QString {
+    if (list.isEmpty())    return fallback;
+    if (list.size() == 1)  return list.at(0);
+    return (i < list.size()) ? list.at(i) : fallback;
+  };
+
+  const int N = freqs.size();
+  QString s;
+
+  // Series impedance, Z0
+  s += QStringLiteral("R_%1 %2 %3 %4\n")
+           .arg(Name, nodePos, junctionNode(0))
+           .arg(z0, 0, 'g', 8);
+
+  // Series AC voltage sources
+  for (int i = 0; i < N; ++i) {
+    const QString pVal      = pick(powers, i, QStringLiteral("0"));
+    const QString freq      = spicecompat::normalize_value(freqs.at(i));
+    const QString phase     = pick(phases, i, QStringLiteral("0"));
+    const QString vamp      = resolveVamp(pVal, z0, spicecompat::SPICEDefault);
+    const QString nodeAbove = junctionNode(i);
+    const QString nodeBelow = (i == N - 1) ? nodeNeg : junctionNode(i + 1);
+
+    s += QStringLiteral("V_%1_t%2 %3 %4 DC 0 AC %5")
+             .arg(Name).arg(i + 1)
+             .arg(nodeAbove, nodeBelow, vamp);
+
+    if (enTran){
+      s += QStringLiteral(" SIN(0 %1 %2 0 0 %3)").arg(vamp, freq, phase);
+    }
+    s += '\n';
+  }
+
+  return s;
+}
+
 
 QString Source_ac::xyce_netlist()
 {
@@ -254,4 +307,51 @@ QString Source_ac::netlist()
         s += " "+Props.at(i)->Name+"=\""+Props.at(i)->Value+"\"";
 
     return s + '\n';
+}
+
+QStringList Source_ac::parseList(const QString &raw) const
+{
+  // Strip surrounding brackets or braces if any, e.g. "{1 MHz, 2 MHz}" or "[1 MHz; 2 MHz]"
+  QString cleaned = raw.trimmed();
+  if ((cleaned.startsWith('{') && cleaned.endsWith('}')) ||
+      (cleaned.startsWith('[') && cleaned.endsWith(']'))) {
+    cleaned = cleaned.mid(1, cleaned.length() - 2).trimmed();
+  }
+
+  QStringList parts = cleaned.split(QRegularExpression("[,;]"));
+  for (QString &s : parts){
+    s = s.trimmed();
+  }
+
+  // Drop any trailing empty entry produced by a trailing delimiter,
+   // e.g. "980 MHz, 990 MHz," would otherwise produce a spurious third empty entry
+  while (!parts.isEmpty() && parts.last().isEmpty()) {
+    parts.removeLast();
+  }
+
+  return parts;
+}
+
+QString Source_ac::resolveVamp(const QString &pVal, double z0,
+                               spicecompat::SpiceDialect dialect) const
+{
+  if (pVal.isEmpty())
+    return QStringLiteral("0");
+
+  bool isNumeric = false;
+  double p = spicecompat::normalize_value(pVal).toDouble(&isNumeric);
+  if (isNumeric) {
+    double vrms = sqrt(z0 / 1000.0) * pow(10.0, p / 20.0);
+    return QString::number(2.0 * vrms * sqrt(2.0), 'g', 8);
+  }
+
+  if (dialect == spicecompat::SPICEXyce) {
+    // Xyce
+    return QStringLiteral("{2*sqrt(2)*sqrt(%1/1000)*pow(10,(%2)/20)}")
+        .arg(z0).arg(pVal);
+  } else {
+    // ngspice
+    return QStringLiteral("'2*sqrt(2)*sqrt(%1/1000)*pow(10,(%2)/20)'")
+        .arg(z0).arg(pVal);
+  }
 }

--- a/qucs/components/source_ac.h
+++ b/qucs/components/source_ac.h
@@ -23,26 +23,31 @@
 
 class Source_ac : public Component  {
 private:
+  /// @brief Build the ngspice netlist line for this component.
   QString ngspice_netlist();
+
+  /// @brief Build the ngspice netlist line for this component.
   QString xyce_netlist();
 
-  /// @brief Prepare the ngspice netline for the multitone setup
-  /// @param z0 Characteristic impedance
-  /// @param freqs List of the tone frequencies
-  /// @param powers List of powers per carrier in dBm (to be converter in Vpeak inside)
+  /// @brief Prepare the ngspice netline for the multitone setup (a series R (Z0) + as many series voltage sources as tones)
+  /// @param z0     Characteristic impedance
+  /// @param freqs  List of the tone frequencies
+  /// @param powers List of powers per carrier in dBm
   /// @param phases List of phases per carrier
-  /// @param enTran Flag for the transient simulation
+  /// @param enTran Flag for the transient simulation.
+  ///               When true, append a SIN(...) transient specification to each voltage source
   QString multitone_ngspice(double z0,
                             const QStringList &freqs,
                             const QStringList &powers,
                             const QStringList &phases, bool enTran);
 
-  /// @brief Prepare the Xyce netline for the multitone setup
-  /// @param z0 Characteristic impedance
-  /// @param freqs List of the tone frequencies
+  /// @brief Prepare the Xyce netline for the multitone setup (a series R (Z0) + as many series voltage sources as tones)
+  /// @param z0     Characteristic impedance
+  /// @param freqs  List of the tone frequencies
   /// @param powers List of powers per carrier in dBm (to be converter in Vpeak inside)
   /// @param phases List of phases per carrier
-  /// @param enTran Flag for the transient simulation
+  /// @param enTran Flag for the transient simulation.
+  ///               When true, append a SIN(...) transient specification to each voltage source
   QString multitone_xyce (double z0,
                          const QStringList &freqs,
                          const QStringList &powers,
@@ -51,10 +56,11 @@ private:
   /// @brief Prepare the ngspice netline for the single-tone setup
   /// @param z0 Characteristic impedance
   /// @param freq Frequency of the tone
-  /// @param power RMS power
-  /// @param phases Phase
+  /// @param power Available power (dBm)
+  /// @param phases Initial phase
   /// @param enTran Flag for the transient simulation
-  /// @param isTermination Flag for passive port
+  ///               When true, append a SIN(...) transient specification.
+  /// @param isTermination Flag for passive port (Vamp = 0)
   QString singletone_ngspice(const QString &nodeString, double z0,
                              const QString &freq, const QString &pVal,
                              const QString &phase,
@@ -63,10 +69,11 @@ private:
   /// @brief Prepare the Xyce netline for the single-tone setup
   /// @param z0 Characteristic impedance
   /// @param freq Frequency of the tone
-  /// @param power RMS power
-  /// @param phases Phase
+  /// @param power Available power (dBm)
+  /// @param phases Initial phase
   /// @param enTran Flag for the transient simulation
-  /// @param isTermination Flag for passive port
+  ///               When true, append a SIN(...) transient specification.
+  /// @param isTermination Flag for passive port (Vamp = 0)
   QString singletone_xyce(const QString &nodeString, double z0,
                           const QString &freq,
                           const QString &pVal,
@@ -77,21 +84,46 @@ private:
 
   /// @brief Split a comma-separated property string into a trimmed list.
   /// @param raw String input from a component property field
+  /// @details Surrounding brackets or braces (e.g. "{1 GHz, 2 GHz}" or "[1 GHz; 2 GHz]")
+  /// are stripped before splitting.
   QStringList parseList(const QString &raw) const;
 
   /// @brief Convert the RMS power into a Xyce/ngspice netlist
   /// @param pVal Power in dBm
   /// @param z0 Characteristic impedance
   /// @param dialect Spice dialect: Xyce of ngspice
+  /// @details When @p pVal is a numeric dBm literal the result is pre-computed:
+  /// Vamp = 2 * sqrt(2) * sqrt(z0/1000) * 10^(pVal/20)
+  /// When @p pVal is a .PARAM name the conversion is embedded as an
+  /// expression in the dialect-appropriate quoting style (single quotes for ngspice, curly braces for Xyce).
   QString resolveVamp(const QString &pVal, double z0, spicecompat::SpiceDialect dialect) const;
 
 public:
+  /// @brief Class constructor
   Source_ac();
+
+  /// @brief Class destructor
   ~Source_ac();
+
+  /// @brief Create a fresh instance of this component.
+  /// @return Heap-allocated Source_ac; ownership passes to the caller.
   Component* newOne();
+
+  /// @brief Return display metadata and optionally create a new instance.
+  /// @param Name        Name of the component
+  /// @param BitmapFile  Bitmap file with the symbol
+  /// @param getNewOne   When true, allocate and return a new instance.
+  /// @return            New Source_ac instance if @p getNewOne is true, else 0.
   static Element* info(QString&, char* &, bool getNewOne=false);
 protected:
+
+  /// @brief Dispatcher: route to the correct dialect-specific netlist builder.
+  /// @param dialect  SPICEXyce selects the Xyce builder
+  ///                 Otherwise, it selects the ngspice builder.
+  /// @return         The netlist fragment for this component.
   QString spice_netlist(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
+
+  /// @brief Build the qucsator netlist line for this component.
   QString netlist();
 };
 

--- a/qucs/components/source_ac.h
+++ b/qucs/components/source_ac.h
@@ -26,15 +26,28 @@ private:
   QString ngspice_netlist();
   QString xyce_netlist();
 
-  /// @brief Prepare netline for multitone setup
+  /// @brief Prepare the ngspice netline for the multitone setup
   /// @param z0 Characteristic impedance
   /// @param freqs List of the tone frequencies
   /// @param powers List of powers per carrier in dBm (to be converter in Vpeak inside)
   /// @param phases List of phases per carrier
   /// @param enTran Flag for the transient simulation
-  QString multitone_ngspice(double z0, const QStringList &freqs,
+  QString multitone_ngspice(double z0,
+                            const QStringList &freqs,
                             const QStringList &powers,
                             const QStringList &phases, bool enTran);
+
+  /// @brief Prepare the ngspice netline for the single-tone setup
+  /// @param z0 Characteristic impedance
+  /// @param freq Frequency of the tone
+  /// @param power RMS power
+  /// @param phases Phase
+  /// @param enTran Flag for the transient simulation
+  /// @param isTermination Flag for passive port
+  QString singletone_ngspice(const QString &nodeString, double z0,
+                             const QString &freq, const QString &pVal,
+                             const QString &phase,
+                             bool enTran, bool isTermination);
 
 
   /// @brief Split a comma-separated property string into a trimmed list.

--- a/qucs/components/source_ac.h
+++ b/qucs/components/source_ac.h
@@ -19,11 +19,34 @@
 #define SOURCE_AC_H
 
 #include "component.h"
+#include <QRegularExpression>
 
 class Source_ac : public Component  {
 private:
   QString ngspice_netlist();
   QString xyce_netlist();
+
+  /// @brief Prepare netline for multitone setup
+  /// @param z0 Characteristic impedance
+  /// @param freqs List of the tone frequencies
+  /// @param powers List of powers per carrier in dBm (to be converter in Vpeak inside)
+  /// @param phases List of phases per carrier
+  /// @param enTran Flag for the transient simulation
+  QString multitone_ngspice(double z0, const QStringList &freqs,
+                            const QStringList &powers,
+                            const QStringList &phases, bool enTran);
+
+
+  /// @brief Split a comma-separated property string into a trimmed list.
+  /// @param raw String input from a component property field
+  QStringList parseList(const QString &raw) const;
+
+  /// @brief Convert the RMS power into a Xyce/ngspice netlist
+  /// @param pVal Power in dBm
+  /// @param z0 Characteristic impedance
+  /// @param dialect Spice dialect: Xyce of ngspice
+  QString resolveVamp(const QString &pVal, double z0, spicecompat::SpiceDialect dialect) const;
+
 public:
   Source_ac();
   ~Source_ac();

--- a/qucs/components/source_ac.h
+++ b/qucs/components/source_ac.h
@@ -37,6 +37,17 @@ private:
                             const QStringList &powers,
                             const QStringList &phases, bool enTran);
 
+  /// @brief Prepare the Xyce netline for the multitone setup
+  /// @param z0 Characteristic impedance
+  /// @param freqs List of the tone frequencies
+  /// @param powers List of powers per carrier in dBm (to be converter in Vpeak inside)
+  /// @param phases List of phases per carrier
+  /// @param enTran Flag for the transient simulation
+  QString multitone_xyce (double z0,
+                         const QStringList &freqs,
+                         const QStringList &powers,
+                         const QStringList &phases, bool enTran);
+
   /// @brief Prepare the ngspice netline for the single-tone setup
   /// @param z0 Characteristic impedance
   /// @param freq Frequency of the tone
@@ -48,6 +59,20 @@ private:
                              const QString &freq, const QString &pVal,
                              const QString &phase,
                              bool enTran, bool isTermination);
+
+  /// @brief Prepare the Xyce netline for the single-tone setup
+  /// @param z0 Characteristic impedance
+  /// @param freq Frequency of the tone
+  /// @param power RMS power
+  /// @param phases Phase
+  /// @param enTran Flag for the transient simulation
+  /// @param isTermination Flag for passive port
+  QString singletone_xyce(const QString &nodeString, double z0,
+                          const QString &freq,
+                          const QString &pVal,
+                          const QString &phase,
+                          bool enTran, bool isTermination);
+
 
 
   /// @brief Split a comma-separated property string into a trimmed list.

--- a/qucs/components/source_ac.h
+++ b/qucs/components/source_ac.h
@@ -19,6 +19,7 @@
 #define SOURCE_AC_H
 
 #include "component.h"
+#include "misc.h"
 #include <QRegularExpression>
 
 class Source_ac : public Component  {
@@ -79,6 +80,18 @@ private:
                           const QString &pVal,
                           const QString &phase,
                           bool enTran, bool isTermination);
+
+  /// @brief Prepare the ngspice netline for the single-tone setup
+  /// @param z0 Characteristic impedance
+  /// @param freq Frequency of the tone
+  /// @param power Available power (dBm)
+  /// @param phases Initial phase
+  /// @param temp Temperature
+  QString multitone_qucsator(double z0,
+                             const QStringList &freqs,
+                             const QStringList &powers,
+                             const QStringList &phases,
+                             const QString &temp);
 
 
 


### PR DESCRIPTION
This PR extends the AC power source component to handle multiple frequencies and phases. The goal is to simplify circuit setup for multitone simulations. The AC power source component now accept a list of frequencies and phases and construct the netlist accordingly.

**Two-tone test before this PR**

<img width="740" height="495" alt="image" src="https://github.com/user-attachments/assets/319c6728-ee64-4f0e-9263-fe6be6ee5ea3" />

**Two-tone test with this PR**

<img width="633" height="429" alt="image" src="https://github.com/user-attachments/assets/a20d8492-3868-478f-8e9a-1285f86c765c" />

Once working on this, I’ve found that the qucsator-rf power source give wrong results in HB and transient simulations. In order to fix this I replaced the qucsator-rf power source instantiation by an AC voltage source + a Z0 resistor in the netlist. Now the qucsator-rf results are consistent with Xyce (HB and tran) and ngspice (tran)

This is the workspace I've used for testing this new features. [Multitone_AC_Power_prj.zip](https://github.com/user-attachments/files/28377436/Multitone_AC_Power_prj.zip)

Tests:
    • Single-tone and Multitone HB: Verified on both qucsator-rf and Xyce backends. Amplitude and phase match expected results. 
    • Single-tone transient: Results are consistent across all three backends (qucsator-rf, Xyce, ngspice). The phase parameter is ok.
    • Multitone Transient Simulations: Waveforms are consistent across all simulation backends. 

<img width="1259" height="717" alt="image" src="https://github.com/user-attachments/assets/4e3adadf-e2e7-496b-ae16-63ec52b7a0a1" />


<img width="1259" height="850" alt="image" src="https://github.com/user-attachments/assets/3a2ffaf3-c289-4129-a13d-11a4db38048d" />

