### PR TITLE
fix(spiceLibComp): handle non-linear port indices

### DIFF
--- a/qucs/extsimkernels/spicelibcompdialog.cpp
+++ b/qucs/extsimkernels/spicelibcompdialog.cpp
@@ -444,7 +444,10 @@ void SpiceLibCompDialog::slotTableCellDoubleClick()
 
   QComboBox *cbxSelectPin = new QComboBox;
   cbxSelectPin->addItem("NC");
-  for (int i = 1; i <= a_symbolPinsCount; i++) {
+  // Ports might not be in a linear range; use the actual indices directly
+  // to ensure correct lookup
+  QList<int> portIndices = a_symbol->getPortIndices();
+  for (int i : portIndices) {
     bool pinAssigned = false;
     for(int j = 0; j < a_tbwPinsTable->rowCount(); j++) {
       if (j == r) continue;

--- a/qucs/spicecomponents/spicelibcomp.cpp
+++ b/qucs/spicecomponents/spicelibcomp.cpp
@@ -232,25 +232,52 @@ QString SpiceLibComp::spice_netlist(spicecompat::SpiceDialect dialect /* = spice
   } else {
     // Sanitize input from dialog
     QStringList pin_nums = pins.split(";", Qt::SkipEmptyParts);
-    int pinCount = pin_nums.count();
     int portCount = Ports.count();
 
-    if (pinCount != portCount) {
-      qWarning() << "pinCount=" << pinCount << " != portCount=" << portCount << ", malformed input?";
+    // Extract port numbers and check for duplicates
+    QList<int> uniquePortNumbers;
+    for (const QString &p : pin_nums) {
+      bool ok = false;
+      int num = p.trimmed().toInt(&ok);
+      if (!ok) {
+        qWarning() << "Invalid pin number:" << p << "; skipping";
+        continue;
+      }
+
+      // check if duplicate
+      if (uniquePortNumbers.contains(num)) {
+        qWarning() << "Duplicate pin number:" << num
+                   << "; only the first occurrence will be used.";
+      } else {
+        uniquePortNumbers.append(num);
+      }
     }
 
-    for (int i = 0; i < pinCount; i++) {
-      bool isNumber = false;
-      int pn = pin_nums.at(i).trimmed().toInt(&isNumber);
-      if (!isNumber) {
-        qWarning() << "Invalid pin number:" << pin_nums.at(i) << "; skipping";
+    // sort for ranking
+    std::sort(uniquePortNumbers.begin(), uniquePortNumbers.end());
+    int pinCount = uniquePortNumbers.count();
+
+    if (pinCount != portCount) {
+      qWarning() << QString("pinCount=%1 != portCount=%2, malformed input?")
+                  .arg(pinCount)
+                  .arg(portCount);
+    }
+
+    // Normalize pin_nums to ranks (0-based)
+    for (const QString &p : pin_nums) {
+      bool ok = false;
+      int num = p.trimmed().toInt(&ok);
+      if (!ok) {
         continue;
       }
-      if (pn < 1 || pn > portCount) {
-        qWarning() << "Pin number out of range:" << pn << "; skipping";
+
+      int rank = uniquePortNumbers.indexOf(num);
+      if (rank < 0 || rank >= Ports.count()) {
+        qWarning() << "Normalized pin number" << rank << "out of bounds; skipping";
         continue;
       }
-      Port *pp = Ports.at(pn-1);
+
+      Port *pp = Ports.at(rank);
       s += " " + spicecompat::normalize_node_name(pp->Connection->Name);
     }
   }

--- a/qucs/symbolwidget.cpp
+++ b/qucs/symbolwidget.cpp
@@ -601,7 +601,14 @@ int SymbolWidget::analyseLine(const QString& Row)
     if(!getCompLineIntegers(Row, &i1, &i2, &i3))  return -1;
     QString portName = Row.section(' ', 5).trimmed();
     if (!portName.isEmpty()) {
-        PortNames.insert(i3, portName);
+      // Port already exists at this index and will be overridden
+      if (PortNames.contains(i3)) {
+        qWarning() << QString("Port index %1 overridden, old port '%2' replaced by '%3'")
+                      .arg(i3)
+                      .arg(getPortName(i3))
+                      .arg(portName);
+      }
+      PortNames.insert(i3, portName);
     }
     Arcs.append(new struct qucs::Arc(i1-4, i2-4, 8, 8, 0, 16*360,
                                QPen(Qt::red,1)));
@@ -812,4 +819,8 @@ void SymbolWidget::setPaintText(const QString &txt)
 
 QString SymbolWidget::getPortName(int n) {
     return PortNames.value(n, QString());
+}
+
+QList<int> SymbolWidget::getPortIndices() const {
+  return PortNames.keys();
 }

--- a/qucs/symbolwidget.h
+++ b/qucs/symbolwidget.h
@@ -57,6 +57,7 @@ public:
   bool showPinNumbersEnabled() { return showPinNumbers; }
   int getPortsNumber() { return portsNumber; }
   QString getPortName(int n);
+  QList<int> getPortIndices() const;
   void setPaintText(const QString &txt);
   void setWarning(const QString &warn) { Warning = warn; }
   // component properties


### PR DESCRIPTION
### What

Use actual port indices from `PortNames`  instead of assuming a linear range. 
Additionally, a `qWarning` is added when overriding a port (same index/number). 
For netlisting, pin numbers are normalized to ranks to handle non-linear or sparse port indices.

### Example:

Using an extended example from #1668, where ports are defined as (index, name): (1, P1), (3, P3), (4, P4), (5, P5), (6, P6),
the dialog now currently displays:

<img width="1723" height="745" alt="image" src="https://github.com/user-attachments/assets/0e46ea33-03a0-445f-aff5-e454ed8373e3" />

Where we now can see that the second port is now P3 and not an empty field.

**Netlisting Example**

With the following map:

<img width="1719" height="1415" alt="image" src="https://github.com/user-attachments/assets/79af5252-9c6c-4240-b964-d4020c3acb9a" />

I get the netlist:

```
* Qucs 26.1.1  /home/torleif/qucs_test.sch
.INCLUDE "/home/torleif/qucs_bug/spicelib_iterator/subckt.cir"
XX1  SYM4 SYM3 SYM1 SYM5 SYM6 RLADDER 
.END
```

Which I would consider _correct_ in this case

**NOTE:**

Since every port must be mapped, ranked indexing works, but it would break if ports could be arbitrarily skipped (would require netlisting to a floating net).

Fixes: #1668 

