### PR TITLE
Fix QucsatorRF simulation regressions after #1669 (SP, power sweep, backward compatibility)

### DIFF
--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -1818,6 +1818,31 @@ Component *getComponentFromName(QString &Line, Schematic *p) {
         return 0;
     }
 
+    // Migrate old Pac/Vac schematics saved before Phase property was inserted at index 4 (PR #1669).
+    // Old order (7 props): Num, Z, P, f, Temp, EnableTran, LoadOnly
+    // New order (8 props): Num, Z, P, f, Phase, Temp, EnableTran, LoadOnly
+    // In old versions, Temp contains a boolean string because old positional values shifted, so the
+    // idea is to detect that and fix it here.
+    if (c->Model == "Pac" || c->Model == "Vac") {
+      Property *pTemp = c->getProperty("Temp");
+      if (pTemp && (pTemp->Value == "true" || pTemp->Value == "false")) {
+        // Values are shifted: index 4 (Phase) has Temp value, index 5 (Temp) has EnableTran value
+        Property *pPhase = c->getProperty("Phase");
+        Property *pEnableTran = c->getProperty("EnableTran");
+        Property *pLoadOnly = c->getProperty("LoadOnly");
+        // Shift values back: Temp gets Phase's value, EnableTran gets Temp's value, etc.
+        pEnableTran->Value = pTemp->Value;       // "true"/"false" belongs here
+        pTemp->Value = pPhase->Value;            // temperature value belongs here
+        pPhase->Value = "0";                     // Phase gets its default
+        // LoadOnly was also shifted - it got EnableTran's old value
+        // but EnableTran already had the right value shifted in above.
+        // Check LoadOnly too:
+        if (pLoadOnly && (pLoadOnly->Value != "true" && pLoadOnly->Value != "false")) {
+          pLoadOnly->Value = "false";
+        }
+      }
+    }
+
     cstr = c->Name;   // is perhaps changed in "recreate" (e.g. subcircuit)
     int x = c->tx, y = c->ty;
     c->setSchematic(p);

--- a/qucs/components/param_sweep.cpp
+++ b/qucs/components/param_sweep.cpp
@@ -231,3 +231,59 @@ QString Param_Sweep::spice_netlist(spicecompat::SpiceDialect dialect /* = spicec
     return s.toLower();
 }
 
+
+// In linear and log sweeps, check if Start/Stop values have "dBm" units.
+// QucsatorRF converts dBm to watts before passing values to the equation
+// evaluator, so a linear dBm sweep becomes linear in watts, so the linear
+// sweep in dBm is list.
+// This function was introduced after the qucsator's AC Power source was replaced
+// by a AC Voltage source + a Z0 resistor in PR #1669 (to match Xyce and ngspice behaviour
+// and fix problems with TR and HB simulations)
+QString Param_Sweep::netlist()
+{
+  const QString type  = getProperty("Type")->Value;
+  const QString param = getProperty("Param")->Value;
+
+  if (type == "lin" || type == "log") {
+    QString startUnit, stopUnit, pointsUnit;
+    double start, stop, points, fac;
+
+    misc::str2num(getProperty("Start")->Value,  start,  startUnit,  fac);
+    start *= fac;
+    misc::str2num(getProperty("Stop")->Value,   stop,   stopUnit,   fac);
+    stop *= fac;
+    misc::str2num(getProperty("Points")->Value, points, pointsUnit, fac);
+    points *= fac;
+
+    // Detect dBm units
+    if (startUnit.trimmed().toLower() == "dbm" ||
+        stopUnit.trimmed().toLower()  == "dbm") {
+
+      // Convert each dBm point to watts: P_W = 10^(P_dBm/10) / 1000
+      QStringList wattsValues;
+      const double step = (stop - start) / (points - 1);
+      for (int i = 0; i < (int)points; ++i) {
+        double p_dbm = start + i * step;
+        double p_w   = std::pow(10.0, p_dbm / 10.0) / 1000.0;
+        wattsValues << QString::number(p_w, 'g', 12);
+      }
+
+      // Emit as a precorrected list in Watts that map a linear sweep in dBm
+      return QStringLiteral(".SW:%1 Sim=\"%2\" Type=\"list\" Param=\"%3\" Values=\"[%4]\"\n")
+          .arg(Name,
+               getProperty("Sim")->Value,
+               param,
+               wattsValues.join(";"));
+    }
+  }
+
+  // Default behavior: keep the sweep as-is for non-dBm sweeps
+  QString s = Model + ":" + Name;
+  for (Property *p : std::as_const(Props)) {
+    if (p->Name == "Symbol") {
+      continue;
+    }
+    s += " " + p->Name + "=\"" + p->Value + "\"";
+  }
+  return s + '\n';
+}

--- a/qucs/components/param_sweep.cpp
+++ b/qucs/components/param_sweep.cpp
@@ -92,8 +92,8 @@ QString Param_Sweep::getNgspiceBeforeSim(QString sim, int lvl)
 
     s = "option interp\n";
     s += QStringLiteral("let number_%1 = 0\n").arg(step_var);
-    if (lvl==0) s += QStringLiteral("echo \"STEP %1.%2\" > spice4qucs.%3.cir.res\n").arg(sim).arg(step_var).arg(sim);
-    else s += QStringLiteral("echo \"STEP %1.%2\" > spice4qucs.%3.cir.res%4\n").arg(sim).arg(step_var).arg(sim).arg(lvl);
+    if (lvl==0) s += QStringLiteral("echo \"STEP %1.%2\" > spice4qucs.%3.cir.res\n").arg(sim, step_var, sim);
+    else s += QStringLiteral("echo \"STEP %1.%2\" > spice4qucs.%3.cir.res%4\n").arg(sim, step_var, sim).arg(lvl);
 
     s += QStringLiteral("foreach  %1_act ").arg(step_var);
 
@@ -151,13 +151,13 @@ QString Param_Sweep::getNgspiceBeforeSim(QString sim, int lvl)
         if (step_var == "temp" || step_var == "temper") temper_sweep = true;
 
         if (temper_sweep) { // Sweep temperature
-          s += QStringLiteral("option temp = $%1_act%2").arg(step_var).arg(nline_char);
+          s += QStringLiteral("option temp = $%1_act%2").arg(step_var, nline_char);
         } else if (compfound) { // Sweep device
-          s += QStringLiteral("alter %1 = $%2_act%3").arg(par).arg(step_var).arg(nline_char);
+          s += QStringLiteral("alter %1 = $%2_act%3").arg(par, step_var, nline_char);
         } else if (par.startsWith("@")) { // Sweep model
-          s += QStringLiteral("altermod %1 = $%2_act%3").arg(par).arg(step_var).arg(nline_char);
+          s += QStringLiteral("altermod %1 = $%2_act%3").arg(par, step_var, nline_char);
         } else { // Sweep .PARAM variable
-          s += QStringLiteral("alterparam %1 = $%2_act%3reset%3").arg(par).arg(step_var).arg(nline_char);
+          s += QStringLiteral("alterparam %1 = $%2_act%3reset%3").arg(par, step_var, nline_char);
         }
     }
     return s;
@@ -175,8 +175,8 @@ QString Param_Sweep::getNgspiceAfterSim(QString sim, int lvl)
 
     s = "set appendwrite\n";
 
-    if (lvl==0) s += QStringLiteral("echo \"$&number_%1  $%2_act\" >> spice4qucs.%3.cir.res\n").arg(par).arg(par).arg(sim);
-    else s += QStringLiteral("echo \"$&number_%1\" $%1_act >> spice4qucs.%2.cir.res%3\n").arg(par).arg(sim).arg(lvl);
+    if (lvl==0) s += QStringLiteral("echo \"$&number_%1  $%2_act\" >> spice4qucs.%3.cir.res\n").arg(par, par, sim);
+    else s += QStringLiteral("echo \"$&number_%1\" $%1_act >> spice4qucs.%2.cir.res%3\n").arg(par, sim).arg(lvl);
     s += QStringLiteral("let number_%1 = number_%1 + 1\n").arg(par);
 
     s += "end\n";
@@ -204,7 +204,7 @@ QString Param_Sweep::spice_netlist(spicecompat::SpiceDialect dialect /* = spicec
             QString list = getProperty("Values")->Value;
             list.remove('[').remove(']');
             list = list.split(';').join(" ");
-            s = QStringLiteral(".STEP %1 LIST %2\n").arg(var).arg(list);
+            s = QStringLiteral(".STEP %1 LIST %2\n").arg(var, list);
             return s.toLower();
         }
     }

--- a/qucs/components/param_sweep.h
+++ b/qucs/components/param_sweep.h
@@ -34,6 +34,7 @@ public:
   QString getCounterVar();
 
 protected:
+  QString netlist() override;
   QString spice_netlist(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
   QString param_split_str=";";
 };

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -360,14 +360,37 @@ QString Source_ac::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
 
 QString Source_ac::netlist()
 {
-  // Get source parameters
+  // Detect the type of simulation.
+  // The AC power source definition is different for SP and TRAN. HB and AC (VAC + R)
+  QString simType;
+  if (Schematic *sch = dynamic_cast<Schematic*>(getSchematic())) {
+    simType = sch->getSimType();
+  }
+
+  // In case of a SP simulation, use the Pac component
+  if (simType == "SP") {
+    QString s = Model + ":" + Name;
+
+    for (Port *p1 : std::as_const(Ports)){
+      s += " " + p1->Connection->Name;
+    }
+
+    for (int i = 0; i < Props.count(); i++) {
+      const QString &name = Props.at(i)->Name;
+      if (name == "EnableTran" || name == "Phase" || name == "LoadOnly")
+        continue;
+      s += " " + name + "=\"" + Props.at(i)->Value + "\"";
+    }
+    return s + '\n';
+  }
+
+
+  // For HB, TR: Thévenin equivalent
   const QStringList freqs  = parseList(getProperty("f")->Value);
   const QStringList powers = parseList(getProperty("P")->Value);
   const QStringList phases = parseList(getProperty("Phase")->Value);
-
   const QString z    = getProperty("Z")->Value;
   const QString temp = getProperty("Temp")->Value;
-
   const bool isTermination =
       (getProperty("LoadOnly")->Value == "true")
       || (powers.isEmpty() || powers.first().isEmpty());
@@ -375,37 +398,22 @@ QString Source_ac::netlist()
   // Parse Z0
   double Z0, scale;
   QString unit;
-
   misc::str2num(z, Z0, unit, scale);
   Z0 *= scale;
 
-  // Passive termination only
   if (isTermination) {
-
-    const QString nodePos =
-        Ports.at(0)->Connection->Name;
-
-    const QString nodeNeg =
-        Ports.at(1)->Connection->Name;
-
+    const QString nodePos = Ports.at(0)->Connection->Name;
+    const QString nodeNeg = Ports.at(1)->Connection->Name;
     return QStringLiteral(
                "R:R_%1 %2 %3 "
                "R=\"%4 Ohm\" "
                "Temp=\"%5\"\n")
-        .arg(Name,
-             nodePos,
-             nodeNeg,
+        .arg(Name, nodePos, nodeNeg,
              QString::number(Z0, 'g', 12),
              temp);
   }
 
-  // Always synthesize Thévenin equivalent, as done with Xyce and ngspice. Don't rely on the qucastor AC power source
-  return multitone_qucsator(
-      Z0,
-      freqs,
-      powers,
-      phases,
-      temp);
+  return multitone_qucsator(Z0, freqs, powers, phases, temp);
 }
 
 QString Source_ac::multitone_qucsator(double z0,

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -422,78 +422,84 @@ QString Source_ac::multitone_qucsator(double z0,
                                       const QStringList &phases,
                                       const QString &temp)
 {
-  auto pick = [](const QStringList &list,
-                 int i,
-                 const QString &fallback) -> QString {
-    if (list.isEmpty())
-      return fallback;
-
-    if (list.size() == 1)
-      return list.first();
-
+  // Helper: pick list[i] if available, broadcast list[0] if single entry, else fallback.
+  // This allows a single power/phase value to apply to all tones in a multitone setup.
+  auto pick = [](const QStringList &list, int i, const QString &fallback) -> QString {
+    if (list.isEmpty())   return fallback;
+    if (list.size() == 1) return list.first();
     return (i < list.size()) ? list.at(i) : fallback;
   };
 
   const int N = freqs.size();
-
   const QString nodePos = Ports.at(0)->Connection->Name;
   const QString nodeNeg = Ports.at(1)->Connection->Name;
 
+  // Internal junction nodes between the series voltage sources:
+  // nodePos -- R -- n0 -- Vac_t1 -- n1 -- Vac_t2 -- ... -- nodeNeg
   auto intNode = [&](int k) {
     return QStringLiteral("%1_n%2").arg(Name).arg(k);
   };
 
   QString s;
 
-  // Single explicit source resistance
-  s += QStringLiteral(
-           "R:R_%1 %2 %3 R=\"%4 Ohm\" Temp=\"%5\"\n")
-           .arg(Name,
-                nodePos,
-                intNode(0),
-                QString::number(z0, 'g', 12),
-                temp);
+  // Thévenin source impedance — one resistor shared by all tones.
+  // Placed between the external positive node and the first internal junction.
+  s += QStringLiteral("R:R_%1 %2 %3 R=\"%4 Ohm\" Temp=\"%5\"\n")
+           .arg(Name, nodePos, intNode(0),
+                QString::number(z0, 'g', 12), temp);
 
   // One ideal sinusoidal voltage source per tone
+  // Adjust the AC voltage amplitude according to the power
   for (int i = 0; i < N; ++i) {
-
     const QString freq  = freqs.at(i);
     const QString power = pick(powers, i, QStringLiteral("0"));
     const QString phase = pick(phases, i, QStringLiteral("0"));
 
-    // Convert dBm -> peak voltage
+    // Series chain: tone i sits between intNode(i) and intNode(i+1),
+    // except the last tone which connects directly to the negative external node.
+    const QString nodeAbove = intNode(i);
+    const QString nodeBelow = (i == N - 1) ? nodeNeg : intNode(i + 1);
+
+    QString vampStr;
     bool ok = false;
     double p_dbm = spicecompat::normalize_value(power).toDouble(&ok);
 
-    double vamp = 0.0;
-
     if (ok) {
-      // Vrms from dBm into z0
-      const double vrms =
-          std::sqrt(z0 / 1000.0) *
-          std::pow(10.0, p_dbm / 20.0);
-
-      vamp = 2 * vrms * std::sqrt(2.0); // peak amplitude [V -> R] -> R (same as with ngspice and xyce)
+      // Numeric power: compute vamp directly
+      const double vrms = std::sqrt(z0 / 1000.0) * std::pow(10.0, p_dbm / 20.0);
+      const double vamp = 2.0 * vrms * std::sqrt(2.0);
+      vampStr = QString::number(vamp, 'g', 12) + " V";
+    } else {
+      // Non-numeric power: the value is a sweep parameter variable (e.g. "Pin").
+      // QucsatorRF cannot evaluate inline expressions inside component property
+      // strings, so it needs to emit a Eqn: block that computes the amplitude
+      // symbolically. The equation is evaluated at each sweep iteration.
+      //
+      // Important: QucsatorRF passes sweep parameter values to the equation
+      // evaluator already converted in W, despite the sweep is in dBm.
+      // The amplitude formula is thus derived from P_watts directly:
+      //   Vrms  = sqrt(Z0 * P_watts)
+      //   Vpeak = sqrt(2) * Vrms
+      //   Vamp  = 2 * Vpeak = 2*sqrt(2)*sqrt(Z0 * P_watts)
+      const QString eqnBlockName = QStringLiteral("Eqn_vamp_%1_t%2").arg(Name).arg(i + 1);
+      const QString eqnVarName   = QStringLiteral("vamp_%1_t%2").arg(Name).arg(i + 1);
+      s += QStringLiteral("Eqn:%1 %2=\"2*sqrt(2)*sqrt(%3*%4)\" Export=\"yes\"\n")
+               .arg(eqnBlockName, eqnVarName,
+                    QString::number(z0, 'g', 12),
+                    power);
+      // Reference the variable name directly — no unit suffix when using a variable
+      vampStr = eqnVarName;
     }
-
-    const QString nodeAbove = intNode(i);
-    const QString nodeBelow =
-        (i == N - 1) ? nodeNeg : intNode(i + 1);
 
     s += QStringLiteral(
              "Vac:V_%1_t%2 %3 %4 "
-             "U=\"%5 V\" "
+             "U=\"%5\" "
              "f=\"%6\" "
              "Phase=\"%7\" "
              "Theta=\"0\" "
              "T=\"0\"\n")
-             .arg(Name)
-             .arg(i + 1)
-             .arg(nodeAbove,
-                  nodeBelow,
-                  QString::number(vamp, 'g', 12),
-                  freq,
-                  phase);
+             .arg(Name).arg(i + 1)
+             .arg(nodeAbove, nodeBelow, vampStr, freq, phase);
   }
 
   return s;

--- a/qucs/components/source_ac.h
+++ b/qucs/components/source_ac.h
@@ -21,6 +21,7 @@
 #include "component.h"
 #include "misc.h"
 #include <QRegularExpression>
+#include "schematic.h" // Needed to detect the type of simulation and adjust the qucsator-rf netlist accordingly
 
 class Source_ac : public Component  {
 private:

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -555,6 +555,9 @@ public:
   bool getIsVerilog() const { return a_isVerilog; }
   bool giveNodeNames(QTextStream *, int&, QStringList&, QPlainTextEdit*, int);
 
+  /// @brief Get the type of simulation from the schematic
+  QString getSimType() const { return m_simType; }
+
 private:
   int  saveDocument();
 
@@ -591,7 +594,6 @@ private:
   bool a_creatingLib;
 
   QString m_simType; // Simulation type. Needed for the Pac (constant AC power source) to determine with network to build with Qucsator-RF
-  QString getSimType() const { return m_simType; } // Return the type of simulation
 };
 
 #endif

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -589,6 +589,9 @@ private:
   bool a_isAnalog;
   bool a_isVerilog;
   bool a_creatingLib;
+
+  QString m_simType; // Simulation type. Needed for the Pac (constant AC power source) to determine with network to build with Qucsator-RF
+  QString getSimType() const { return m_simType; } // Return the type of simulation
 };
 
 #endif

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -2334,6 +2334,14 @@ QString Schematic::createNetlist(QTextStream& stream, int NumPorts)
   a_Signals.clear();  // was filled in "giveNodeNames()"
   FileList.clear();
 
+  // Determine the type of simulation in the schematic.
+  // This is needed for component whose netlist depend on the type of simulation (e.g. Pac)
+  for (Component *pc : a_DocComps) {
+    if (pc->Model == ".SP") { m_simType = "SP"; break; }
+    if (pc->Model == ".HB") { m_simType = "HB"; break; }
+    if (pc->Model == ".TR") { m_simType = "TR"; break; }
+  }
+
   QString s, Time;
   for(Component *pc : a_DocComps) {
     if(pc->Model == "CMD") continue; // Skip "system command" component. It must not go to the simulation backend


### PR DESCRIPTION
**Problem**

After merging PR #1669, the following issues were identified:

**1) Qucsator-RF SP simulation is broken**
PR #1669 modified the qucsator's netlist generation for AC Power sources to use a constant AC Voltage source + Z0 series resistor. This was intended to be done in HB and TRAN simulations only, but it was accidentally applied to SP simulations as well.

<img width="840" height="668" alt="image" src="https://github.com/user-attachments/assets/c785f568-6b05-4142-a3df-5d1573d0df2e" />

**2) Backward compatibility broken for old schematics**
PR #1669 added the "phase" property to the AC power source component. Since Qucs-S loads component properties positionally from the schematic file, any schematic created before this change loads with shifted property values: "Phase" receives the "temperature" field. 
Positional loading seems to be a bad practice, hopefully it'll be fixed by the IHP team with the new XML component schema, #1354 

**3) Broken HB/TRAN power sweep in qucsator-RF**
3.1) After #1669, the peak voltage amplitude is computed from the available power at netlist generation time. When the power property contains a sweep parameter (e.g. Pin) rather than a numeric value, the conversion fails silently and the amplitude is fixed at zero for all sweep steps.

<img width="1534" height="798" alt="image" src="https://github.com/user-attachments/assets/826b2911-fc00-42b4-a597-0c2ef5ecd413" />


3.2) For linear dBm sweeps, QucsatorRF converts the start/stop endpoints from dBm to watts and interpolates linearly in watts, producing non-uniform dBm spacing instead of the intended uniform dBm steps.

---
**Fixes**

**1)** The Pac component need to know which type of simulation the user wants to run. For doing this, a new field was introduced in Schematic class to identify the simulation before each component generates its portion of netlist. 

Commits:
https://github.com/ra3xdh/qucs_s/commit/1cd79b61fb66786eb8e1676347a6c2df53b0a846
https://github.com/ra3xdh/qucs_s/commit/f10ce7c7db70673690e076b20e3512daf16155bd

**2)** Automatically add the phase property to Pac and Vac sources if it's not present at loading. If they don't contain enough property fields, it means that the schematic don't include the phase property.

Commit:
https://github.com/ra3xdh/qucs_s/commit/22247052a64ac147f2d8b4f3ca015fc2c64891b5

**3.1)** When the power value is non-numeric, a companion Eqn: block is emitted alongside the Vac: source to compute the amplitude symbolically at each sweep iteration.
Commit:
https://github.com/ra3xdh/qucs_s/commit/c368f11cfa4a5cde367c4099bd33194b0bef0f21

**3.2)**  Overload Param_Sweep::netlist() by mapping linear dBm sweep into an explicit list of watts values, preserving the correct dBm spacing at each step.
https://github.com/ra3xdh/qucs_s/commit/5420809befc7e03a69d56a57423381f039de5e94

*Note: Fixed some QString multiarg warnings once there.*

I attach the schematics I used for testing all this: [Multitone_AC_Power_prj.zip](https://github.com/user-attachments/files/28821597/Multitone_AC_Power_prj.zip)