### PR TITLE
S-parameter deembedding component

### DIFF
--- a/qucs/components/CMakeLists.txt
+++ b/qucs/components/CMakeLists.txt
@@ -65,6 +65,7 @@ systemcommand.cpp
 simulation.cpp
 vdmos.cpp
 property.cpp
+spdeembed.cpp
 )
 
 SET(COMPONENTS_HDRS
@@ -203,6 +204,7 @@ simulation.h
 source_ac.h
 sp_sim.h
 sparamfile.h
+spdeembed.h
 spicedialog.h
 spicefile.h
 subcircuit.h

--- a/qucs/components/component.h
+++ b/qucs/components/component.h
@@ -33,7 +33,7 @@
 class Schematic;
 class QString;
 class QPen;
-
+class ComponentDialog;
 
 class Component : public Element {
 public:
@@ -72,6 +72,11 @@ public:
   bool    mirrorY() noexcept override;
   QString save();
   bool    load(const QString&);
+
+  /// @brief Creates the properties dialog
+  /// @details This allows components to create custom property dialogs. It was introduced
+  /// with the S-parameter de-embedding components to fill the port number automatically for the S-parameter file
+  virtual ComponentDialog* createDialog(Schematic* s);
 
   // helper function that sets the node of the port to the same center as the port
   bool setNodePortCenter(Port* p);

--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -1350,3 +1350,11 @@ void ShellHighlighter::highlightBlock(const QString& text)
     }
   }
 }
+
+/// @brief Default implementation of the createDialog virtual function
+/// @details If the component does not have a custom dialog implemented, control reaches this
+/// function and a new ComponentDialog object is created
+ComponentDialog* Component::createDialog(Schematic* s)
+{
+  return new ComponentDialog(this, s);
+}

--- a/qucs/components/components.h
+++ b/qucs/components/components.h
@@ -36,6 +36,7 @@
 #include "subcirport.h"
 #include "subcircuit.h"
 #include "sparamfile.h"
+#include "spdeembed.h"
 #include "equation.h"
 #include "attenuator.h"
 #include "amplifier.h"

--- a/qucs/components/sparamfile.cpp
+++ b/qucs/components/sparamfile.cpp
@@ -46,7 +46,7 @@ SParamFile::SParamFile()
   Props.append(new Property("Ports", "1", false,
 		QObject::tr("number of ports")));
 
-  createSymbol();
+  SParamFile::createSymbol();
 }
 
 // -------------------------------------------------------
@@ -116,7 +116,7 @@ QString SParamFile::netlist()
   QString s = Model+":"+Name;
 
   // output all node names
-  for (Port *p1 : Ports)
+  for (Port *p1 : std::as_const(Ports))
     s += " "+p1->Connection->Name;   // node names
 
   // output all properties
@@ -206,14 +206,13 @@ QString SParamFile::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
         for(int i = 0; i < Np; i++) {
             QString p_in = spicecompat::normalize_node_name(Ports.at(i)->Connection->Name);
             QString p_com = spicecompat::normalize_node_name(Ports.at(Np)->Connection->Name);
-            s += QStringLiteral(" %1 %2").arg(p_in).arg(p_com);
+            s += QStringLiteral(" %1 %2").arg(p_in, p_com);
         }
         s += QStringLiteral(" %1\n").arg(s_mod);
-        s += QStringLiteral(".MODEL %1 LIN TSTONEFILE=%2\n").arg(s_mod)
-                .arg(getSubcircuitFile());
+        s += QStringLiteral(".MODEL %1 LIN TSTONEFILE=%2\n").arg(s_mod, getSubcircuitFile());
     } else {
         s += SpiceModel+Name;
-        for (Port *p1 : Ports) {
+        for (Port *p1 : std::as_const(Ports)) {
             s += " "+ spicecompat::normalize_node_name(p1->Connection->Name);   // node names
         }
         s += " Sub_" + Model + "_" + Name + "\n";

--- a/qucs/components/sparamfile.cpp
+++ b/qucs/components/sparamfile.cpp
@@ -220,3 +220,66 @@ QString SParamFile::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
     }
     return s;
 }
+
+ComponentDialog* SParamFile::createDialog(Schematic* s)
+{
+  return new SParamFileDialog(this, s);
+}
+
+// Same function used in spdeembed component
+int SParamFile::portsFromFilename(const QString& filename)
+{
+  QFileInfo fi(filename);
+  QString ext = fi.suffix().toLower();       // e.g. "s3p"
+  if (!ext.startsWith('s') || !ext.endsWith('p'))
+    return -1;
+  QString middle = ext.mid(1, ext.length() - 2);  // strip 's' and 'p'
+  bool ok = false;
+  int n = middle.toInt(&ok);
+  return (ok && n >= 1) ? n : -1;
+}
+
+
+// Similar function used in spdeembed component
+SParamFileDialog::SParamFileDialog(Component* c, Schematic* s)
+    : ComponentDialog(c, s)
+{
+  // The base class constructor has already built the full property table.
+  QTableWidget* table = findChild<QTableWidget*>();
+  if (!table) return;
+
+  int fileRow  = -1;
+  int portsRow = -1;
+
+  // Walk the table rows to find the "File" and "Ports" properties by name.
+  for (int row = 0; row < table->rowCount(); ++row) {
+    QTableWidgetItem* nameItem = table->item(row, 0);
+    if (!nameItem) continue;
+    if (nameItem->text() == "File")  fileRow  = row;
+    if (nameItem->text() == "Ports") portsRow = row;
+  }
+  if (fileRow < 0 || portsRow < 0) return;
+
+  QWidget* cellWidget = table->cellWidget(fileRow, 1);
+  if (!cellWidget) return;
+  QLineEdit* fileEdit = cellWidget->findChild<QLineEdit*>();
+  if (!fileEdit) return;
+
+  // Note: The lambda function here is the most simple way to check the number of ports. "table", "fileEdit" and "ports" are not member variables
+  connect(fileEdit, &QLineEdit::textChanged,
+          this, [table, portsRow](const QString& filename)
+          {
+            int n = SParamFile::portsFromFilename(filename);
+            if (n < 1) return;
+
+            QString value = QString::number(n);
+
+            // Update the QTableWidgetItem
+            QTableWidgetItem* item = table->item(portsRow, 1);
+            if (item) item->setText(value);
+
+            // Update the port number widget.
+            QLineEdit* portsEdit = qobject_cast<QLineEdit*>(table->cellWidget(portsRow, 1));
+            if (portsEdit) portsEdit->setText(value);
+  });
+}

--- a/qucs/components/sparamfile.h
+++ b/qucs/components/sparamfile.h
@@ -20,22 +20,50 @@
 
 #include "component.h"
 
+// Needed for the custom properties dialog to autoupdate the port count
+#include "componentdialog.h"
+#include <QTableWidget>
+#include <QTableWidgetItem>
+#include <QLineEdit>
+
+/// @class SParamFileDialog
+/// @brief Custom properties dialog for SParamFile.
+/// @details Automatically fills the Ports field when the user selects
+///          a Touchstone file according to its extension
+class SParamFileDialog : public ComponentDialog {
+  Q_OBJECT
+public:
+  /// @brief Constructor.
+  /// @param c  The SParamFile component being edited.
+  /// @param s  The schematic that owns the component.
+  SParamFileDialog(Component* c, Schematic* s);
+};
 
 class SParamFile : public MultiViewComponent  {
 public:
   SParamFile();
  ~SParamFile() {};
-  Component* newOne();
+  Component* newOne() override;
   static Element* info(QString&, char* &, bool getNewOne=false);
   static Element* info1(QString&, char* &, bool getNewOne=false);
   static Element* info2(QString&, char* &, bool getNewOne=false);
 
-  QString getSubcircuitFile();
+  QString getSubcircuitFile() override;
+
+  /// @brief Creates the custom properties dialog.
+  /// @param s  The schematic that owns the component.
+  /// @return   SParamFileDialog object.
+  ComponentDialog* createDialog(Schematic* s) override;
+
+  /// @brief Parses port count N from a .sNp filename extension.
+  /// @param filename  Full or relative path to the Touchstone file.
+  /// @return Port count (>= 1) on success, or -1 if not recognised.
+  static int portsFromFilename(const QString& filename);
 
 protected:
-  QString netlist();
-  void createSymbol();
-  QString spice_netlist(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault);
+  QString netlist() override;
+  void createSymbol() override;
+  QString spice_netlist(spicecompat::SpiceDialect dialect = spicecompat::SPICEDefault) override;
 };
 
 #endif

--- a/qucs/components/spdeembed.cpp
+++ b/qucs/components/spdeembed.cpp
@@ -186,11 +186,13 @@ int SPDeEmbed::portsFromFilename(const QString& filename)
 SPDeEmbedDialog::SPDeEmbedDialog(Component* c, Schematic* s)
     : ComponentDialog(c, s)
 {
+  // The base class constructor has already built the full property table.
   QTableWidget* table = findChild<QTableWidget*>();
   if (!table) return;
 
   int fileRow  = -1;
   int portsRow = -1;
+  // Walk the table rows to find the "File" and "Ports" properties by name.
   for (int row = 0; row < table->rowCount(); ++row) {
     QTableWidgetItem* nameItem = table->item(row, 0);
     if (!nameItem) continue;
@@ -205,10 +207,31 @@ SPDeEmbedDialog::SPDeEmbedDialog(Component* c, Schematic* s)
   QLineEdit* fileEdit = cellWidget->findChild<QLineEdit*>();
   if (!fileEdit) return;
 
-  connect(fileEdit, &QLineEdit::textChanged, this, [table, portsRow](const QString& filename) {
+  // Note: The lambda function here is the most simple way to check the number of ports. "table", "fileEdit" and "ports" are
+  // not member variables
+  connect(fileEdit, &QLineEdit::textChanged, this, [this, table, portsRow, fileEdit](const QString& filename) {
     // Get the number of ports from the .snp extension
     int n = SPDeEmbed::portsFromFilename(filename);
     if (n < 1) return;
+
+    // Port count must be even
+    if (n % 2 != 0) {
+      QMessageBox::critical(this,
+                            QObject::tr("Invalid port count"),
+                            QObject::tr("The file \"%1\" specifies %2 port(s).\n\n"
+                                        "De-embedding requires an even number of ports.")
+                                .arg(QFileInfo(filename).fileName())
+                                .arg(n));
+
+      // Block the signal temporarily to avoid re-triggering this handler,
+      // then clear the file field so the invalid file is not accepted.
+      fileEdit->blockSignals(true);
+      fileEdit->clear();
+      fileEdit->blockSignals(false);
+      return;
+    }
+
+
     QString value = QString::number(n);
 
     // Update the QTableWidgetItem text — this is what slotApplyButton reads back.

--- a/qucs/components/spdeembed.cpp
+++ b/qucs/components/spdeembed.cpp
@@ -1,25 +1,12 @@
-/*
- * spdeembed.cpp - N-port S-parameters de-embedding component
- *
- * Copyright (C) 2017 Qucs Team
- * based on sparamfile.cpp, (C) 2003 by Michael Margraf
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2, or (at your option)
- * any later version.
- *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this package; see the file COPYING.  If not, write to
- * the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
- * Boston, MA 02110-1301, USA.
- *
- */
+/// @file spdeembed.cpp
+/// @brief S-parameter network N-port de-embedding component (implementation)
+/// @author Qucs Team; Andrés Martínez Mera
+/// @date 2017-2026
+/// @copyright Copyright (C) 2017 Qucs Team,
+///            Based on sparamfile.cpp (C) 2003 by Michael Margraf
+///            2026 Andrés Martínez Mera
+///            Code porting from Qucs PR#693; GPLv3-or-later
+/// @license GPL-3.0-or-later
 
 #include "spdeembed.h"
 #include "main.h" // for QucsSettings
@@ -176,4 +163,60 @@ void SPDeEmbed::createSymbol()
   QFontMetrics  metrics(QucsSettings.font, 0);   // use the screen-compatible metric
   tx = x1+4;
   ty = y1 - 2*metrics.lineSpacing() - 4;
+}
+
+
+ComponentDialog* SPDeEmbed::createDialog(Schematic* s)
+{
+  return new SPDeEmbedDialog(this, s);
+}
+
+int SPDeEmbed::portsFromFilename(const QString& filename)
+{
+  QFileInfo fi(filename);
+  QString ext = fi.suffix().toLower();  // e.g. "s4p"
+  if (!ext.startsWith('s') || !ext.endsWith('p'))
+    return -1;
+  QString middle = ext.mid(1, ext.length() - 2);  // strip leading 's' and trailing 'p'
+  bool ok = false;
+  int n = middle.toInt(&ok);
+  return (ok && n >= 1) ? n : -1;
+}
+
+SPDeEmbedDialog::SPDeEmbedDialog(Component* c, Schematic* s)
+    : ComponentDialog(c, s)
+{
+  QTableWidget* table = findChild<QTableWidget*>();
+  if (!table) return;
+
+  int fileRow  = -1;
+  int portsRow = -1;
+  for (int row = 0; row < table->rowCount(); ++row) {
+    QTableWidgetItem* nameItem = table->item(row, 0);
+    if (!nameItem) continue;
+    if (nameItem->text() == "File")  fileRow  = row;
+    if (nameItem->text() == "Ports") portsRow = row;
+  }
+
+  if (fileRow < 0 || portsRow < 0) return;
+
+  QWidget* cellWidget = table->cellWidget(fileRow, 1);
+  if (!cellWidget) return;
+  QLineEdit* fileEdit = cellWidget->findChild<QLineEdit*>();
+  if (!fileEdit) return;
+
+  connect(fileEdit, &QLineEdit::textChanged, this, [table, portsRow](const QString& filename) {
+    // Get the number of ports from the .snp extension
+    int n = SPDeEmbed::portsFromFilename(filename);
+    if (n < 1) return;
+    QString value = QString::number(n);
+
+    // Update the QTableWidgetItem text — this is what slotApplyButton reads back.
+    QTableWidgetItem* item = table->item(portsRow, 1);
+    if (item) item->setText(value);
+
+    // Update the port number widget.
+    QLineEdit* portsEdit = qobject_cast<QLineEdit*>(table->cellWidget(portsRow, 1));
+    if (portsEdit) portsEdit->setText(value);
+  });
 }

--- a/qucs/components/spdeembed.cpp
+++ b/qucs/components/spdeembed.cpp
@@ -1,0 +1,203 @@
+/*
+ * spdeembed.cpp - N-port S-parameters de-embedding component
+ *
+ * Copyright (C) 2017 Qucs Team
+ * based on sparamfile.cpp, (C) 2003 by Michael Margraf
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this package; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "spdeembed.h"
+#include "main.h" // for QucsSettings
+#include "schematic.h"
+#include "misc.h"
+
+#include <QFileInfo>
+
+
+SPDeEmbed::SPDeEmbed()
+{
+  Description = QObject::tr("S parameter file de-embedding");
+  Model = "SPDfile";
+  Name  = "XD";
+
+         // must be the first property !!!
+  Props.append(new Property("File", "test.s2p", true,
+                            QObject::tr("name of the s parameter file")));
+  Props.append(new Property("Data", "rectangular", false,
+                            QObject::tr("data type")+" [rectangular, polar]"));
+  Props.append(new Property("Interpolator", "linear", false,
+                            QObject::tr("interpolation type")+" [linear, cubic]"));
+  Props.append(new Property("duringDC", "open", false,
+                            QObject::tr("representation during DC analysis")+
+                                " [open, short, shortall, unspecified]"));
+
+         // must be the last property !!!
+  Props.append(new Property("Ports", "2", false,
+                            QObject::tr("number of ports")));
+
+  SPDeEmbed::createSymbol();
+}
+
+// -------------------------------------------------------
+Component* SPDeEmbed::newOne()
+{
+  SPDeEmbed* p = new SPDeEmbed();
+  return p;
+}
+
+Element* SPDeEmbed::info(QString& Name, char* &BitmapFile, bool getNewOne)
+{
+  // "de-embedding" at the beginning, so it's always visible in the component dock
+  // to help distinguish it from the regular embedding component
+  Name = QObject::tr("de-embedding n-port S parameter file");
+  BitmapFile = (char *) "spdfile6";
+
+  if(getNewOne) {
+    SPDeEmbed* p = new SPDeEmbed();
+    p->Props.first()->Value = "test.s6p";
+    p->Props.last()->Value = "6";
+    return p;
+  }
+  return 0;
+}
+
+// -------------------------------------------------------
+Element* SPDeEmbed::info2(QString& Name, char* &BitmapFile, bool getNewOne)
+{
+  Name = QObject::tr("de-embedding 2-port S parameter file");
+  BitmapFile = (char *) "spdfile2";
+
+  if(getNewOne)  return new SPDeEmbed();
+  return 0;
+}
+
+// -------------------------------------------------------
+Element* SPDeEmbed::info4(QString& Name, char* &BitmapFile, bool getNewOne)
+{
+  Name = QObject::tr("de-embedding 4-port S parameter file");
+  BitmapFile = (char *) "spdfile4";
+
+  if(getNewOne) {
+    SPDeEmbed* p = new SPDeEmbed();
+    p->Props.first()->Value = "test.s4p";
+    p->Props.last()->Value = "4";
+    return p;
+  }
+  return 0;
+}
+
+// -------------------------------------------------------
+QString SPDeEmbed::getSubcircuitFile()
+{
+  // construct full filename
+  QString FileName = Props.first()->Value;
+  return misc::properAbsFileName(FileName);
+}
+
+// -------------------------------------------------------
+QString SPDeEmbed::netlist()
+{
+  QString s = Model+":"+Name;
+
+  // output all node names
+  foreach(Port *p1, Ports)
+    s += " "+p1->Connection->Name;   // node names
+
+  // output all properties
+  Property *p2 = Props.first();
+  s += " "+p2->Name+"=\"{"+getSubcircuitFile()+"}\"";
+
+  // data type
+  p2 = Props.at(1);
+  s += " "+p2->Name+"=\""+p2->Value+"\"";
+
+  // interpolator type
+  p2 = Props.at(2);
+  s += " "+p2->Name+"=\""+p2->Value+"\"";
+
+  // DC property
+  p2 = Props.at(3);
+  s += " "+p2->Name+"=\""+p2->Value+"\"\n";
+
+  return s;
+}
+
+// -------------------------------------------------------
+void SPDeEmbed::createSymbol()
+{
+  QFont Font(QucsSettings.font); // default application font
+  // symbol text is smaller (10 pt default)
+  Font.setPointSize(10 );
+  // get the small font size; use the screen-compatible metric
+  QFontMetrics  smallmetrics(Font, 0);
+  int fHeight = smallmetrics.lineSpacing();
+  QString stmp;
+
+  int w, PortDistance = 60;
+  int Num = Props.last()->Value.toInt();
+
+  // adjust number of ports: force even port number
+  Num = 2 * (Num / 2);
+  if(Num < 2){
+    Num = 2;
+  } else if(Num > 8) {
+    PortDistance = 20;
+    if(Num > 40) Num = 40;
+  }
+  Props.last()->Value = QString::number(Num);
+
+         // draw symbol outline
+  int h = (PortDistance/2)*((Num-1)/2) + 15;
+  QPen pen(Qt::darkBlue, 2, Qt::DashLine);
+  Lines.append(new qucs::Line(-15, -h, 15, -h, pen));
+  Lines.append(new qucs::Line( 15, -h, 15,  h, pen));
+  Lines.append(new qucs::Line(-15,  h, 15,  h, pen));
+  Lines.append(new qucs::Line(-15, -h,-15,  h, pen));
+  stmp = QObject::tr("file");
+  w = smallmetrics.horizontalAdvance(stmp); // compute text size to center it
+  Texts.append(new Text(-w/2, -fHeight/2, stmp));
+
+  int i=0, y = 15-h;
+  while(i<Num) { // add ports lines and numbers
+    i++;
+    Lines.append(new qucs::Line(-30, y,-15, y,QPen(Qt::darkBlue,2)));
+    Ports.append(new Port(-30, y));
+    stmp = QString::number(i);
+    w = smallmetrics.horizontalAdvance(stmp);
+    Texts.append(new Text(-25-w, y-fHeight-2, stmp)); // text right-aligned
+
+    if(i == Num) break; // if odd number of ports there will be one port less on the right side
+    i++;
+    Lines.append(new qucs::Line( 15, y, 30, y,QPen(Qt::darkBlue,2)));
+    Ports.append(new Port( 30, y));
+    stmp = QString::number(i);
+    Texts.append(new Text(25, y-fHeight-2, stmp)); // text left-aligned
+    y += PortDistance;
+  }
+
+  Lines.append(new qucs::Line( 0, h, 0,h+15,QPen(Qt::darkBlue,2)));
+  Texts.append(new Text( 4, h,"Ref"));
+  Ports.append(new Port( 0,h+15));    // 'Ref' port
+
+  x1 = -30; y1 = -h-2;
+  x2 =  30; y2 =  h+15;
+  // compute component name text position - normal size font
+  QFontMetrics  metrics(QucsSettings.font, 0);   // use the screen-compatible metric
+  tx = x1+4;
+  ty = y1 - 2*metrics.lineSpacing() - 4;
+}

--- a/qucs/components/spdeembed.cpp
+++ b/qucs/components/spdeembed.cpp
@@ -65,37 +65,12 @@ Element* SPDeEmbed::info(QString& Name, char* &BitmapFile, bool getNewOne)
   // "de-embedding" at the beginning, so it's always visible in the component dock
   // to help distinguish it from the regular embedding component
   Name = QObject::tr("de-embedding n-port S parameter file");
-  BitmapFile = (char *) "spdfile6";
-
-  if(getNewOne) {
-    SPDeEmbed* p = new SPDeEmbed();
-    p->Props.first()->Value = "test.s6p";
-    p->Props.last()->Value = "6";
-    return p;
-  }
-  return 0;
-}
-
-// -------------------------------------------------------
-Element* SPDeEmbed::info2(QString& Name, char* &BitmapFile, bool getNewOne)
-{
-  Name = QObject::tr("de-embedding 2-port S parameter file");
   BitmapFile = (char *) "spdfile2";
 
-  if(getNewOne)  return new SPDeEmbed();
-  return 0;
-}
-
-// -------------------------------------------------------
-Element* SPDeEmbed::info4(QString& Name, char* &BitmapFile, bool getNewOne)
-{
-  Name = QObject::tr("de-embedding 4-port S parameter file");
-  BitmapFile = (char *) "spdfile4";
-
   if(getNewOne) {
     SPDeEmbed* p = new SPDeEmbed();
-    p->Props.first()->Value = "test.s4p";
-    p->Props.last()->Value = "4";
+    p->Props.first()->Value = "test.s2p";
+    p->Props.last()->Value = "2";
     return p;
   }
   return 0;

--- a/qucs/components/spdeembed.cpp
+++ b/qucs/components/spdeembed.cpp
@@ -32,6 +32,7 @@
 SPDeEmbed::SPDeEmbed()
 {
   Description = QObject::tr("S parameter file de-embedding");
+  Simulator = spicecompat::simQucsator; // qucsator-RF only
   Model = "SPDfile";
   Name  = "XD";
 

--- a/qucs/components/spdeembed.h
+++ b/qucs/components/spdeembed.h
@@ -16,10 +16,15 @@
 
 /// @class SPDeEmbedDialog
 /// @brief Custom dialog for the S-parameter de-embedding component
+/// @details Extends ComponentDialog to automatically fill the Ports field
+/// when the user selects a Touchstone file whose extension encodes the
+/// port count (e.g. .s4p → 4 ports).
 class SPDeEmbedDialog : public ComponentDialog {
   Q_OBJECT
 public:
   /// @brief Constructor
+  /// @param c  The SPDeEmbed component being edited.
+  /// @param s  The schematic that owns the component.
   SPDeEmbedDialog(Component* c, Schematic* s);
 };
 
@@ -28,17 +33,38 @@ public:
 /// @details S-parameter de-embedding component
 class SPDeEmbed : public MultiViewComponent  {
 public:
+  /// @brief Constructor
   SPDeEmbed();
+
+  /// @brief Destructor
   ~SPDeEmbed() {};
+
+  /// @brief Creates a new instance of this component.
   Component* newOne() override;
+
+  /// @brief Provides component metadata and optionally creates a new instance.
   static Element* info(QString&, char* &, bool getNewOne=false);
 
+  /// @brief Creates the custom properties dialog.
+  /// @param s  The schematic that owns the component.
+  /// @return SPDeEmbedDialog object
   ComponentDialog* createDialog(Schematic* s) override;
+
+  /// @brief Parses the port count from a Touchstone filename extension.
+  /// @param filename  Full or relative path to the Touchstone file.
+  /// @return Port: number of ports
   static int portsFromFilename(const QString& filename);
+
+  /// @brief Returns the absolute path to the Touchstone file.
   QString getSubcircuitFile() override;
 
 protected:
+
+  /// @brief Generates the Qucsator netlist line for this component.
+  /// @return netlist
   QString netlist() override;
+
+  /// @brief Draws the schematic symbol depending on @c Ports value.
   void createSymbol() override;
 };
 

--- a/qucs/components/spdeembed.h
+++ b/qucs/components/spdeembed.h
@@ -13,6 +13,7 @@
 
 #include "component.h"
 #include "componentdialog.h"
+#include <QMessageBox>
 
 /// @class SPDeEmbedDialog
 /// @brief Custom dialog for the S-parameter de-embedding component

--- a/qucs/components/spdeembed.h
+++ b/qucs/components/spdeembed.h
@@ -1,0 +1,46 @@
+/*
+ * spdeembed.h - two-port S-parameters de-embedding component
+ *
+ * Copyright (C) 2017 Qucs Team
+ * based on sparamfile.h, (C) 2003 by Michael Margraf
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this package; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef SPDEEMBED_H
+#define SPDEEMBED_H
+
+#include "component.h"
+
+
+class SPDeEmbed : public MultiViewComponent  {
+public:
+  SPDeEmbed();
+  ~SPDeEmbed() {};
+  Component* newOne();
+  static Element* info(QString&, char* &, bool getNewOne=false);
+  static Element* info2(QString&, char* &, bool getNewOne=false);
+  static Element* info4(QString&, char* &, bool getNewOne=false);
+
+  QString getSubcircuitFile();
+
+protected:
+  QString netlist();
+  void createSymbol();
+};
+
+#endif /* SPDEEMBED_H */

--- a/qucs/components/spdeembed.h
+++ b/qucs/components/spdeembed.h
@@ -1,44 +1,45 @@
-/*
- * spdeembed.h - two-port S-parameters de-embedding component
- *
- * Copyright (C) 2017 Qucs Team
- * based on sparamfile.h, (C) 2003 by Michael Margraf
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2, or (at your option)
- * any later version.
- *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this package; see the file COPYING.  If not, write to
- * the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
- * Boston, MA 02110-1301, USA.
- *
- */
+/// @file spdeembed.h
+/// @brief S-parameter network N-port de-embedding component (definition)
+/// @author Qucs Team; Andrés Martínez Mera
+/// @date 2017-2026
+/// @copyright Copyright (C) 2017 Qucs Team,
+///            Based on sparamfile.cpp (C) 2003 by Michael Margraf
+///            2026 Andrés Martínez Mera
+///            Code porting from Qucs PR#693; GPLv3-or-later
+/// @license GPL-3.0-or-later
 
 #ifndef SPDEEMBED_H
 #define SPDEEMBED_H
 
 #include "component.h"
+#include "componentdialog.h"
+
+/// @class SPDeEmbedDialog
+/// @brief Custom dialog for the S-parameter de-embedding component
+class SPDeEmbedDialog : public ComponentDialog {
+  Q_OBJECT
+public:
+  /// @brief Constructor
+  SPDeEmbedDialog(Component* c, Schematic* s);
+};
 
 
+/// @class SPDeEmbed
+/// @details S-parameter de-embedding component
 class SPDeEmbed : public MultiViewComponent  {
 public:
   SPDeEmbed();
   ~SPDeEmbed() {};
-  Component* newOne();
+  Component* newOne() override;
   static Element* info(QString&, char* &, bool getNewOne=false);
 
-  QString getSubcircuitFile();
+  ComponentDialog* createDialog(Schematic* s) override;
+  static int portsFromFilename(const QString& filename);
+  QString getSubcircuitFile() override;
 
 protected:
-  QString netlist();
-  void createSymbol();
+  QString netlist() override;
+  void createSymbol() override;
 };
 
 #endif /* SPDEEMBED_H */

--- a/qucs/components/spdeembed.h
+++ b/qucs/components/spdeembed.h
@@ -33,8 +33,6 @@ public:
   ~SPDeEmbed() {};
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
-  static Element* info2(QString&, char* &, bool getNewOne=false);
-  static Element* info4(QString&, char* &, bool getNewOne=false);
 
   QString getSubcircuitFile();
 

--- a/qucs/module.cpp
+++ b/qucs/module.cpp
@@ -516,6 +516,7 @@ void Module::registerModules (void) {
   REGISTER_FILE_1 (SpiceLibComp);
   REGISTER_FILE_1 (SpiceFile);
   REGISTER_FILE_3 (SParamFile, info1, info2, info);
+  REGISTER_FILE_3 (SPDeEmbed, info2, info4, info);
   REGISTER_FILE_1 (SpiceGeneric);
   REGISTER_FILE_1 (XspiceGeneric);
 

--- a/qucs/module.cpp
+++ b/qucs/module.cpp
@@ -516,7 +516,7 @@ void Module::registerModules (void) {
   REGISTER_FILE_1 (SpiceLibComp);
   REGISTER_FILE_1 (SpiceFile);
   REGISTER_FILE_3 (SParamFile, info1, info2, info);
-  REGISTER_FILE_3 (SPDeEmbed, info2, info4, info);
+  REGISTER_FILE_1 (SPDeEmbed);
   REGISTER_FILE_1 (SpiceGeneric);
   REGISTER_FILE_1 (XspiceGeneric);
 

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1788,7 +1788,9 @@ void MouseActions::editElement(Schematic *Doc, QMouseEvent *Event)
             if (od->exec() != 1)
                 break; // dialog is WDestructiveClose
         } else {
-            ComponentDialog *cd = new ComponentDialog(c, Doc);
+            // Create the properties dialog. If the component doesn't have a custom implementation (X:createDialog() member)
+            // the control flow goes to Component::createDialog()
+            ComponentDialog *cd = c->createDialog(Doc);
             if (cd->exec() != 1)
                 break; // dialog is WDestructiveClose
 


### PR DESCRIPTION
In this PR, the S-parameter de-embedding component developed by @in3otd was ported from Qucs. See https://github.com/Qucs/qucs/pull/693 for details.
Qucsator-RF already supports this component, but it was never ported to Qucs-S.

A feature was added to auto-detect the number of ports from the Touchstone file extension (e.g. .s4p → 4 ports) and fill the Ports field automatically in the properties dialog. It was included this in the existing S-parameter file component as well.

I attach a few tests to demonstrate it works. [de-embedding_TEST_prj.zip](https://github.com/user-attachments/files/29437633/de-embedding_TEST_prj.zip)


**2 ports**
<img width="1216" height="824" alt="image" src="https://github.com/user-attachments/assets/94ffa4ad-d7ba-4b97-9606-bbd9e30d2d34" />

**4 ports**
<img width="1492" height="650" alt="image" src="https://github.com/user-attachments/assets/ed74e41f-5731-4b49-a629-bf287d36c8cd" />


**8 ports**
<img width="1492" height="824" alt="image" src="https://github.com/user-attachments/assets/f6f497f7-69ce-4f95-8ee1-40f1f4d0dc1c" />
