### PR TITLE
Fix compiler/clang-analyzer/clazy warnings across the codebase

### DIFF
--- a/qucs/components/ac_sim.cpp
+++ b/qucs/components/ac_sim.cpp
@@ -99,7 +99,7 @@ QString AC_Sim::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
     }
     QString fstart = spicecompat::normalize_value(Props.at(1)->Value); // Start freq.
     QString fstop = spicecompat::normalize_value(Props.at(2)->Value); // Stop freq.
-    s += QStringLiteral("%1 %2 \n").arg(fstart).arg(fstop);
+    s += QStringLiteral("%1 %2 \n").arg(fstart, fstop);
     if (dialect != spicecompat::SPICEXyce) s.remove(0,1);
     return s.toLower();
 

--- a/qucs/components/ampere_ac.cpp
+++ b/qucs/components/ampere_ac.cpp
@@ -90,7 +90,7 @@ QString Ampere_ac::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
 
     QString plus = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
     QString minus = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
-    s += QStringLiteral(" %1 %2 ").arg(plus).arg(minus);
+    s += QStringLiteral(" %1 %2 ").arg(plus, minus);
 
     QString amperes = spicecompat::normalize_value(Props.at(0)->Value);
     QString freq = spicecompat::normalize_value(Props.at(1)->Value);
@@ -106,7 +106,6 @@ QString Ampere_ac::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
     theta.remove(' ');
     if (theta.isEmpty()) theta="0";
     s += QStringLiteral(" DC %7 SIN(%7 %1 %2 %8 %3 %4) AC %5 ACPHASE %6\n")
-             .arg(amperes).arg(freq).arg(theta).arg(phase).arg(amperes).arg(phase)
-             .arg(IO).arg(TD);
+             .arg(amperes, freq, theta, phase, amperes, phase, IO, TD);
     return s;
 }

--- a/qucs/components/ampere_dc.cpp
+++ b/qucs/components/ampere_dc.cpp
@@ -66,8 +66,7 @@ QString Ampere_dc::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
     if (plus=="gnd") plus = "0";
     QString minus = Ports.at(0)->Connection->Name;
     if (minus=="gnd") minus = "0";
-    s += QStringLiteral(" %1 %2 DC %3\n").arg(plus).arg(minus)
-            .arg(spicecompat::normalize_value(Props.at(0)->Value));
+    s += QStringLiteral(" %1 %2 DC %3\n").arg(plus, minus, spicecompat::normalize_value(Props.at(0)->Value));
     return s;
 }
 

--- a/qucs/components/ampere_noise.cpp
+++ b/qucs/components/ampere_noise.cpp
@@ -97,11 +97,11 @@ QString Ampere_noise::va_code()
 
     if ( e == "0" ) 
     {
-       s += QStringLiteral("%1 <+ white_noise(%2,\"shot\" );\n").arg(Ipm).arg(u);
+       s += QStringLiteral("%1 <+ white_noise(%2,\"shot\" );\n").arg(Ipm, u);
     }
     else 
     {
-	  s += QStringLiteral("%1 <+ flicker_noise(%2, %3, \"flicker\" );\n" ).arg(Ipm).arg(u).arg(e);
+          s += QStringLiteral("%1 <+ flicker_noise(%2, %3, \"flicker\" );\n" ).arg(Ipm, u, e);
     }
 
     return s;

--- a/qucs/components/biast.cpp
+++ b/qucs/components/biast.cpp
@@ -90,7 +90,7 @@ QString BiasT::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     QString pin1 = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
     QString pin2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
     QString pin3 = spicecompat::normalize_node_name(Ports.at(2)->Connection->Name);
-    s += QStringLiteral("C_%1 %2 %3 %4\n").arg(Name).arg(pin1).arg(pin2).arg(C);
-    s += QStringLiteral("L_%1 %2 %3 %4\n").arg(Name).arg(pin2).arg(pin3).arg(L);
+    s += QStringLiteral("C_%1 %2 %3 %4\n").arg(Name, pin1, pin2, C);
+    s += QStringLiteral("L_%1 %2 %3 %4\n").arg(Name, pin2, pin3, L);
     return s;
 }

--- a/qucs/components/bjt.cpp
+++ b/qucs/components/bjt.cpp
@@ -48,7 +48,7 @@ QString BJT::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::S
     QList<int> pin_seq;
     pin_seq<<1<<0<<2; // Pin sequence: CBE
     // output all node names
-    for (int pin : pin_seq) {
+    for (int pin : std::as_const(pin_seq)) {
         QString nam = Ports.at(pin)->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names
@@ -71,7 +71,7 @@ QString BJT::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::S
 
     if (!isDialectCDL)
     {
-        s += QStringLiteral(".MODEL QMOD_%1 %2 (%3)\n").arg(Name).arg(getProperty("Type")->Value).arg(par_str);
+        s += QStringLiteral(".MODEL QMOD_%1 %2 (%3)\n").arg(Name, getProperty("Type")->Value, par_str);
     }
 
     return s;
@@ -140,12 +140,12 @@ QString BJT::netlist()
   QString s = "BJT:"+Name;
 
   // output all node names
-  for (Port *p1 : Ports)
+  for (Port *p1 : std::as_const(Ports))
     s += " "+p1->Connection->Name;   // node names
   s += " "+Ports.at(1)->Connection->Name;  // connect substrate to collector
 
   // output all properties
-  for(const auto& p2 : Props)
+  for(const auto& p2 : std::as_const(Props))
     s += " "+p2->Name+"=\""+p2->Value+"\"";
 
   return s + '\n';

--- a/qucs/components/bjt.cpp
+++ b/qucs/components/bjt.cpp
@@ -24,7 +24,7 @@ BJT::BJT()
 {
   // properties obtained from "Basic_BJT" in bjtsub.cpp
   Description = QObject::tr("bipolar junction transistor");
-  BJT;;createSymbol();
+  BJT::createSymbol();
   tx = x2+4;
   ty = y1+4;
   Model = "_BJT";
@@ -66,8 +66,7 @@ QString BJT::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::S
     if (getProperty("UseGlobTemp")->Value == "yes" || isDialectCDL) {
         s += QStringLiteral(" QMOD_%1 %2=%3\n").arg(Name).arg(isDialectCDL ? "$EA" : "AREA").arg(getProperty("Area")->Value);
     } else {
-        s += QStringLiteral(" QMOD_%1 AREA=%2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
-            .arg(getProperty("Temp")->Value);
+        s += QStringLiteral(" QMOD_%1 AREA=%2 TEMP=%3\n").arg(Name, getProperty("Area")->Value, getProperty("Temp")->Value);
     }
 
     if (!isDialectCDL)

--- a/qucs/components/bjt.cpp
+++ b/qucs/components/bjt.cpp
@@ -24,7 +24,7 @@ BJT::BJT()
 {
   // properties obtained from "Basic_BJT" in bjtsub.cpp
   Description = QObject::tr("bipolar junction transistor");
-  createSymbol();
+  BJT;;createSymbol();
   tx = x2+4;
   ty = y1+4;
   Model = "_BJT";

--- a/qucs/components/bjtsub.cpp
+++ b/qucs/components/bjtsub.cpp
@@ -211,7 +211,7 @@ QString BJTsub::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
     QList<int> pin_seq;
     pin_seq<<1<<0<<2<<3; // Pin sequence: CBE
     // output all node names
-    for (int pin : pin_seq) {
+    for (int pin : std::as_const(pin_seq)) {
         QString nam = Ports.at(pin)->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names
@@ -228,13 +228,12 @@ QString BJTsub::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
     if (getProperty("UseGlobTemp")->Value == "yes" || isDialectCDL) {
         s += QStringLiteral(" QMOD_%1 %2=%3\n").arg(Name).arg(isDialectCDL ? "$EA" : "AREA").arg(getProperty("Area")->Value);
     } else {
-        s += QStringLiteral(" QMOD_%1 AREA=%2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
-            .arg(getProperty("Temp")->Value);
+        s += QStringLiteral(" QMOD_%1 AREA=%2 TEMP=%3\n").arg(Name, getProperty("Area")->Value, getProperty("Temp")->Value);
     }
 
     if (!isDialectCDL)
     {
-        s += QStringLiteral(".MODEL QMOD_%1 %2 (%3)\n").arg(Name).arg(getProperty("Type")->Value).arg(par_str);
+        s += QStringLiteral(".MODEL QMOD_%1 %2 (%3)\n").arg(Name, getProperty("Type")->Value, par_str);
     }
 
     return s;

--- a/qucs/components/bjtsub.cpp
+++ b/qucs/components/bjtsub.cpp
@@ -133,7 +133,7 @@ BJTsub::BJTsub()
 {
   Description = QObject::tr("bipolar junction transistor with substrate");
   Simulator = spicecompat::simAll;
-  createSymbol();
+  BJTsub::createSymbol();
   tx = x2+4;
   ty = y1+4;
   Model = "BJT";

--- a/qucs/components/capacitor.cpp
+++ b/qucs/components/capacitor.cpp
@@ -32,7 +32,7 @@ Capacitor::Capacitor()
   Props.append(new Property("Symbol", "neutral", false,
   QObject::tr("schematic symbol")+" [neutral, polar]"));
 
-  createSymbol();
+  Capacitor::createSymbol();
   tx = x1+4;
   ty = y2+4;
   Model = "C";

--- a/qucs/components/capacitor.cpp
+++ b/qucs/components/capacitor.cpp
@@ -58,8 +58,7 @@ QString Capacitor::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
 {
     QString s = spicecompat::check_refdes(Name,SpiceModel);
 
-    s += QStringLiteral(" %1 %2 ").arg(Ports.at(0)->Connection->Name)
-            .arg(Ports.at(1)->Connection->Name); // output  nodes
+    s += QStringLiteral(" %1 %2 ").arg(Ports.at(0)->Connection->Name, Ports.at(1)->Connection->Name); // output  nodes
     s.replace(" gnd ", " 0 ");
 
     s += " "+spicecompat::normalize_value(Props.at(0)->Value) + " ";
@@ -86,7 +85,7 @@ QString Capacitor::va_code()
     QString Vpm = vacompat::normalize_voltage(plus,minus);
     if (Vpm.startsWith("(-")) Vpm.remove(1,1); // Make capacitor unipolar, remove starting minus
     QString Ipm = vacompat::normalize_current(plus,minus,true);
-    s  += QStringLiteral("%1  <+ ddt( %2 *  %3  );\n").arg(Ipm).arg(Vpm).arg(val);
+    s  += QStringLiteral("%1  <+ ddt( %2 *  %3  );\n").arg(Ipm, Vpm, val);
 
     return s;
 }

--- a/qucs/components/capq.cpp
+++ b/qucs/components/capq.cpp
@@ -114,15 +114,15 @@ QString CapQ::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::
     QString double_pi = "8*atan(1)";
     QString mode = getProperty("Mode")->Value;
     if (mode == "Constant") {
-        res_eq = QStringLiteral("%1*(%2)*hertz/(%3)").arg(double_pi).arg(C).arg(Q);
+        res_eq = QStringLiteral("%1*(%2)*hertz/(%3)").arg(double_pi, C, Q);
     } else if (mode == "Linear") {
-        res_eq = QStringLiteral("%1*(%2)*(%3)/(%4)").arg(double_pi).arg(C).arg(f0).arg(Q);
+        res_eq = QStringLiteral("%1*(%2)*(%3)/(%4)").arg(double_pi, C, f0, Q);
     } else if (mode == "SquareRoot") {
-        res_eq = QStringLiteral("%1*(%2)*sqrt(hertz*(%3))/(%4)").arg(double_pi).arg(C).arg(f0).arg(Q);
+        res_eq = QStringLiteral("%1*(%2)*sqrt(hertz*(%3))/(%4)").arg(double_pi, C, f0, Q);
     }
 
-    s = QStringLiteral("%1 %2 %3 C='%4'\n").arg(Cname).arg(pin1).arg(pin2).arg(C);
-    s += QStringLiteral("%1 %2 %3 R='1/((%4)+1e-8)'\n").arg(Rname).arg(pin1).arg(pin2).arg(res_eq);
+    s = QStringLiteral("%1 %2 %3 C='%4'\n").arg(Cname, pin1, pin2, C);
+    s += QStringLiteral("%1 %2 %3 R='1/((%4)+1e-8)'\n").arg(Rname, pin1, pin2, res_eq);
 
     return s;
 }

--- a/qucs/components/cccs.cpp
+++ b/qucs/components/cccs.cpp
@@ -98,11 +98,11 @@ QString CCCS::va_code()
 
     QString Vpm = vacompat::normalize_voltage(P1,P2);
     QString Ipm = vacompat::normalize_current(P1,P2,true);
-    s += QStringLiteral(" %1  <+  %2 * 1e3;\n").arg(Ipm).arg(Vpm);
+    s += QStringLiteral(" %1  <+  %2 * 1e3;\n").arg(Ipm, Vpm);
     QString Vpm2 = vacompat::normalize_voltage(P4,P3);
     QString Ipm2 = vacompat::normalize_current(P4,P3,true);
-    s += QStringLiteral("%1  <+   %2 * 1e-9;\n").arg(Ipm2).arg(Vpm2);
-    s += QStringLiteral("%1  <+   %2 * 1e3 * %3 ;\n").arg(Ipm2).arg(Vpm).arg(Gain);
+    s += QStringLiteral("%1  <+   %2 * 1e-9;\n").arg(Ipm2, Vpm2);
+    s += QStringLiteral("%1  <+   %2 * 1e3 * %3 ;\n").arg(Ipm2, Vpm, Gain);
 
     return s;
 }
@@ -113,12 +113,10 @@ QString CCCS::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::
     QString s = spicecompat::check_refdes(Name,SpiceModel); // spice CCCS consists two sources: output source
                         // and zero value controlling source
     QString val = spicecompat::normalize_value(Props.at(0)->Value);
-    s += QStringLiteral(" %1 %2 ").arg(Ports.at(1)->Connection->Name)
-            .arg(Ports.at(2)->Connection->Name); // output source nodes
+    s += QStringLiteral(" %1 %2 ").arg(Ports.at(1)->Connection->Name, Ports.at(2)->Connection->Name); // output source nodes
     s.replace(" gnd ", " 0 ");
-    s += QStringLiteral(" V%1 %2\n").arg(Name).arg(val);
-    s += QStringLiteral("V%1 %2 %3 DC 0\n").arg(Name).arg(Ports.at(0)->Connection->Name)
-            .arg(Ports.at(3)->Connection->Name);   // controlling 0V source
+    s += QStringLiteral(" V%1 %2\n").arg(Name, val);
+    s += QStringLiteral("V%1 %2 %3 DC 0\n").arg(Name, Ports.at(0)->Connection->Name, Ports.at(3)->Connection->Name);   // controlling 0V source
 
     return s;
 }

--- a/qucs/components/ccvs.cpp
+++ b/qucs/components/ccvs.cpp
@@ -96,11 +96,11 @@ QString CCVS::va_code()
 
     QString Vpm = vacompat::normalize_voltage(P1,P2);
     QString Ipm = vacompat::normalize_current(P1,P2,true);
-    s += QStringLiteral(" %1  <+  %2 * 1e3;\n").arg(Ipm).arg(Vpm);
+    s += QStringLiteral(" %1  <+  %2 * 1e3;\n").arg(Ipm, Vpm);
     QString Vpm2 = vacompat::normalize_voltage(P3,P4);
     QString Ipm2 = vacompat::normalize_current(P3,P4,true);
-    s += QStringLiteral("%1  <+  -(%2 * 1e3);\n").arg(Ipm2).arg(Vpm2);
-    s += QStringLiteral("%1  <+  -(%2 * 1e6*  %3) ;\n").arg(Ipm2).arg(Vpm).arg(Gain);
+    s += QStringLiteral("%1  <+  -(%2 * 1e3);\n").arg(Ipm2, Vpm2);
+    s += QStringLiteral("%1  <+  -(%2 * 1e6*  %3) ;\n").arg(Ipm2, Vpm, Gain);
 
     return s;
 }
@@ -113,12 +113,10 @@ QString CCVS::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::
     QString s = spicecompat::check_refdes(Name,SpiceModel); // spice CCVS consists two sources: output source
                         // and zero value controlling source
     QString val = spicecompat::normalize_value(Props.at(0)->Value);
-    s += QStringLiteral(" %1 %2 ").arg(Ports.at(1)->Connection->Name)
-            .arg(Ports.at(2)->Connection->Name); // output source nodes
+    s += QStringLiteral(" %1 %2 ").arg(Ports.at(1)->Connection->Name, Ports.at(2)->Connection->Name); // output source nodes
     s.replace(" gnd ", " 0 ");
-    s += QStringLiteral(" V%1 %2\n").arg(Name).arg(val);
-    s += QStringLiteral("V%1 %2 %3 DC 0 \n").arg(Name).arg(Ports.at(0)->Connection->Name)
-            .arg(Ports.at(3)->Connection->Name);   // controlling 0V source
+    s += QStringLiteral(" V%1 %2\n").arg(Name, val);
+    s += QStringLiteral("V%1 %2 %3 DC 0 \n").arg(Name, Ports.at(0)->Connection->Name, Ports.at(3)->Connection->Name);   // controlling 0V source
 
     return s;
 }

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -187,7 +187,7 @@ int Component::getTextSelected(int point_x, int point_y) {
     }
     text_index += 1;
 
-    for (auto* prop : Props) {
+    for (auto* prop : std::as_const(Props)) {
         if (!prop->display) {
             text_index += 1;
             continue;
@@ -218,7 +218,7 @@ void Component::paint(QPainter *p) {
         p->drawText(tx, ty, 1, 1, Qt::TextDontClip, Name, &text_br);
     }
 
-    for (auto *prop : Props) {
+    for (auto *prop : std::as_const(Props)) {
         if (!prop->display) continue;
         if ((prop->simulators & QucsSettings.DefaultSimulator) != QucsSettings.DefaultSimulator) continue;
         prop->paint(text_br.left(), text_br.bottom(), p);
@@ -256,27 +256,27 @@ void Component::drawSymbol(QPainter* p) {
         p->restore();
     };
 
-    for (qucs::DrawingPrimitive *line: Lines) {
+    for (qucs::DrawingPrimitive *line: std::as_const(Lines)) {
         draw_primitive(line, p);
     }
 
-    for (qucs::DrawingPrimitive *pl: Polylines) {
+    for (qucs::DrawingPrimitive *pl: std::as_const(Polylines)) {
         draw_primitive(pl, p);
     }
 
-    for (qucs::DrawingPrimitive *arc: Arcs) {
+    for (qucs::DrawingPrimitive *arc: std::as_const(Arcs)) {
         draw_primitive(arc, p);
     }
 
-    for (qucs::DrawingPrimitive *rect: Rects) {
+    for (qucs::DrawingPrimitive *rect: std::as_const(Rects)) {
         draw_primitive(rect, p);
     }
 
-    for (qucs::DrawingPrimitive *ellips: Ellipses) {
+    for (qucs::DrawingPrimitive *ellips: std::as_const(Ellipses)) {
         draw_primitive(ellips, p);
     }
 
-    for (qucs::DrawingPrimitive *text: Texts) {
+    for (qucs::DrawingPrimitive *text: std::as_const(Texts)) {
         draw_primitive(text, p);
     }
 }
@@ -306,39 +306,39 @@ void Component::paintIcon(QPixmap* pixmap) {
     painter.save();
 
     painter.setPen(QPen{Qt::red});
-    for (auto* port : Ports) {
+    for (auto* port : std::as_const(Ports)) {
         painter.drawEllipse(port->x - 2, port->y - 2, 4, 4);
     }
 
-    for (qucs::Line* line : Lines) {
+    for (qucs::Line* line : std::as_const(Lines)) {
         painter.setPen(line->penHint());
         line->draw(&painter);
     }
 
-    for (qucs::Polyline* pl : Polylines) {
+    for (qucs::Polyline* pl : std::as_const(Polylines)) {
         painter.setPen(pl->penHint());
         pl->draw(&painter);
     }
 
-    for (qucs::Arc* arc : Arcs) {
+    for (qucs::Arc* arc : std::as_const(Arcs)) {
         painter.setPen(arc->penHint());
         arc->draw(&painter);
     }
 
-    for (qucs::Rect* rect : Rects) {
+    for (qucs::Rect* rect : std::as_const(Rects)) {
         painter.setPen(rect->penHint());
         painter.setBrush(rect->brushHint());
         rect->draw(&painter);
     }
 
-    for (qucs::Ellips* ellipse : Ellipses) {
+    for (qucs::Ellips* ellipse : std::as_const(Ellipses)) {
         painter.setPen(ellipse->penHint());
         painter.setBrush(ellipse->brushHint());
         ellipse->draw(&painter);
     }
     painter.restore();
 
-    for (Text* pt : Texts) {
+    for (Text* pt : std::as_const(Texts)) {
         pt->draw(&painter);
     }
 }
@@ -356,10 +356,10 @@ void Component::paintScheme(Schematic *p) {
     }
 
     // paint all lines
-    for (qucs::Line *p1: Lines)
+    for (qucs::Line *p1: std::as_const(Lines))
         p->PostPaintEvent(_Line, cx + p1->x1, cy + p1->y1, cx + p1->x2, cy + p1->y2);
 
-    for (auto* pl : Polylines) {
+    for (auto* pl : std::as_const(Polylines)) {
         for (size_t i = 1; i < pl->points.size(); i++) {
             auto& prev = pl->points.at(i - 1);
             auto& curr = pl->points.at(i);
@@ -368,7 +368,7 @@ void Component::paintScheme(Schematic *p) {
     }
 
     // paint all ports
-    for (Port *p2 : Ports)
+    for (Port *p2 : std::as_const(Ports))
       if (p2->avail) {
         Node *node = p2->Connection;
         if (!node) {
@@ -376,14 +376,14 @@ void Component::paintScheme(Schematic *p) {
         }
       }
 
-    for (qucs::Arc *p3: Arcs)   // paint all arcs
+    for (qucs::Arc *p3: std::as_const(Arcs))   // paint all arcs
         p->PostPaintEvent(_Arc, cx + p3->x, cy + p3->y, p3->w, p3->h, p3->angle, p3->arclen);
 
 
-    for (qucs::Rect *pa: Rects) // paint all rectangles
+    for (qucs::Rect *pa: std::as_const(Rects)) // paint all rectangles
         p->PostPaintEvent(_Rect, cx + pa->x, cy + pa->y, pa->w, pa->h);
 
-    for (qucs::Ellips *pa: Ellipses) // paint all ellipses
+    for (qucs::Ellips *pa: std::as_const(Ellipses)) // paint all ellipses
         p->PostPaintEvent(_Ellipse, cx + pa->x, cy + pa->y, pa->w, pa->h);
 }
 
@@ -392,7 +392,7 @@ bool Component::moveCenter(int dx, int dy) noexcept {
 
     if (moved) {
         // We also need to move every port node
-        for (auto* pp : Ports) {
+        for (auto* pp : std::as_const(Ports)) {
             setNodePortCenter(pp);
         }
     }
@@ -409,7 +409,7 @@ bool Component::rotate() noexcept {
     int tmp, dx, dy;
 
     // rotate all lines
-    for (qucs::Line *p1: Lines) {
+    for (qucs::Line *p1: std::as_const(Lines)) {
         tmp = -p1->x1;
         p1->x1 = p1->y1;
         p1->y1 = tmp;
@@ -419,7 +419,7 @@ bool Component::rotate() noexcept {
     }
 
     // rotate all ports
-    for (Port *p2: Ports) {
+    for (Port *p2: std::as_const(Ports)) {
         tmp = -p2->x;
         p2->x = p2->y;
         p2->y = tmp;
@@ -429,7 +429,7 @@ bool Component::rotate() noexcept {
     }
 
     // rotate all arcs
-    for (qucs::Arc *p3: Arcs) {
+    for (qucs::Arc *p3: std::as_const(Arcs)) {
         tmp = -p3->x;
         p3->x = p3->y;
         p3->y = tmp - p3->w;
@@ -441,7 +441,7 @@ bool Component::rotate() noexcept {
     }
 
     // rotate all rectangles
-    for (qucs::Rect *pa: Rects) {
+    for (qucs::Rect *pa: std::as_const(Rects)) {
         tmp = -pa->x;
         pa->x = pa->y;
         pa->y = tmp - pa->w;
@@ -451,7 +451,7 @@ bool Component::rotate() noexcept {
     }
 
     // rotate all ellipses
-    for (qucs::Ellips *pa: Ellipses) {
+    for (qucs::Ellips *pa: std::as_const(Ellipses)) {
         tmp = -pa->x;
         pa->x = pa->y;
         pa->y = tmp - pa->w;
@@ -462,7 +462,7 @@ bool Component::rotate() noexcept {
 
     // rotate all text
     float ftmp;
-    for (Text *pt: Texts) {
+    for (Text *pt: std::as_const(Texts)) {
         tmp = -pt->x;
         pt->x = pt->y;
         pt->y = tmp;
@@ -472,7 +472,7 @@ bool Component::rotate() noexcept {
         pt->mCos = ftmp;
     }
 
-    for (qucs::Polyline* pl : Polylines) {
+    for (qucs::Polyline* pl : std::as_const(Polylines)) {
         for (auto& pt : pl->points) {
             std::swap(pt.rx(), pt.ry());
             pt.ry() *= -1;
@@ -495,7 +495,7 @@ bool Component::rotate() noexcept {
         dx = metrics.boundingRect(Name).width();
         dy = metrics.lineSpacing();
     }
-    for (Property *pp : Props)
+    for (Property *pp : std::as_const(Props))
         if (pp->display) {
             // get width of text
             tmp = metrics.boundingRect(pp->Name + "=" + pp->Value).width();
@@ -524,20 +524,20 @@ bool Component::mirrorX() noexcept {
         if (Ports.count() < 1) return false;  // do not rotate components without ports
 
     // mirror all lines
-    for (qucs::Line *p1: Lines) {
+    for (qucs::Line *p1: std::as_const(Lines)) {
         p1->y1 = -p1->y1;
         p1->y2 = -p1->y2;
     }
 
     // mirror all ports
-    for (Port *p2: Ports) {
+    for (Port *p2: std::as_const(Ports)) {
         p2->y = -p2->y;
         // mirror node(s)
         setNodePortCenter(p2);
     }
 
     // mirror all arcs
-    for (qucs::Arc *p3: Arcs) {
+    for (qucs::Arc *p3: std::as_const(Arcs)) {
         p3->y = -p3->y - p3->h;
         if (p3->angle > 16 * 180) p3->angle -= 16 * 360;
         p3->angle = -p3->angle;    // mirror
@@ -546,16 +546,16 @@ bool Component::mirrorX() noexcept {
     }
 
     // mirror all rectangles
-    for (qucs::Rect *pa: Rects)
+    for (qucs::Rect *pa: std::as_const(Rects))
         pa->y = -pa->y - pa->h;
 
     // mirror all ellipses
-    for (qucs::Ellips *pa: Ellipses)
+    for (qucs::Ellips *pa: std::as_const(Ellipses))
         pa->y = -pa->y - pa->h;
 
     QFont f = QucsSettings.font;
     // mirror all text
-    for (Text *pt: Texts) {
+    for (Text *pt: std::as_const(Texts)) {
         f.setPixelSize(pt->Size);
         // use the screen-compatible metric
         QFontMetrics smallMetrics(f, 0);
@@ -563,7 +563,7 @@ bool Component::mirrorX() noexcept {
         pt->y = -pt->y - int(pt->mCos) * s.height() + int(pt->mSin) * s.width();
     }
 
-    for (qucs::Polyline* pl : Polylines) {
+    for (qucs::Polyline* pl : std::as_const(Polylines)) {
         for (auto& pt : pl->points) {
             pt.ry() *= -1;
         }
@@ -577,7 +577,7 @@ bool Component::mirrorX() noexcept {
     int dy = 0;
     if (showName)
         dy = metrics.lineSpacing();   // for "Name"
-    for (Property *pp : Props)
+    for (Property *pp : std::as_const(Props))
         if (pp->display) dy += metrics.lineSpacing();
     if ((tx > x1) && (tx < x2)) ty = -ty - dy;     // mirror text position
     else ty = y1 + ty + y2;
@@ -597,37 +597,37 @@ bool Component::mirrorY() noexcept {
         if (Ports.count() < 1) return false;  // do not rotate components without ports
 
     // mirror all lines
-    for (qucs::Line *p1: Lines) {
+    for (qucs::Line *p1: std::as_const(Lines)) {
         p1->x1 = -p1->x1;
         p1->x2 = -p1->x2;
     }
 
     // mirror all ports
-    for (Port *p2: Ports) {
+    for (Port *p2: std::as_const(Ports)) {
         p2->x = -p2->x;
         // mirror node(s)
         setNodePortCenter(p2);
     }
 
     // mirror all arcs
-    for (qucs::Arc *p3: Arcs) {
+    for (qucs::Arc *p3: std::as_const(Arcs)) {
         p3->x = -p3->x - p3->w;
         p3->angle = 16 * 180 - p3->angle - p3->arclen;  // mirror
         if (p3->angle < 0) p3->angle += 16 * 360;   // angle has to be > 0
     }
 
     // mirror all rectangles
-    for (qucs::Rect *pa: Rects)
+    for (qucs::Rect *pa: std::as_const(Rects))
         pa->x = -pa->x - pa->w;
 
     // mirror all ellipses
-    for (qucs::Ellips *pa: Ellipses)
+    for (qucs::Ellips *pa: std::as_const(Ellipses))
         pa->x = -pa->x - pa->w;
 
     int tmp;
     QFont f = QucsSettings.font;
     // mirror all text
-    for (Text *pt: Texts) {
+    for (Text *pt: std::as_const(Texts)) {
         f.setPixelSize(pt->Size);
         // use the screen-compatible metric
         QFontMetrics smallMetrics(f, 0);
@@ -635,7 +635,7 @@ bool Component::mirrorY() noexcept {
         pt->x = -pt->x - int(pt->mSin) * s.height() - int(pt->mCos) * s.width();
     }
 
-    for (qucs::Polyline* pl : Polylines) {
+    for (qucs::Polyline* pl : std::as_const(Polylines)) {
         for (auto& pt : pl->points) {
             pt.rx() *= -1;
         }
@@ -649,7 +649,7 @@ bool Component::mirrorY() noexcept {
     int dx = 0;
     if (showName)
         dx = metrics.boundingRect(Name).width();
-    for (Property *pp : Props)
+    for (Property *pp : std::as_const(Props))
         if (pp->display) {
             // get width of text
             tmp = metrics.boundingRect(pp->Name + "=" + pp->Value).width();
@@ -691,13 +691,13 @@ QString Component::netlist() {
     QString s = Model + ":" + Name;
 
     // output all node names
-    for (Port *p1: Ports)
+    for (Port *p1: std::as_const(Ports))
         s += " " + p1->Connection->Name;   // node names
 
     // output all properties
     QStringList no_sim_props;
     no_sim_props<<"Symbol"<<"UseGlobTemp"<<"LibName"<<"CompName";
-    for (const auto &p2 : Props) {
+    for (const auto &p2 : std::as_const(Props)) {
       if (!no_sim_props.contains(p2->Name)) {
         s += " " + p2->Name + "=\"" + p2->Value + "\"";
       }
@@ -723,7 +723,7 @@ QString Component::form_spice_param_list(QStringList &ignore_list, QStringList &
                 nam = Props.at(i)->Name;
             }
             QString val = spicecompat::normalize_value(Props.at(i)->Value);
-            par_str += QStringLiteral("%1=%2 ").arg(nam).arg(val);
+            par_str += QStringLiteral("%1=%2 ").arg(nam, val);
         }
 
     }
@@ -921,7 +921,7 @@ QString Component::save() {
     s += " " + QString::number(rotated);
 
     // write all properties
-    for (Property *p1 : Props) {
+    for (Property *p1 : std::as_const(Props)) {
         QString val = p1->Value; // enable newline in properties
         val.replace("\n", "\\n");
         val.replace("\"", "''");
@@ -1454,7 +1454,7 @@ QString Component::getSpiceSubstrateLine()
 
   if (sub == nullptr) return s;
 
-  for(Property *pp: sub->Props) {
+  for(Property *pp: std::as_const(sub->Props)) {
     QString vv = spicecompat::normalize_value(pp->Value);
     QString nn = pp->Name;
     s += QString(" %1=%2 ").arg(nn.toLower(), vv);
@@ -1523,7 +1523,7 @@ QString GateComponent::netlist() {
     QString s = Model + ":" + Name;
 
     // output all node names
-    for (Port *pp: Ports)
+    for (Port *pp: std::as_const(Ports))
         s += " " + pp->Connection->Name;   // node names
 
     // output all properties

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -1457,7 +1457,7 @@ QString Component::getSpiceSubstrateLine()
   for(Property *pp: sub->Props) {
     QString vv = spicecompat::normalize_value(pp->Value);
     QString nn = pp->Name;
-    s += QString(" %1=%2 ").arg(nn.toLower()).arg(vv);
+    s += QString(" %1=%2 ").arg(nn.toLower(), vv);
   }
 
   return s;
@@ -1551,7 +1551,7 @@ QString GateComponent::spice_netlist(spicecompat::SpiceDialect dialect) {
     s += "] " + Ports.at(0)->Connection->Name;
     s += " " + tmp_model + "\n";
     s += QStringLiteral(".model %1 %2(rise_delay=%3 fall_delay=%3 input_load=5e-13)\n")
-            .arg(tmp_model).arg(type).arg(td);
+            .arg(tmp_model, type, td);
     return s;
 }
 

--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -54,7 +54,7 @@ QStringList getOptionsFromString(const QString& description)
   if (start != -1 && end != -1)
   {
     list = description.mid(start + 1, end - start - 1).split(',');
-    for(auto entry : std::as_const(list))
+    for(const auto &entry : std::as_const(list))
       options << entry.trimmed(); // QString::trimmed flagged by valgrind leak check
   }
 
@@ -1005,7 +1005,7 @@ void ComponentDialog::slotApplyButton()
       // Note: Order is very important here. The component expects parameters in a 
       // specific order depending on which sweep parameters are valid for the component
       // type.
-      for (auto param : std::as_const(sweepProperties))
+      for (const auto &param : std::as_const(sweepProperties))
       {
         /* TODO: ***HACK*** to be fixed */
         QString temp = param;

--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -92,7 +92,7 @@ public:
     setLayout(layout);
 
     if (func)
-      connect(mButton, &QPushButton::released, [=]() { if (dialog) (dialog->*func)(mEdit); });    
+      connect(mButton, &QPushButton::released, [this, dialog, func]() { if (dialog) (dialog->*func)(mEdit); });
   }
   ~CompoundWidget()
   {
@@ -189,7 +189,7 @@ class ParamLineEdit : public QLineEdit, public ParamWidget
       setValidator(validator);
       
       if (func)
-        connect(this, &QLineEdit::textEdited, [=]() { if (dialog) (dialog->*func)(mParam); });
+        connect(this, &QLineEdit::textEdited, [this, dialog, func]() { if (dialog) (dialog->*func)(mParam); });
     }
 
     void setEnabled(bool enabled) override
@@ -229,7 +229,7 @@ class ParamCombo : public QComboBox, public ParamWidget
       layout->addWidget(this, layout->rowCount() - 1, 1);
       
       if (func)
-        connect(this, &QComboBox::currentTextChanged, [=]() { if (dialog) (dialog->*func)(mParam); });
+        connect(this, &QComboBox::currentTextChanged, [this, dialog, func]() { if (dialog) (dialog->*func)(mParam); });
     }
 
     void setEnabled(bool enabled) override
@@ -637,7 +637,7 @@ ComponentDialog::ComponentDialog(Component* schematicComponent, Schematic* schem
 
     // Try to move the cursor to the editable cell if any cell is clicked.
     connect(propertyTable, &QTableWidget::cellClicked, 
-                [=](int row, int column) { (void)column; propertyTable->setCurrentCell(row, 1); } );
+                [this](int row, int column) { (void)column; propertyTable->setCurrentCell(row, 1); } );
   }
 
   // Add the dialog button widgets.

--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -565,7 +565,7 @@ ComponentDialog::ComponentDialog(Component* schematicComponent, Schematic* schem
       sweepTypeEnabledParams["lin"] = QStringList{"Sim", "Type", "Param", "Start", "Stop", "Step", "Points"};    
       sweepTypeEnabledParams["log"] = QStringList{"Sim", "Type", "Param", "Start", "Stop", "Step", "Points"};
       sweepTypeEnabledParams["list"] = QStringList{"Sim", "Type", "Param", "Values"};
-      sweepTypeSpecialLabels[qMakePair(QString("log"),QString("Step"))] = {"Points per decade"};
+      sweepTypeSpecialLabels[qMakePair(QString("log"),QString("Step"))] = "Points per decade";
 
       // Setup the widgets as per the stored type.
       sweepParamWidget["Sim"]->setOptions(getSimulationList(false));

--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -865,7 +865,7 @@ void ComponentDialog::updateEqnEditor()
   // Save plain text components (e.g. systemcommand component)
   if (isPlainText)
   {
-    for (auto prop : qAsConst(component->Props)) {
+    for (auto prop : std::as_const(component->Props)) {
       if (prop->Name == "cmd"){
         eqnEditor->setPlainText(prop->Value);
       }
@@ -912,7 +912,7 @@ void ComponentDialog::writeEquation()
     // The command text is stored as-is — no parsing or transformation is applied,
     // preserving multi-line scripts, comments, and blank lines exactly as the user typed them.
 
-    for (auto prop : qAsConst(component->Props)) {
+    for (auto prop : std::as_const(component->Props)) {
       if (prop->Name == "cmd") {
         prop->Value = eqnEditor->document()->toPlainText().trimmed();
       }
@@ -955,7 +955,7 @@ void ComponentDialog::writeEquation()
   QString text = eqnEditor->document()->toPlainText();
   QStringList lines = text.split('\n', Qt::SkipEmptyParts);
   
-  for (const QString& line : qAsConst(lines))
+  for (const QString& line : std::as_const(lines))
   {
     QString LHS = line.section('=',0,0).trimmed();
     QString RHS = line.section('=',1).trimmed();

--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -54,7 +54,7 @@ QStringList getOptionsFromString(const QString& description)
   if (start != -1 && end != -1)
   {
     list = description.mid(start + 1, end - start - 1).split(',');
-    for(auto entry : list)
+    for(auto entry : std::as_const(list))
       options << entry.trimmed(); // QString::trimmed flagged by valgrind leak check
   }
 
@@ -713,7 +713,7 @@ void ComponentDialog::updateSweepProperty(const QString& property)
 
   if (property == "All")
   {
-    for (auto property : component->Props)
+    for (auto property : std::as_const(component->Props))
     {
       // qDebug() << "Property name " << property->Name;
       if (sweepParamWidget.contains(property->Name))
@@ -884,7 +884,7 @@ void ComponentDialog::updateEqnEditor()
 
   QString eqnList;
 
-  for (auto property : component->Props)
+  for (auto property : std::as_const(component->Props))
   {
     if (eqnSimCombo && property->Name == "Simulation")
       eqnSimCombo->setCurrentText(property->Value);
@@ -1005,7 +1005,7 @@ void ComponentDialog::slotApplyButton()
       // Note: Order is very important here. The component expects parameters in a 
       // specific order depending on which sweep parameters are valid for the component
       // type.
-      for (auto param : sweepProperties) 
+      for (auto param : std::as_const(sweepProperties))
       {
         /* TODO: ***HACK*** to be fixed */
         QString temp = param;
@@ -1022,7 +1022,7 @@ void ComponentDialog::slotApplyButton()
     }
 
     row = 0;
-    for (Property* property : component->Props)
+    for (Property* property : std::as_const(component->Props))
     {
       if ((property->simulators & QucsSettings.DefaultSimulator) != QucsSettings.DefaultSimulator) {
         continue;
@@ -1266,7 +1266,7 @@ void ComponentDialog::slotFillFromSpice()
   // Make a copy of the componenty type and properties.
   Component tempComponent;
   tempComponent.SpiceModelcards = component->SpiceModelcards;
-  for (auto property : component->Props)
+  for (auto property : std::as_const(component->Props))
     tempComponent.Props.append(new Property(property->Name, property->Value, property->display, property->Description));
 
   // Populate the temporary component from the spice model.
@@ -1279,7 +1279,7 @@ void ComponentDialog::slotFillFromSpice()
   }
 
   // Cleanup.
-  for (auto property : tempComponent.Props)
+  for (auto property : std::as_const(tempComponent.Props))
     delete property; 
 
   delete dlg;

--- a/qucs/components/ctline.cpp
+++ b/qucs/components/ctline.cpp
@@ -109,9 +109,9 @@ QString CoupledTLine::spice_netlist(spicecompat::SpiceDialect dialect)
 
   s = QString("A_%1 %hd(%2 0) %hd(%3 0) %hd(%4 0) %hd(%5 0)"
               " %vd(%2 0) %vd(%3 0) %vd(%4 0) %vd(%5 0) MODEL_%1\n")
-              .arg(Name).arg(p1).arg(p2).arg(p3).arg(p4);
+              .arg(Name, p1, p2, p3, p4);
   s += QString(".MODEL MODEL_%1 CPLINE(L=%2 ze=%3 zo=%4 ere=%5 ero=%6 ae=%7 ao=%8)\n")
-           .arg(Name).arg(L).arg(Ze).arg(Zo).arg(Ere).arg(Ero).arg(Ae).arg(Ao);
+           .arg(Name, L, Ze, Zo, Ere, Ero, Ae, Ao);
 
   return s;
 }

--- a/qucs/components/d_flipflop.cpp
+++ b/qucs/components/d_flipflop.cpp
@@ -139,7 +139,7 @@ QString D_FlipFlop::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
 
     s += " " + tmp_model + "\n";
     s += QStringLiteral(".model %1 d_dff(clk_delay=%2 set_delay=%2 reset_delay=%2 rise_delay=%2 fall_delay=%2)\n")
-            .arg(tmp_model).arg(td);
+            .arg(tmp_model, td);
     s += QStringLiteral("C%1 QB_%1 0 1e-9 \n").arg(Name); // capacitor load for unused QB pin
 
     return s;

--- a/qucs/components/dff_SR.cpp
+++ b/qucs/components/dff_SR.cpp
@@ -194,6 +194,6 @@ QString dff_SR::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
 
     s += " " + tmp_model + "\n";
     s += QStringLiteral(".model %1 d_dff(clk_delay=%2 set_delay=%2 reset_delay=%2 rise_delay=%2 fall_delay=%2)\n")
-            .arg(tmp_model).arg(td);
+            .arg(tmp_model, td);
     return s;
 }

--- a/qucs/components/diode.cpp
+++ b/qucs/components/diode.cpp
@@ -149,15 +149,15 @@ QString Diode::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     }
 
     if (getProperty("UseGlobTemp")->Value == "yes") {
-      s += QStringLiteral(" DMOD_%1 AREA=%2\n").arg(Name).arg(getProperty("Area")->Value);
+      s += QStringLiteral(" DMOD_%1 AREA=%2\n").arg(Name, getProperty("Area")->Value);
     } else {
-      s += QStringLiteral(" DMOD_%1 AREA=%2 Temp=%3\n").arg(Name).arg(getProperty("Area")->Value)
+      s += QStringLiteral(" DMOD_%1 AREA=%2 Temp=%3\n").arg(Name, getProperty("Area")->Value)
       .arg(getProperty("Temp")->Value);
     }
 
     if (dialect != spicecompat::CDL)
     {
-      s += QStringLiteral(".MODEL DMOD_%1 D (%2)\n").arg(Name).arg(par_str);
+      s += QStringLiteral(".MODEL DMOD_%1 D (%2)\n").arg(Name, par_str);
     }
 
     return s;

--- a/qucs/components/diode.cpp
+++ b/qucs/components/diode.cpp
@@ -110,7 +110,7 @@ QString Diode::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     QList<int> pin_seq;
     pin_seq<<1<<0; // Pin sequence: CBE
     // output all node names
-    for (int pin : pin_seq) {
+    for (int pin : std::as_const(pin_seq)) {
         QString nam = Ports.at(pin)->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names
@@ -151,8 +151,7 @@ QString Diode::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     if (getProperty("UseGlobTemp")->Value == "yes") {
       s += QStringLiteral(" DMOD_%1 AREA=%2\n").arg(Name, getProperty("Area")->Value);
     } else {
-      s += QStringLiteral(" DMOD_%1 AREA=%2 Temp=%3\n").arg(Name, getProperty("Area")->Value)
-      .arg(getProperty("Temp")->Value);
+      s += QStringLiteral(" DMOD_%1 AREA=%2 Temp=%3\n").arg(Name, getProperty("Area")->Value, getProperty("Temp")->Value);
     }
 
     if (dialect != spicecompat::CDL)

--- a/qucs/components/diode.cpp
+++ b/qucs/components/diode.cpp
@@ -89,7 +89,7 @@ Diode::Diode()
   Props.append(new Property("CompName", "Generic", false,
                             QObject::tr("Component name in library")));
 
-  createSymbol();
+  Diode::createSymbol();
   tx = x1+4;
   ty = y2+4;
   Model = "Diode";

--- a/qucs/components/ecvs.cpp
+++ b/qucs/components/ecvs.cpp
@@ -96,11 +96,11 @@ QString ecvs::netlist()
   QString s = Model+":"+Name;
 
   // output all node names
-  for (Port *p1 : Ports)
+  for (Port *p1 : std::as_const(Ports))
     s += " "+p1->Connection->Name;   // node names
 
   // output all properties
-  for(Property *p2 : Props)
+  for(Property *p2 : std::as_const(Props))
     s += " "+p2->Name+"=\""+p2->Value+"\"";
 
   return s + "\n";

--- a/qucs/components/eqndefined.cpp
+++ b/qucs/components/eqndefined.cpp
@@ -48,7 +48,7 @@ EqnDefined::EqnDefined()
   Props.append(new Property("Q1", "0", false,
 		QObject::tr("charge equation") + " 1"));
 
-  createSymbol();
+  EqnDefined::createSymbol();
 }
 
 // -------------------------------------------------------

--- a/qucs/components/eqndefined.cpp
+++ b/qucs/components/eqndefined.cpp
@@ -133,8 +133,7 @@ QString EqnDefined::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
                 s += QStringLiteral("V_%1sens_%2 %3 %4 DC 0\n").arg(Name).arg(i).arg(plus).arg(plus+"_sens");
                 plus = plus+"_sens";
             }
-            s += QStringLiteral("B%1I%2 %3 %4 I=%5\n").arg(Name).arg(i).arg(plus)
-                    .arg(minus).arg(Itokens.join(""));
+            s += QStringLiteral("B%1I%2 %3 %4 I=%5\n").arg(Name).arg(i).arg(plus, minus, Itokens.join(""));
 
             QString Qeqn = Props.at(2*(i+1)+1)->Value; // parse charge equation only for Xyce
             if (Qeqn!="0") {
@@ -145,9 +144,9 @@ QString EqnDefined::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
                 spicecompat::convert_functions(Qtokens, dialect == spicecompat::SPICEXyce);
                 subsVoltages(Qtokens,Nbranch);
                 subsCurrents(Qtokens);
-                s += QStringLiteral("G%1Q%2 %3 %4 n%1Q%2 %4 1.0\n").arg(Name).arg(i).arg(plus).arg(minus);
+                s += QStringLiteral("G%1Q%2 %3 %4 n%1Q%2 %4 1.0\n").arg(Name).arg(i).arg(plus, minus);
                 s += QStringLiteral("L%1Q%2 n%1Q%2 %3 1.0\n").arg(Name).arg(i).arg(minus);
-                s += QStringLiteral("B%1Q%2 n%1Q%2 %3 I=-(%4)\n").arg(Name).arg(i).arg(minus).arg(Qtokens.join(""));
+                s += QStringLiteral("B%1Q%2 n%1Q%2 %3 I=-(%4)\n").arg(Name).arg(i).arg(minus, Qtokens.join(""));
             }
         }
     } else {
@@ -174,7 +173,7 @@ QString EqnDefined::va_code()
                 vacompat::convert_functions(Itokens);
                 subsVoltages(Itokens,Nbranch);
                 if (plus=="gnd") s += QStringLiteral("%1 <+ -(%2);\n").arg(Ipm).arg(Itokens.join(""));
-                else s += QStringLiteral("%1 <+ %2;\n").arg(Ipm).arg(Itokens.join(""));
+                else s += QStringLiteral("%1 <+ %2;\n").arg(Ipm, Itokens.join(""));
             }
             QString Qeqn = Props.at(2*(i+1)+1)->Value; // parse charge equation only for Xyce
             if (Qeqn!="0") {
@@ -183,7 +182,7 @@ QString EqnDefined::va_code()
                 vacompat::convert_functions(Qtokens);
                 subsVoltages(Qtokens,Nbranch);
                 if (plus=="gnd") s += QStringLiteral("%1 <+ -ddt( %2 );\n").arg(Ipm).arg(Qtokens.join(""));
-                else s += QStringLiteral("%1 <+ ddt( %2 );\n").arg(Ipm).arg(Qtokens.join(""));
+                else s += QStringLiteral("%1 <+ ddt( %2 );\n").arg(Ipm, Qtokens.join(""));
             }
         }
     } else {

--- a/qucs/components/eqndefined.cpp
+++ b/qucs/components/eqndefined.cpp
@@ -84,7 +84,7 @@ QString EqnDefined::netlist()
   QString e = "\n";
 
   // output all node names
-  for (Port *p1 : Ports)
+  for (Port *p1 : std::as_const(Ports))
     s += " "+p1->Connection->Name;   // node names
 
   // output all properties
@@ -130,7 +130,7 @@ QString EqnDefined::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
             QString plus = Ports.at(2*i)->Connection->Name;
             QString minus = Ports.at(2*i+1)->Connection->Name;
             if (used_currents.contains(i)) { // if current is used add sensing source V=0
-                s += QStringLiteral("V_%1sens_%2 %3 %4 DC 0\n").arg(Name).arg(i).arg(plus).arg(plus+"_sens");
+                s += QStringLiteral("V_%1sens_%2 %3 %4 DC 0\n").arg(Name).arg(i).arg(plus, plus+"_sens");
                 plus = plus+"_sens";
             }
             s += QStringLiteral("B%1I%2 %3 %4 I=%5\n").arg(Name).arg(i).arg(plus, minus, Itokens.join(""));
@@ -172,7 +172,7 @@ QString EqnDefined::va_code()
                 spicecompat::splitEqn(Ieqn,Itokens);
                 vacompat::convert_functions(Itokens);
                 subsVoltages(Itokens,Nbranch);
-                if (plus=="gnd") s += QStringLiteral("%1 <+ -(%2);\n").arg(Ipm).arg(Itokens.join(""));
+                if (plus=="gnd") s += QStringLiteral("%1 <+ -(%2);\n").arg(Ipm, Itokens.join(""));
                 else s += QStringLiteral("%1 <+ %2;\n").arg(Ipm, Itokens.join(""));
             }
             QString Qeqn = Props.at(2*(i+1)+1)->Value; // parse charge equation only for Xyce
@@ -181,7 +181,7 @@ QString EqnDefined::va_code()
                 spicecompat::splitEqn(Qeqn,Qtokens);
                 vacompat::convert_functions(Qtokens);
                 subsVoltages(Qtokens,Nbranch);
-                if (plus=="gnd") s += QStringLiteral("%1 <+ -ddt( %2 );\n").arg(Ipm).arg(Qtokens.join(""));
+                if (plus=="gnd") s += QStringLiteral("%1 <+ -ddt( %2 );\n").arg(Ipm, Qtokens.join(""));
                 else s += QStringLiteral("%1 <+ ddt( %2 );\n").arg(Ipm, Qtokens.join(""));
             }
         }

--- a/qucs/components/equation.cpp
+++ b/qucs/components/equation.cpp
@@ -112,7 +112,7 @@ QString Equation::getVAExpressions()
         QStringList tokens;
         spicecompat::splitEqn(Props.at(i)->Value,tokens);
         vacompat::convert_functions(tokens);
-        s += QStringLiteral("%1=%2;\n").arg(Props.at(i)->Name).arg(tokens.join(""));
+        s += QStringLiteral("%1=%2;\n").arg(Props.at(i)->Name, tokens.join(""));
     }
     return s;
 }
@@ -156,7 +156,7 @@ QString Equation::getExpression(spicecompat::SpiceDialect dialect /* = spicecomp
         }
 
         if (!spicecompat::containNodes(tokens,ng_vars)) {
-            s += QStringLiteral(".PARAM %1=%2\n").arg(Props.at(i)->Name).arg(eqn);
+            s += QStringLiteral(".PARAM %1=%2\n").arg(Props.at(i)->Name, eqn);
         }
     }
     return s;
@@ -194,7 +194,7 @@ QString Equation::getEquations(QString sim, QStringList &dep_vars)
             if ( used_sim.toLower() == "tran" ) used_sim = "tr";
             if ( (sim.startsWith(used_sim.toLower())) || (used_sim=="all") ) {
                 eqn = tokens.join("");
-                s += QStringLiteral("let %1=%2\n").arg(Props.at(i)->Name).arg(eqn);
+                s += QStringLiteral("let %1=%2\n").arg(Props.at(i)->Name, eqn);
                 dep_vars.append(Props.at(i)->Name);
             }
         }
@@ -224,7 +224,7 @@ QString Equation::getNgspiceScript()
         eqn = tokens.join("");
 
         if (!spicecompat::containNodes(tokens,ng_vars)) {
-            s += QStringLiteral("let %1=%2\n").arg(Props.at(i)->Name).arg(eqn);
+            s += QStringLiteral("let %1=%2\n").arg(Props.at(i)->Name, eqn);
         }
     }
     return s;

--- a/qucs/components/equation.cpp
+++ b/qucs/components/equation.cpp
@@ -64,7 +64,7 @@ QString Equation::verilogCode(int)
 {
   QString s;
   // output all equations
-  for(Property *pr : Props)
+  for(Property *pr : std::as_const(Props))
     if(pr->Name != "Export")
       s += "  real "+pr->Name+"; initial "+pr->Name+" = "+pr->Value+";\n";
   return s;
@@ -75,7 +75,7 @@ QString Equation::vhdlCode(int)
 {
   QString s;
   // output all equations
-  for(Property *pr : Props)
+  for(Property *pr : std::as_const(Props))
     if(pr->Name != "Export")
       s += "  constant "+pr->Name+" : time := "+pr->Value+";\n";
   return s;
@@ -255,7 +255,7 @@ void Equation::getNgnutmegVars(QStringList &vars, QStringList &sims)
             }
         }
     }
-    for (const QString& var : vars) {
+    for (const QString& var : std::as_const(vars)) {
         QString sim;
         int idx = vars.indexOf(var);
         if (idx>=0) sim = sims.at(idx);
@@ -263,7 +263,7 @@ void Equation::getNgnutmegVars(QStringList &vars, QStringList &sims)
             QString eqn = getProperty(var)->Value;
             QStringList tokens;
             spicecompat::splitEqn(eqn,tokens);
-            for (const QString& tok : tokens) {
+            for (const QString& tok : std::as_const(tokens)) {
                 int idx1 = vars.indexOf(tok);
                 if ((idx1>=0)&&(sims[idx1]!="all")) sims[idx]=sims[idx1];
             }

--- a/qucs/components/gyrator.cpp
+++ b/qucs/components/gyrator.cpp
@@ -94,7 +94,7 @@ QString Gyrator::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
     if (n3=="gnd") n3="0";
     QString n4 = Ports.at(3)->Connection->Name;
     if (n4=="gnd") n4="0";
-    s +=  QStringLiteral("B%1_1 %2 %3 I=(1/(%4))*(V(%5)-V(%6))\n").arg(Name).arg(n1).arg(n4).arg(R).arg(n2).arg(n3);
-    s +=  QStringLiteral("B%1_2 %2 %3 I=-1.0*(1/(%4))*(V(%5)-V(%6))\n").arg(Name).arg(n2).arg(n3).arg(R).arg(n1).arg(n4);
+    s +=  QStringLiteral("B%1_1 %2 %3 I=(1/(%4))*(V(%5)-V(%6))\n").arg(Name, n1, n4, R, n2, n3);
+    s +=  QStringLiteral("B%1_2 %2 %3 I=-1.0*(1/(%4))*(V(%5)-V(%6))\n").arg(Name, n2, n3, R, n1, n4);
     return s;
 }

--- a/qucs/components/iexp.cpp
+++ b/qucs/components/iexp.cpp
@@ -101,7 +101,7 @@ QString iExp::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::
     QString Tr = spicecompat::normalize_value(Props.at(4)->Value);
     QString Tf = spicecompat::normalize_value(Props.at(5)->Value);
 
-    s += QStringLiteral(" DC 0 EXP(%1 %2 %3 %4 %5 %6) AC 0\n").arg(U1).arg(U2).arg(T1).arg(Tr).arg(T2).arg(Tf);
+    s += QStringLiteral(" DC 0 EXP(%1 %2 %3 %4 %5 %6) AC 0\n").arg(U1, U2, T1, Tr, T2, Tf);
     return s;
 }
 

--- a/qucs/components/ifile.cpp
+++ b/qucs/components/ifile.cpp
@@ -96,7 +96,7 @@ QString iFile::netlist()
   QString s = Model+":"+Name;
 
   // output all node names
-  for (Port *p1 : Ports)
+  for (Port *p1 : std::as_const(Ports))
     s += " "+p1->Connection->Name;   // node names
 
   // output file properties
@@ -117,7 +117,7 @@ QString iFile::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     QString modname = "mod_" + Model + Name;
     QString p1 = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
     QString p2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
-    s += QStringLiteral(" %id([%1 %2]) %3\n").arg(p2).arg(p1).arg(modname);
+    s += QStringLiteral(" %id([%1 %2]) %3\n").arg(p2, p1, modname);
     QString file = getSubcircuitFile();
     QString sc = getProperty("G")->Value;
     QString step = "false";
@@ -125,7 +125,7 @@ QString iFile::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     if (getProperty("Interpolator")->Value != "linear") step = "true";
     s += QStringLiteral(".MODEL %1 filesource (file=\"%2\" amplscale=[%3] amplstep=%4 "
                  "amploffset=[0] timeoffset=%5 timescale=1)\n")
-            .arg(modname).arg(file).arg(sc).arg(step).arg(delay);
+            .arg(modname, file, sc, step, delay);
 
     return s;
 }

--- a/qucs/components/indq.cpp
+++ b/qucs/components/indq.cpp
@@ -122,15 +122,15 @@ QString IndQ::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::
     QString double_pi = "8*atan(1)";
     QString mode = getProperty("Mode")->Value;
     if (mode == "Constant") {
-        res_eq = QStringLiteral("%1*(%2)*hertz/(%3)").arg(double_pi).arg(L).arg(Q);
+        res_eq = QStringLiteral("%1*(%2)*hertz/(%3)").arg(double_pi, L, Q);
     } else if (mode == "Linear") {
-        res_eq = QStringLiteral("%1*(%2)*(%3)/(%4)").arg(double_pi).arg(L).arg(f0).arg(Q);
+        res_eq = QStringLiteral("%1*(%2)*(%3)/(%4)").arg(double_pi, L, f0, Q);
     } else if (mode == "SquareRoot") {
-        res_eq = QStringLiteral("%1*(%2)*sqrt(hertz*(%3))/(%4)").arg(double_pi).arg(L).arg(f0).arg(Q);
+        res_eq = QStringLiteral("%1*(%2)*sqrt(hertz*(%3))/(%4)").arg(double_pi, L, f0, Q);
     }
 
-    s = QStringLiteral("%1 %2 %3 L='%4'\n").arg(Lname).arg(pin1).arg(pin_int).arg(L);
-    s += QStringLiteral("%1 %2 %3 R='%4'\n").arg(Rname).arg(pin_int).arg(pin2).arg(res_eq);
+    s = QStringLiteral("%1 %2 %3 L='%4'\n").arg(Lname, pin1, pin_int, L);
+    s += QStringLiteral("%1 %2 %3 R='%4'\n").arg(Rname, pin_int, pin2, res_eq);
 
     return s;
 }

--- a/qucs/components/inductor.cpp
+++ b/qucs/components/inductor.cpp
@@ -63,8 +63,7 @@ QString Inductor::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecomp
 {
     QString s = spicecompat::check_refdes(Name,SpiceModel);
 
-    s += QStringLiteral(" %1 %2 ").arg(Ports.at(0)->Connection->Name)
-            .arg(Ports.at(1)->Connection->Name); // output source nodes
+    s += QStringLiteral(" %1 %2 ").arg(Ports.at(0)->Connection->Name, Ports.at(1)->Connection->Name); // output source nodes
     s.replace(" gnd ", " 0 ");
 
     s += " "+spicecompat::normalize_value(Props.at(0)->Value) + " ";
@@ -91,7 +90,7 @@ QString Inductor::va_code()
     QString s = "";
     QString Vpm = vacompat::normalize_voltage(plus,minus,true);
     QString Ipm = vacompat::normalize_current(plus,minus);
-    s += QStringLiteral("%1  <+ ddt( %2 *  %3  );\n").arg(Vpm).arg(Ipm).arg(val);
+    s += QStringLiteral("%1  <+ ddt( %2 *  %3  );\n").arg(Vpm, Ipm, val);
     return s;
 
 }

--- a/qucs/components/iprobe.cpp
+++ b/qucs/components/iprobe.cpp
@@ -83,8 +83,7 @@ QString iProbe::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
 {
     Q_UNUSED(dialect);
 
-    QString s = QStringLiteral("V%1 %2 %3 DC 0\n").arg(Name).arg(Ports.at(0)->Connection->Name)
-            .arg(Ports.at(1)->Connection->Name);
+    QString s = QStringLiteral("V%1 %2 %3 DC 0\n").arg(Name, Ports.at(0)->Connection->Name, Ports.at(1)->Connection->Name);
     return s;
 }
 

--- a/qucs/components/ipulse.cpp
+++ b/qucs/components/ipulse.cpp
@@ -107,7 +107,7 @@ QString iPulse::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
 
 
     s += QStringLiteral(" DC 0 PULSE(%1 %2 %3 %4 %5 {(%6)-(%3)-(%4)-(%5)}) AC 0\n")
-             .arg(IL).arg(IH).arg(T1).arg(Tr).arg(Tf).arg(T2);
+             .arg(IL, IH, T1, Tr, Tf, T2);
 
     return s;
 }

--- a/qucs/components/irect.cpp
+++ b/qucs/components/irect.cpp
@@ -86,7 +86,7 @@ QString iRect::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
 
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names
@@ -108,7 +108,7 @@ QString iRect::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     misc::str2num(Props.at(4)->Value,Tfval,unit,fac);
     T = Tfval*fac+T;
 
-    s += QStringLiteral(" DC 0 PULSE( 0  -%1 %2 %3 %4 %5 %6)  AC 0\n").arg(U).arg(Td).arg(Tr).arg(Tf).arg(TH).arg(T);
+    s += QStringLiteral(" DC 0 PULSE( 0  -%1 %2 %3 %4 %5 %6)  AC 0\n").arg(U, Td, Tr, Tf).arg(TH).arg(T);
 
     return s;
 }

--- a/qucs/components/jfet.cpp
+++ b/qucs/components/jfet.cpp
@@ -104,7 +104,7 @@ QString JFET::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::
     QList<int> pin_seq;
     pin_seq<<1<<0<<2; // Pin sequence: DGS
     // output all node names
-    for (int pin : pin_seq) {
+    for (int pin : std::as_const(pin_seq)) {
         QString nam = Ports.at(pin)->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names
@@ -130,15 +130,14 @@ QString JFET::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::
     QString jfet_type = getProperty("Type")->Value.at(0).toUpper();
 
     if (getProperty("UseGlobTemp")->Value == "yes") {
-      s += QStringLiteral(" JMOD_%1 %2\n").arg(Name).arg(getProperty("Area")->Value);
+      s += QStringLiteral(" JMOD_%1 %2\n").arg(Name, getProperty("Area")->Value);
     } else {
-      s += QStringLiteral(" JMOD_%1 %2 TEMP=%3\n").arg(Name).arg(getProperty("Area")->Value)
-      .arg(getProperty("Temp")->Value);
+      s += QStringLiteral(" JMOD_%1 %2 TEMP=%3\n").arg(Name, getProperty("Area")->Value, getProperty("Temp")->Value);
     }
 
     if (dialect != spicecompat::CDL)
     {
-        s += QStringLiteral(".MODEL JMOD_%1 %2JF (%3)\n").arg(Name).arg(jfet_type).arg(par_str);
+        s += QStringLiteral(".MODEL JMOD_%1 %2JF (%3)\n").arg(Name, jfet_type, par_str);
     }
 
     return s;

--- a/qucs/components/jfet.cpp
+++ b/qucs/components/jfet.cpp
@@ -79,7 +79,7 @@ JFET::JFET() {
     Props.append(new Property("CompName", "Generic", false,
                               QObject::tr("Component name in library")));
 
-    createSymbol();
+    JFET::createSymbol();
     tx = x2 + 4;
     ty = y1 + 4;
     Model = "JFET";

--- a/qucs/components/jkff_SR.cpp
+++ b/qucs/components/jkff_SR.cpp
@@ -204,6 +204,6 @@ QString jkff_SR::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
 
     s += " " + tmp_model + "\n";
     s += QStringLiteral(".model %1 d_jkff(clk_delay=%2 set_delay=%2 reset_delay=%2 rise_delay=%2 fall_delay=%2)\n")
-            .arg(tmp_model).arg(td);
+            .arg(tmp_model, td);
     return s;
 }

--- a/qucs/components/libcomp.cpp
+++ b/qucs/components/libcomp.cpp
@@ -312,7 +312,7 @@ QString LibComp::netlist()
   QString s = "Sub:"+Name;   // output as subcircuit
 
   // output all node names
-  for (Port *p1 : Ports)
+  for (Port *p1 : std::as_const(Ports))
     s += " "+p1->Connection->Name;   // node names
 
   // output property
@@ -366,7 +366,7 @@ QString LibComp::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
     Q_UNUSED(dialect);
 
     QString s = SpiceModel + Name + " " + "0"; // connect ground of subckt to circuit ground
-    for (Port *p1 : Ports)
+    for (Port *p1 : std::as_const(Ports))
       s += " "  + spicecompat::normalize_node_name(p1->Connection->Name);   // node names
     s += " " + createType();
 
@@ -395,7 +395,7 @@ QString LibComp::getSpiceLibrary()
   if (r<0) {
     return QString();
   }
-  for (const auto &file : attach) {
+  for (const auto &file : std::as_const(attach)) {
     if (file.endsWith(".cir", Qt::CaseInsensitive) ||
         file.endsWith(".ckt", Qt::CaseInsensitive) ||
         file.endsWith(".lib", Qt::CaseInsensitive) ||

--- a/qucs/components/logical_buf.cpp
+++ b/qucs/components/logical_buf.cpp
@@ -37,7 +37,7 @@ Logical_Buf::Logical_Buf()
   Props.append(new Property("Symbol", "old", false,
 		QObject::tr("schematic symbol")+" [old, DIN40900]"));
 
-  createSymbol();
+  Logical_Buf::createSymbol();
   tx = x1+4;
   ty = y2+4;
   Model = "Buf";

--- a/qucs/components/logical_buf.cpp
+++ b/qucs/components/logical_buf.cpp
@@ -146,6 +146,6 @@ QString Logical_Buf::spice_netlist(spicecompat::SpiceDialect dialect /* = spicec
     s += " " + Ports.at(0)->Connection->Name;
     s += " " + tmp_model + "\n";
     s += QStringLiteral(".model %1 d_buffer(rise_delay=%2 fall_delay=%2 input_load=5e-13)\n")
-            .arg(tmp_model).arg(td);
+            .arg(tmp_model, td);
     return s;
 }

--- a/qucs/components/logical_inv.cpp
+++ b/qucs/components/logical_inv.cpp
@@ -163,6 +163,6 @@ QString Logical_Inv::spice_netlist(spicecompat::SpiceDialect dialect /* = spicec
     s += " " + Ports.at(0)->Connection->Name;
     s += " " + tmp_model + "\n";
     s += QStringLiteral(".model %1 d_inverter(rise_delay=%2 fall_delay=%2 input_load=5e-13)\n")
-            .arg(tmp_model).arg(td);
+            .arg(tmp_model, td);
     return s;
 }

--- a/qucs/components/logical_inv.cpp
+++ b/qucs/components/logical_inv.cpp
@@ -37,7 +37,7 @@ Logical_Inv::Logical_Inv()
   Props.append(new Property("Symbol", "old", false,
 		QObject::tr("schematic symbol")+" [old, DIN40900]"));
 
-  createSymbol();
+  Logical_Inv::createSymbol();
   tx = x1+4;
   ty = y2+4;
   Model = "Inv";

--- a/qucs/components/mosfet.cpp
+++ b/qucs/components/mosfet.cpp
@@ -129,12 +129,12 @@ QString MOSFET::netlist()
   QString s = "MOSFET:"+Name;
 
   // output all node names
-  for (Port *p1 : Ports)
+  for (Port *p1 : std::as_const(Ports))
     s += " "+p1->Connection->Name;   // node names
   s += " "+Ports.at(2)->Connection->Name;  // connect substrate to source
 
   // output all properties
-  for(Property *p2 : Props)
+  for(Property *p2 : std::as_const(Props))
     s += " "+p2->Name+"=\""+p2->Value+"\"";
 
   return s + '\n';
@@ -146,7 +146,7 @@ QString MOSFET::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
     QList<int> pin_seq;
     pin_seq<<1<<0<<2<<2; // Pin sequence: DGS; coonect substrate to source
     // output all node names
-    for (int pin : pin_seq) {
+    for (int pin : std::as_const(pin_seq)) {
         QString nam = Ports.at(pin)->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names
@@ -166,7 +166,7 @@ QString MOSFET::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
     QStringList check_defaults_list;
     QString unit;
     check_defaults_list<<"Nsub"<<"Nss";
-    for (const QString& parnam : check_defaults_list) { // Check some parameters for default value (zero)
+    for (const QString& parnam : std::as_const(check_defaults_list)) { // Check some parameters for default value (zero)
         double val,fac;   // And reduce parameter list
         misc::str2num(getProperty(parnam)->Value,val,unit,fac);
         if ((val *= fac)==0.0) {

--- a/qucs/components/mosfet.cpp
+++ b/qucs/components/mosfet.cpp
@@ -25,7 +25,7 @@ MOSFET::MOSFET()
 {
   // properties obtained from "Basic_MOSFET" in mosfet_sub.cpp
   Description = QObject::tr("MOS field-effect transistor");
-  createSymbol();
+  MOSFET::createSymbol();
   tx = x2+4;
   ty = y1+4;
   Model = "_MOSFET";

--- a/qucs/components/mosfet.cpp
+++ b/qucs/components/mosfet.cpp
@@ -169,7 +169,7 @@ QString MOSFET::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
     for (const QString& parnam : std::as_const(check_defaults_list)) { // Check some parameters for default value (zero)
         double val,fac;   // And reduce parameter list
         misc::str2num(getProperty(parnam)->Value,val,unit,fac);
-        if ((val *= fac)==0.0) {
+        if ((val * fac)==0.0) {
             spice_incompat.append(parnam);
         }
     }

--- a/qucs/components/mosfet.cpp
+++ b/qucs/components/mosfet.cpp
@@ -187,15 +187,15 @@ QString MOSFET::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
 
     if (getProperty("UseGlobTemp")->Value == "yes") {
       s += QStringLiteral(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7\n")
-      .arg(Name).arg(l).arg(w).arg(ad).arg(as).arg(pd).arg(ps);
+      .arg(Name, l, w, ad, as, pd, ps);
     } else {
       s += QStringLiteral(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7 Temp=%8\n")
-      .arg(Name).arg(l).arg(w).arg(ad).arg(as).arg(pd).arg(ps).arg(getProperty("Temp")->Value);
+      .arg(Name, l, w, ad, as, pd, ps, getProperty("Temp")->Value);
     }
 
     if (dialect != spicecompat::CDL)
     {
-        s += QStringLiteral(".MODEL MMOD_%1 %2MOS (%3)\n").arg(Name).arg(mosfet_type).arg(par_str);
+        s += QStringLiteral(".MODEL MMOD_%1 %2MOS (%3)\n").arg(Name, mosfet_type, par_str);
     }
 
     return s;

--- a/qucs/components/mosfet_sub.cpp
+++ b/qucs/components/mosfet_sub.cpp
@@ -182,7 +182,7 @@ QString MOSFET_sub::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
     for (const QString& parnam : std::as_const(check_defaults_list)) { // Check some parameters for default value (zero)
         double val,fac;   // And reduce parameter list
         misc::str2num(getProperty(parnam)->Value,val,unit,fac);
-        if ((val *= fac)==0.0) {
+        if ((val * fac)==0.0) {
             spice_incompat.append(parnam);
         }
     }

--- a/qucs/components/mosfet_sub.cpp
+++ b/qucs/components/mosfet_sub.cpp
@@ -136,7 +136,7 @@ MOSFET_sub::MOSFET_sub()
 {
   Description = QObject::tr("MOS field-effect transistor with substrate");
   Simulator = spicecompat::simAll;
-  createSymbol();
+  MOSFET_sub::createSymbol();
   tx = x2+4;
   ty = y1+4;
   Model = "MOSFET";

--- a/qucs/components/mosfet_sub.cpp
+++ b/qucs/components/mosfet_sub.cpp
@@ -200,15 +200,15 @@ QString MOSFET_sub::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
 
     if (getProperty("UseGlobTemp")->Value == "yes") {
       s += QStringLiteral(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7\n")
-      .arg(Name).arg(l).arg(w).arg(ad).arg(as).arg(pd).arg(ps);
+      .arg(Name, l, w, ad, as, pd, ps);
     } else {
       s += QStringLiteral(" MMOD_%1 L=%2 W=%3 Ad=%4 As=%5 Pd=%6 Ps=%7 Temp=%8\n")
-      .arg(Name).arg(l).arg(w).arg(ad).arg(as).arg(pd).arg(ps).arg(getProperty("Temp")->Value);
+      .arg(Name, l, w, ad, as, pd, ps, getProperty("Temp")->Value);
     }
 
     if (dialect != spicecompat::CDL)
     {
-        s += QStringLiteral(".MODEL MMOD_%1 %2MOS (%3)\n").arg(Name).arg(mosfet_type).arg(par_str);
+        s += QStringLiteral(".MODEL MMOD_%1 %2MOS (%3)\n").arg(Name, mosfet_type, par_str);
     }
 
     return s;

--- a/qucs/components/mosfet_sub.cpp
+++ b/qucs/components/mosfet_sub.cpp
@@ -160,7 +160,7 @@ QString MOSFET_sub::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
     QList<int> pin_seq;
     pin_seq<<1<<0<<2<<3; // Pin sequence: DGS
     // output all node names
-    for (int pin : pin_seq) {
+    for (int pin : std::as_const(pin_seq)) {
         QString nam = Ports.at(pin)->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names
@@ -179,7 +179,7 @@ QString MOSFET_sub::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
     QStringList check_defaults_list;
     QString unit;
     check_defaults_list<<"Nsub"<<"Nss";
-    for (const QString& parnam : check_defaults_list) { // Check some parameters for default value (zero)
+    for (const QString& parnam : std::as_const(check_defaults_list)) { // Check some parameters for default value (zero)
         double val,fac;   // And reduce parameter list
         misc::str2num(getProperty(parnam)->Value,val,unit,fac);
         if ((val *= fac)==0.0) {

--- a/qucs/components/mscoupled.cpp
+++ b/qucs/components/mscoupled.cpp
@@ -114,9 +114,9 @@ QString MScoupled::spice_netlist(spicecompat::SpiceDialect dialect)
 
   s = QString("A_%1 %hd(%2 0) %hd(%3 0) %hd(%4 0) %hd(%5 0)"
               " %vd(%2 0) %vd(%3 0) %vd(%4 0) %vd(%5 0) MODEL_%1\n")
-          .arg(Name).arg(p1).arg(p2).arg(p3).arg(p4);
+          .arg(Name, p1, p2, p3, p4);
   s += QString(".MODEL MODEL_%1 CPMLIN(L=%2 W=%3 S=%4 model=%5 disp=%6 tranmodel=%7 %8)\n")
-           .arg(Name).arg(L).arg(W).arg(S).arg(Mod).arg(Disp).arg(Tran).arg(subline);
+           .arg(Name, L, W, S).arg(Mod).arg(Disp).arg(Tran).arg(subline);
 
   return s;
 }

--- a/qucs/components/mscross.cpp
+++ b/qucs/components/mscross.cpp
@@ -47,7 +47,7 @@ MScross::MScross()
 	QObject::tr("show port numbers in symbol or not")+
 	" [showNumbers, noNumbers]"));
 
-  createSymbol();
+  MScross::createSymbol();
 }
 
 MScross::~MScross()

--- a/qucs/components/msline.cpp
+++ b/qucs/components/msline.cpp
@@ -98,9 +98,9 @@ QString MSline::spice_netlist(spicecompat::SpiceDialect dialect)
   int Tran = spicecompat::strToTranModel(getProperty("TranModel")->Value);
 
   s = QString("A_%1 %hd(%2 0) %hd(%3 0) %vd(%2 0) %vd(%3 0) MODEL_%1\n")
-          .arg(Name).arg(p1).arg(p2);
+          .arg(Name, p1, p2);
   s += QString(".MODEL MODEL_%1 MLIN(l=%2 w=%3 model=%4 disp=%5 tranmodel=%6 %7)\n")
-          .arg(Name).arg(L).arg(W).arg(Mod).arg(Disp).arg(Tran).arg(subline);
+          .arg(Name, L, W).arg(Mod).arg(Disp).arg(Tran).arg(subline);
 
   return s;
 }

--- a/qucs/components/msopen.cpp
+++ b/qucs/components/msopen.cpp
@@ -91,9 +91,9 @@ QString MSopen::spice_netlist(spicecompat::SpiceDialect dialect)
   int Mopen = spicecompat::strToMsopenModel(getProperty("Model")->Value);
 
   s = QString("A_%1 %gd(%2 0) MODEL_%1\n")
-          .arg(Name).arg(p1);
+          .arg(Name, p1);
   s += QString(".MODEL MODEL_%1 MSOPEN(w=%2 model=%3 disp=%4 msopen_model=%5 %6)\n")
-           .arg(Name).arg(W).arg(Mod).arg(Disp).arg(Mopen).arg(subline);
+           .arg(Name, W).arg(Mod).arg(Disp).arg(Mopen).arg(subline);
 
   return s;
 }

--- a/qucs/components/mstee.cpp
+++ b/qucs/components/mstee.cpp
@@ -55,7 +55,7 @@ MStee::MStee()
 	QObject::tr("show port numbers in symbol or not")+
 	" [showNumbers, noNumbers]"));
 
-  createSymbol();
+  MStee::createSymbol();
 }
 
 MStee::~MStee()

--- a/qucs/components/msvia.cpp
+++ b/qucs/components/msvia.cpp
@@ -80,7 +80,7 @@ QString MSvia::netlist()
   s += " " + Ports.first()->Connection->Name + " gnd";
 
   // output all properties
-  for(Property *p2 : Props)
+  for(Property *p2 : std::as_const(Props))
     s += " "+p2->Name+"=\""+p2->Value+"\"";
 
   return s + '\n';

--- a/qucs/components/mutual.cpp
+++ b/qucs/components/mutual.cpp
@@ -93,15 +93,15 @@ QString Mutual::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
     QString k1 = "K" + Name;
     QString ind1 = spicecompat::normalize_value(getProperty("L1")->Value);
     QString ind2 = spicecompat::normalize_value(getProperty("L2")->Value);
-    QString s = QStringLiteral("%1 %2 %3 %4\n").arg(l1)
-            .arg(spicecompat::normalize_node_name(Ports.at(0)->Connection->Name))
-            .arg(spicecompat::normalize_node_name(Ports.at(3)->Connection->Name))
-            .arg(ind1);
-    s += QStringLiteral("%1 %2 %3 %4\n").arg(l2)
-            .arg(spicecompat::normalize_node_name(Ports.at(1)->Connection->Name))
-            .arg(spicecompat::normalize_node_name(Ports.at(2)->Connection->Name))
-            .arg(ind2);
-    s += QStringLiteral("%1 %2 %3 %4\n").arg(k1).arg(l1).arg(l2)
-            .arg(spicecompat::normalize_value(getProperty("k")->Value));
+    QString s = QStringLiteral("%1 %2 %3 %4\n").arg(l1,
+            spicecompat::normalize_node_name(Ports.at(0)->Connection->Name),
+            spicecompat::normalize_node_name(Ports.at(3)->Connection->Name),
+            ind1);
+    s += QStringLiteral("%1 %2 %3 %4\n").arg(l2,
+            spicecompat::normalize_node_name(Ports.at(1)->Connection->Name),
+            spicecompat::normalize_node_name(Ports.at(2)->Connection->Name),
+            ind2);
+    s += QStringLiteral("%1 %2 %3 %4\n").arg(k1, l1, l2,
+            spicecompat::normalize_value(getProperty("k")->Value));
     return s;
 }

--- a/qucs/components/mutual2.cpp
+++ b/qucs/components/mutual2.cpp
@@ -127,23 +127,23 @@ QString Mutual2::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
     QString ind1 = spicecompat::normalize_value(getProperty("L1")->Value);
     QString ind2 = spicecompat::normalize_value(getProperty("L2")->Value);
     QString ind3 = spicecompat::normalize_value(getProperty("L3")->Value);
-    QString s = QStringLiteral("%1 %2 %3 %4\n").arg(l1)
-            .arg(spicecompat::normalize_node_name(Ports.at(0)->Connection->Name))
-            .arg(spicecompat::normalize_node_name(Ports.at(5)->Connection->Name))
-            .arg(ind1);
-    s += QStringLiteral("%1 %2 %3 %4\n").arg(l2)
-            .arg(spicecompat::normalize_node_name(Ports.at(4)->Connection->Name))
-            .arg(spicecompat::normalize_node_name(Ports.at(3)->Connection->Name))
-            .arg(ind2);
-    s += QStringLiteral("%1 %2 %3 %4\n").arg(l3)
-            .arg(spicecompat::normalize_node_name(Ports.at(1)->Connection->Name))
-            .arg(spicecompat::normalize_node_name(Ports.at(2)->Connection->Name))
-            .arg(ind3);
-    s += QStringLiteral("%1 %2 %3 %4\n").arg(k12).arg(l1).arg(l2)
-            .arg(spicecompat::normalize_value(getProperty("k12")->Value));
-    s += QStringLiteral("%1 %2 %3 %4\n").arg(k13).arg(l1).arg(l3)
-            .arg(spicecompat::normalize_value(getProperty("k12")->Value));
-    s += QStringLiteral("%1 %2 %3 %4\n").arg(k23).arg(l2).arg(l3)
-            .arg(spicecompat::normalize_value(getProperty("k23")->Value));
+    QString s = QStringLiteral("%1 %2 %3 %4\n").arg(l1,
+            spicecompat::normalize_node_name(Ports.at(0)->Connection->Name),
+            spicecompat::normalize_node_name(Ports.at(5)->Connection->Name),
+            ind1);
+    s += QStringLiteral("%1 %2 %3 %4\n").arg(l2,
+            spicecompat::normalize_node_name(Ports.at(4)->Connection->Name),
+            spicecompat::normalize_node_name(Ports.at(3)->Connection->Name),
+            ind2);
+    s += QStringLiteral("%1 %2 %3 %4\n").arg(l3,
+            spicecompat::normalize_node_name(Ports.at(1)->Connection->Name),
+            spicecompat::normalize_node_name(Ports.at(2)->Connection->Name),
+            ind3);
+    s += QStringLiteral("%1 %2 %3 %4\n").arg(k12, l1, l2,
+            spicecompat::normalize_value(getProperty("k12")->Value));
+    s += QStringLiteral("%1 %2 %3 %4\n").arg(k13, l1, l3,
+            spicecompat::normalize_value(getProperty("k12")->Value));
+    s += QStringLiteral("%1 %2 %3 %4\n").arg(k23, l2, l3,
+            spicecompat::normalize_value(getProperty("k23")->Value));
     return s;
 }

--- a/qucs/components/mutualx.cpp
+++ b/qucs/components/mutualx.cpp
@@ -80,7 +80,7 @@ QString MutualX::netlist()
     QString s = Model + ":" + Name;
 
     // output all node names
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
       s += " "+p1->Connection->Name;   // node names
     }
 

--- a/qucs/components/mutualx.cpp
+++ b/qucs/components/mutualx.cpp
@@ -49,7 +49,7 @@ MutualX::MutualX()
        Props.append(new Property(nam,"0.9",false,desc));
     }
 
-  createSymbol();
+  MutualX::createSymbol();
 }
 
 // --------------------------------------------------------

--- a/qucs/components/mutualx.cpp
+++ b/qucs/components/mutualx.cpp
@@ -240,10 +240,10 @@ QString MutualX::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
         QString li = "L" + Name + "_L" + QString::number(i+1);
         QString prop_l = "L" + QString::number(i+1);
         QString ind = spicecompat::normalize_value(getProperty(prop_l)->Value);
-        s += QStringLiteral("%1 %2 %3 %4\n").arg(li)
-                .arg(spicecompat::normalize_node_name(Ports.at(2*i)->Connection->Name))
-                .arg(spicecompat::normalize_node_name(Ports.at(2*i+1)->Connection->Name))
-                .arg(ind);
+        s += QStringLiteral("%1 %2 %3 %4\n").arg(li,
+                spicecompat::normalize_node_name(Ports.at(2*i)->Connection->Name),
+                spicecompat::normalize_node_name(Ports.at(2*i+1)->Connection->Name),
+                ind);
     }
     for (int i = 0; i < coils; i++) {
         for (int j = i; j < coils; j++) {
@@ -255,7 +255,7 @@ QString MutualX::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
             auto pp = getProperty("k" + QString::number(i+1) + QString::number(j+1));
             if (pp == nullptr) continue;
             QString val_k = spicecompat::normalize_value(pp->Value);
-            s += QStringLiteral("%1 %2 %3 %4\n").arg(kij).arg(li).arg(lj).arg(val_k);
+            s += QStringLiteral("%1 %2 %3 %4\n").arg(kij, li, lj, val_k);
         }
     }
 

--- a/qucs/components/opamp.cpp
+++ b/qucs/components/opamp.cpp
@@ -87,16 +87,16 @@ QString OpAmp::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     QString Vmax = spicecompat::normalize_value(Props.at(1)->Value);
 
     QString s;
-    s = QStringLiteral("B_%1 %2 0 V = ").arg(Name).arg(out);
+    s = QStringLiteral("B_%1 %2 0 V = ").arg(Name, out);
 
     if (dialect == spicecompat::SPICEXyce) {
         s += QStringLiteral("%1*V(%2,%3)*stp(%4-%1*V(%2,%3))*stp(%1*V(%2,%3)-(-%4))"
                     "+%4*stp(%1*V(%2,%3)-%4)"
-                    "+(-%4)*stp((-%4)-%1*V(%2,%3))\n").arg(G).arg(in_p).arg(in_m).arg(Vmax);
+                    "+(-%4)*stp((-%4)-%1*V(%2,%3))\n").arg(G, in_p, in_m, Vmax);
     } else {
         s += QStringLiteral("%1*V(%2,%3)*u(%4-%1*V(%2,%3))*u(%1*V(%2,%3)-(-%4))"
                     "+%4*u(%1*V(%2,%3)-%4)"
-                    "+(-%4)*u((-%4)-%1*V(%2,%3))\n").arg(G).arg(in_p).arg(in_m).arg(Vmax);
+                    "+(-%4)*u((-%4)-%1*V(%2,%3))\n").arg(G, in_p, in_m, Vmax);
     }
     return s;
 }

--- a/qucs/components/param_sweep.cpp
+++ b/qucs/components/param_sweep.cpp
@@ -194,7 +194,7 @@ QString Param_Sweep::getCounterVar()
 
 QString Param_Sweep::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::SPICEDefault */)
 {
-    double start,stop,step,fac,points;
+    double start=0,stop=0,step=0,fac,points;
     QString unit;
     QString s;
 

--- a/qucs/components/potentiometer.cpp
+++ b/qucs/components/potentiometer.cpp
@@ -122,7 +122,7 @@ QString potentiometer::spice_netlist(spicecompat::SpiceDialect dialect /* = spic
     QString pin1 = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
     QString pin2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
     QString pin3 = spicecompat::normalize_node_name(Ports.at(2)->Connection->Name);
-    s += QStringLiteral("R%1_1 %2 %3 R='(%4)*(%5)/(%6)'\n").arg(Name).arg(pin1).arg(pin2).arg(R).arg(rot).arg(max_rot);
-    s += QStringLiteral("R%1_2 %2 %3 R='(%4)*(1.0-(%5)/(%6))'\n").arg(Name).arg(pin2).arg(pin3).arg(R).arg(rot).arg(max_rot);
+    s += QStringLiteral("R%1_1 %2 %3 R='(%4)*(%5)/(%6)'\n").arg(Name, pin1, pin2, R, rot, max_rot);
+    s += QStringLiteral("R%1_2 %2 %3 R='(%4)*(1.0-(%5)/(%6))'\n").arg(Name, pin2, pin3, R, rot, max_rot);
     return s;
 }

--- a/qucs/components/relais.cpp
+++ b/qucs/components/relais.cpp
@@ -128,7 +128,7 @@ QString Relais::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
       QList<int> seq; // nodes sequence
       seq<<1<<2<<0<<3;
       // output all node names
-      for (int i : seq) {
+      for (int i : std::as_const(seq)) {
         QString nam = spicecompat::normalize_node_name(Ports.at(i)->Connection->Name);
         s += " "+ nam;   // node names
       }
@@ -145,7 +145,7 @@ QString Relais::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
       QList<int> seq; // nodes sequence
       seq<<2<<1<<4<<0<<3;
       // output all node names
-      for (int i : seq) {
+      for (int i : std::as_const(seq)) {
         QString nam = spicecompat::normalize_node_name(Ports.at(i)->Connection->Name);
         s += " "+ nam;   // node names
       }

--- a/qucs/components/relais.cpp
+++ b/qucs/components/relais.cpp
@@ -42,7 +42,7 @@ Relais::Relais()
 		QObject::tr("simulation temperature in degree Celsius")));
   Props.append(new Property("Type", "SPST", true,
                             QObject::tr("Switch type)") + "[SPST,SPDT]"));
-  createSymbol();
+  Relais::createSymbol();
 }
 
 void Relais::createSymbol()

--- a/qucs/components/relais.cpp
+++ b/qucs/components/relais.cpp
@@ -135,9 +135,9 @@ QString Relais::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
       s += " " + model + " OFF\n";
 
       if (dialect == spicecompat::SPICEXyce) {
-        s += QStringLiteral(".MODEL %1 vswitch von=%2 voff=%3 ron=%4 roff=%5 \n").arg(model).arg(Vt).arg(Vt-Vh).arg(Ron).arg(Roff);
+        s += QStringLiteral(".MODEL %1 vswitch von=%2 voff=%3 ron=%4 roff=%5 \n").arg(model).arg(Vt).arg(Vt-Vh).arg(Ron, Roff);
       } else {
-        s += QStringLiteral(".MODEL %1 sw vt=%2 vh=%3 ron=%4 roff=%5 \n").arg(model).arg(Vt).arg(Vh).arg(Ron).arg(Roff);
+        s += QStringLiteral(".MODEL %1 sw vt=%2 vh=%3 ron=%4 roff=%5 \n").arg(model).arg(Vt).arg(Vh).arg(Ron, Roff);
       }
     } else {
       s = "X";
@@ -149,7 +149,7 @@ QString Relais::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
         QString nam = spicecompat::normalize_node_name(Ports.at(i)->Connection->Name);
         s += " "+ nam;   // node names
       }
-      s += QStringLiteral(" spdt vt=%2 vh=%3 ron=%4 roff=%5\n").arg(Vt).arg(Vh).arg(Ron).arg(Roff);
+      s += QStringLiteral(" spdt vt=%2 vh=%3 ron=%4 roff=%5\n").arg(Vt).arg(Vh).arg(Ron, Roff);
     }
 
     return s;

--- a/qucs/components/resistor.cpp
+++ b/qucs/components/resistor.cpp
@@ -50,7 +50,7 @@ Resistor::Resistor(bool european)
         QObject::tr("schematic symbol")+" [european, US]"));
   if(!european)  Props.back()->Value = "US";
 
-  createSymbol();
+  Resistor::createSymbol();
   tx = x1+4;
   ty = y2+4;
   Model = "R";

--- a/qucs/components/resistor.cpp
+++ b/qucs/components/resistor.cpp
@@ -68,8 +68,8 @@ QString Resistor::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecomp
 {
     QString s = spicecompat::check_refdes(Name,SpiceModel);
 
-    s += QStringLiteral(" %1 %2 ").arg(Ports.at(0)->Connection->Name)
-            .arg(Ports.at(1)->Connection->Name); // output 2 nodes
+    s += QStringLiteral(" %1 %2 ").arg(Ports.at(0)->Connection->Name,
+                                       Ports.at(1)->Connection->Name); // output 2 nodes
     s.replace(" gnd ", " 0 ");
 
     QString Tc1 = getProperty("Tc1")->Value;
@@ -108,10 +108,10 @@ QString Resistor::va_code()
     QString Vpm = vacompat::normalize_voltage(plus,minus);
     QString Ipm = vacompat::normalize_current(plus,minus,true);
 
-    if (plus=="gnd") s += QStringLiteral("%1 <+ -(%2/( %3 ));\n").arg(Ipm).arg(Vpm).arg(val);
-    else s+= QStringLiteral("%1 <+ %2/( %3 );\n").arg(Ipm).arg(Vpm).arg(val);
+    if (plus=="gnd") s += QStringLiteral("%1 <+ -(%2/( %3 ));\n").arg(Ipm, Vpm, val);
+    else s+= QStringLiteral("%1 <+ %2/( %3 );\n").arg(Ipm, Vpm, val);
     s += QStringLiteral("%1 <+ white_noise( 4.0*`P_K*( %2 + 273.15) / ( %3 ), \"thermal\" );\n")
-                 .arg(Ipm).arg(valTemp).arg(val);
+                 .arg(Ipm, valTemp, val);
 
     return s;
 }

--- a/qucs/components/rfedd.cpp
+++ b/qucs/components/rfedd.cpp
@@ -85,7 +85,7 @@ QString RFedd::netlist()
   QString n, p;
 
   // output all node names
-  for (Port *p1 : Ports)
+  for (Port *p1 : std::as_const(Ports))
     s += " "+p1->Connection->Name;   // node names
 
   // output all properties

--- a/qucs/components/rfedd.cpp
+++ b/qucs/components/rfedd.cpp
@@ -48,7 +48,7 @@ RFedd::RFedd()
   Props.append(new Property("P22", "0", false,
 		QObject::tr("parameter equation") + " 22"));
 
-  createSymbol();
+  RFedd::createSymbol();
 }
 
 // -------------------------------------------------------

--- a/qucs/components/rfedd2p.cpp
+++ b/qucs/components/rfedd2p.cpp
@@ -83,7 +83,7 @@ QString RFedd2P::netlist()
   QString n, p;
 
   // output all node names
-  for (Port *p1 : Ports)
+  for (Port *p1 : std::as_const(Ports))
     s += " "+p1->Connection->Name;   // node names
 
   // output all properties

--- a/qucs/components/rfedd2p.cpp
+++ b/qucs/components/rfedd2p.cpp
@@ -140,7 +140,7 @@ void RFedd2P::createSymbol()
   Ports.append(new Port( 30,  y));
   tmp = QString::number(i+1);
   Texts.append(new Text(25, y-fHeight-2, tmp)); // text left-aligned
-  y += 60;
+
   i++;
 
   x1 = -30; y1 = -h-2;

--- a/qucs/components/rfedd2p.cpp
+++ b/qucs/components/rfedd2p.cpp
@@ -48,7 +48,7 @@ RFedd2P::RFedd2P()
   Props.append(new Property("P22", "0", false,
 		QObject::tr("parameter equation") + " 22"));
 
-  createSymbol();
+  RFedd2P::createSymbol();
 }
 
 // -------------------------------------------------------

--- a/qucs/components/rlcg.cpp
+++ b/qucs/components/rlcg.cpp
@@ -106,10 +106,10 @@ QString RLCG::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::
     QString G = spicecompat::normalize_value(getProperty("G")->Value);
     QString LEN = spicecompat::normalize_value(getProperty("Length")->Value);
     QString modname = "mod_" + Name;
-    s += QStringLiteral("O%1 %2 0 %3 0 %4\n").arg(Name).arg(in).arg(out).arg(modname);
+    s += QStringLiteral("O%1 %2 0 %3 0 %4\n").arg(Name, in, out, modname);
 
     s += QStringLiteral(".MODEL %1 LTRA(R=%2 C=%3 L=%4 G=%5 LEN=%6)\n")
-        .arg(modname).arg(R).arg(C).arg(L).arg(G).arg(LEN);
+        .arg(modname, R, C, L, G, LEN);
     return s;
 }
 

--- a/qucs/components/sp_sim.cpp
+++ b/qucs/components/sp_sim.cpp
@@ -176,7 +176,7 @@ QString SP_Sim::getSweepString()
     }
     QString fstart = spicecompat::normalize_value(Props.at(1)->Value); // Start freq.
     QString fstop = spicecompat::normalize_value(Props.at(2)->Value); // Stop freq.
-    s += QStringLiteral("%1 %2").arg(fstart).arg(fstop);
+    s += QStringLiteral("%1 %2").arg(fstart, fstop);
     return s;
 }
 

--- a/qucs/components/spicedialog.cpp
+++ b/qucs/components/spicedialog.cpp
@@ -525,7 +525,7 @@ bool SpiceDialog::loadSpiceNetList(const QString& s)
   {
     PortsList->clear();
     QStringList ports = pp->Value.split(',');
-    for (const QString& port : ports) {
+    for (const QString& port : std::as_const(ports)) {
       PortsList->addItem(port);
     }
   }

--- a/qucs/components/spicefile.cpp
+++ b/qucs/components/spicefile.cpp
@@ -158,7 +158,7 @@ QString SpiceFile::netlist()
     return QString();  // no ports, no subcircuit instance
 
   QString s = "Sub:"+Name;   // SPICE netlist is subcircuit
-  for (Port *pp : Ports)
+  for (Port *pp : std::as_const(Ports))
     s += " "+pp->Connection->Name;   // output all node names
 
   QString f = misc::properFileName(Props.first()->Value);

--- a/qucs/components/subcircuit.cpp
+++ b/qucs/components/subcircuit.cpp
@@ -207,7 +207,7 @@ QString Subcircuit::netlist() {
   QString s = Model + ":" + Name;
 
   // output all node names
-  for (Port *p1 : Ports)
+  for (Port *p1 : std::as_const(Ports))
     s += " " + p1->Connection->Name; // node names
 
   // type for subcircuit
@@ -227,7 +227,7 @@ QString Subcircuit::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
   QString s;
   QString f = misc::properFileName(Props.at(0)->Value);
   s += spicecompat::check_refdes(Name, SpiceModel);
-  for (Port *p1 : Ports) {
+  for (Port *p1 : std::as_const(Ports)) {
     QString nam = p1->Connection->Name;
     if (nam == "gnd")
       nam = "0";

--- a/qucs/components/subcircuit.cpp
+++ b/qucs/components/subcircuit.cpp
@@ -83,7 +83,6 @@ void Subcircuit::createSymbol() {
     while (ip.hasNext()) {
       pp = ip.next();
       if (!pp->avail) {
-        pp = ip.peekNext();
         ip.remove();
       }
     }

--- a/qucs/components/subcirport.cpp
+++ b/qucs/components/subcirport.cpp
@@ -31,7 +31,7 @@ SubCirPort::SubCirPort()
 		QObject::tr("type of the port (for digital simulation only)")
 		+" [analog, in, out, inout]"));
 
-  createSymbol();
+  SubCirPort::createSymbol();
   tx = x1+4;
   ty = y2+4;
   icon_dx = 4;

--- a/qucs/components/switch.cpp
+++ b/qucs/components/switch.cpp
@@ -50,7 +50,7 @@ Switch::Switch()
   Props.append(new Property("Type", "SPST", true,
                             QObject::tr("Switch type)") + "[SPST,SPDT]"));
 
-  createSymbol();
+  Switch::createSymbol();
   tx = x1+4;
   ty = y2+4;
   Model = "Switch";

--- a/qucs/components/switch.cpp
+++ b/qucs/components/switch.cpp
@@ -129,10 +129,10 @@ QString Switch::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
   if (getProperty("Type")->Value == "SPDT") {
     QString port3 = spicecompat::normalize_node_name(Ports.at(2)->Connection->Name);
     s = "X" + s;
-    s += QStringLiteral(" %1 %2 %3 control_net%4 0 spdt ").arg(port1).arg(port2).arg(port3).arg(Name);
-    s += QStringLiteral(" vt=0.5 vh=0.05 ron =%1 roff =%2\n").arg(Ron).arg(Roff);
+    s += QStringLiteral(" %1 %2 %3 control_net%4 0 spdt ").arg(port1, port2, port3, Name);
+    s += QStringLiteral(" vt=0.5 vh=0.05 ron =%1 roff =%2\n").arg(Ron, Roff);
   } else {
-    s += QStringLiteral(" %1 %2 control_net%3 0 switch_model%3\n").arg(port1).arg(port2).arg(Name);
+    s += QStringLiteral(" %1 %2 control_net%3 0 switch_model%3\n").arg(port1, port2, Name);
 
   }
 
@@ -160,7 +160,7 @@ QString Switch::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
     evenValue = "0";
   }
 
-  s += QStringLiteral("V%1 control_net%1 0 DC %2 PWL(0 %2").arg(Name).arg(oddValue);
+  s += QStringLiteral("V%1 control_net%1 0 DC %2 PWL(0 %2").arg(Name, oddValue);
 
   for (int i = 0; i < timesList.size(); i++) {
     QString timeStep = timesList[i].toLower();
@@ -192,7 +192,7 @@ QString Switch::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
   s += ")\n";
 
   if (getProperty("Type")->Value == "SPST") {
-    s += QStringLiteral(".model switch_model%1 sw vt =0.5 ron =%2 roff =%3\n").arg(Name).arg(Ron).arg(Roff);
+    s += QStringLiteral(".model switch_model%1 sw vt =0.5 ron =%2 roff =%3\n").arg(Name, Ron, Roff);
   }
   return s;
 }

--- a/qucs/components/tff_SR.cpp
+++ b/qucs/components/tff_SR.cpp
@@ -194,6 +194,6 @@ QString tff_SR::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
 
     s += " " + tmp_model + "\n";
     s += QStringLiteral(".model %1 d_tff(clk_delay=%2 set_delay=%2 reset_delay=%2 rise_delay=%2 fall_delay=%2)\n")
-            .arg(tmp_model).arg(td);
+            .arg(tmp_model, td);
     return s;
 }

--- a/qucs/components/tline.cpp
+++ b/qucs/components/tline.cpp
@@ -90,9 +90,7 @@ QString TLine::spice_netlist(spicecompat::SpiceDialect dialect)
   QString l = spicecompat::normalize_value(getProperty("L")->Value);
 
   QString s = QString("T%1 %2 0 %3 0 Z0=%4 TD={%5/%6}\n")
-                  .arg(Name)
-                  .arg(p1).arg(p2)
-                  .arg(zw).arg(l).arg(c0);
+                  .arg(Name, p1, p2, zw, l, c0);
 
   return s;
 

--- a/qucs/components/tline_4port.cpp
+++ b/qucs/components/tline_4port.cpp
@@ -96,9 +96,7 @@ QString TLine_4Port::spice_netlist(spicecompat::SpiceDialect dialect)
   QString l = spicecompat::normalize_value(getProperty("L")->Value);
 
   QString s = QString("T%1 %2 %3 %4 %5 Z0=%6 TD={%7/%8}\n")
-                  .arg(Name)
-                  .arg(p1).arg(p3).arg(p2).arg(p4)
-                  .arg(zw).arg(l).arg(c0);
+                  .arg(Name, p1, p3, p2, p4, zw, l, c0);
 
   return s;
 

--- a/qucs/components/vacomponent.cpp
+++ b/qucs/components/vacomponent.cpp
@@ -301,7 +301,7 @@ QString vacomponent::spice_netlist(spicecompat::SpiceDialect dialect /* = spicec
     if (dialect == spicecompat::SPICEXyce) return QString();
 
     QString s = SpiceModel + Name + " ";
-    for(const auto pp: Ports) {
+    for(const auto pp: std::as_const(Ports)) {
         s += pp->Connection->Name + " ";
     }
     QString tmp_model = QStringLiteral("mod_%1_%2").arg(Model, Name);

--- a/qucs/components/vacomponent.cpp
+++ b/qucs/components/vacomponent.cpp
@@ -304,17 +304,14 @@ QString vacomponent::spice_netlist(spicecompat::SpiceDialect dialect /* = spicec
     for(const auto pp: Ports) {
         s += pp->Connection->Name + " ";
     }
-    QString tmp_model = QStringLiteral("mod_%1_%2").arg(Model).arg(Name);
+    QString tmp_model = QStringLiteral("mod_%1_%2").arg(Model, Name);
     s += tmp_model + "\n";
     QString par_str;
     for(int i = 0; i < Props.count(); i++) {
         par_str += QStringLiteral("%1=%2 ")
-                .arg(Props.at(i)->Name)
-                .arg(Props.at(i)->Value);
+                .arg(Props.at(i)->Name, Props.at(i)->Value);
     }
-    s += QStringLiteral(".MODEL %1 %2 %3\n").arg(tmp_model)
-                                      .arg(Model)
-                                      .arg(par_str);
+    s += QStringLiteral(".MODEL %1 %2 %3\n").arg(tmp_model, Model, par_str);
     return s;
 }
 

--- a/qucs/components/vccs.cpp
+++ b/qucs/components/vccs.cpp
@@ -99,11 +99,11 @@ QString VCCS::va_code()
 
     QString Vpm = vacompat::normalize_voltage(P1,P2);
     QString Ipm = vacompat::normalize_current(P1,P2,true);
-    s += QStringLiteral(" %1  <+  %2 * 1e-9;\n").arg(Ipm).arg(Vpm);
+    s += QStringLiteral(" %1  <+  %2 * 1e-9;\n").arg(Ipm, Vpm);
     QString Vpm2 = vacompat::normalize_voltage(P4,P3);
     QString Ipm2 = vacompat::normalize_current(P4,P3,true);
-    s += QStringLiteral("%1  <+   %2 * 1e-9;\n").arg(Ipm2).arg(Vpm2);
-    s += QStringLiteral("%1  <+   %2 * %3 ;\n").arg(Ipm2).arg(Vpm).arg(Gain);
+    s += QStringLiteral("%1  <+   %2 * 1e-9;\n").arg(Ipm2, Vpm2);
+    s += QStringLiteral("%1  <+   %2 * %3 ;\n").arg(Ipm2, Vpm, Gain);
 
     return s;
 }

--- a/qucs/components/vccs.cpp
+++ b/qucs/components/vccs.cpp
@@ -116,7 +116,7 @@ QString VCCS::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::
     QList<int> seq; // nodes sequence
     seq<<1<<2<<0<<3;
     // output all node names
-    for (int i : seq) {
+    for (int i : std::as_const(seq)) {
         QString nam = Ports.at(i)->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names

--- a/qucs/components/vcvs.cpp
+++ b/qucs/components/vcvs.cpp
@@ -123,7 +123,7 @@ QString VCVS::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::
     QList<int> seq; // nodes sequence
     seq<<1<<2<<0<<3;
     // output all node names
-    for (int i : seq) {
+    for (int i : std::as_const(seq)) {
         QString nam = Ports.at(i)->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names

--- a/qucs/components/vcvs.cpp
+++ b/qucs/components/vcvs.cpp
@@ -106,11 +106,11 @@ QString VCVS::va_code()
 
     QString Vpm = vacompat::normalize_voltage(P1,P2);
     QString Ipm = vacompat::normalize_current(P1,P2,true);
-    s += QStringLiteral(" %1  <+  %2 * 1e-9;\n").arg(Ipm).arg(Vpm);
+    s += QStringLiteral(" %1  <+  %2 * 1e-9;\n").arg(Ipm, Vpm);
     QString Vpm2 = vacompat::normalize_voltage(P3,P4);
     QString Ipm2 = vacompat::normalize_current(P3,P4,true);
-    s += QStringLiteral("%1  <+  -(%2 * 1e3);\n").arg(Ipm2).arg(Vpm2);
-    s += QStringLiteral("%1  <+  -(%2 * 1e3*  %3) ;\n").arg(Ipm2).arg(Vpm).arg(Gain);
+    s += QStringLiteral("%1  <+  -(%2 * 1e3);\n").arg(Ipm2, Vpm2);
+    s += QStringLiteral("%1  <+  -(%2 * 1e3*  %3) ;\n").arg(Ipm2, Vpm, Gain);
 
     return s;
 }

--- a/qucs/components/vdmos.cpp
+++ b/qucs/components/vdmos.cpp
@@ -189,13 +189,13 @@ QString VDMOS::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     if (getProperty("UseGlobTemp")->Value == "yes") {
       s += QString(" VDMOS_%1 ").arg(Name);
     } else {
-      s += QString(" VDMOS_%1 TEMP=%2").arg(Name).arg(getProperty("Temp")->Value);
+      s += QString(" VDMOS_%1 TEMP=%2").arg(Name, getProperty("Temp")->Value);
     }
 
     if (hasThermal) s += " THERMAL";
     s += "\n";
 
-        s += QString(".MODEL VDMOS_%1 VDMOS(%2 %3)\n").arg(Name).arg(type).arg(par_str);
+        s += QString(".MODEL VDMOS_%1 VDMOS(%2 %3)\n").arg(Name, type, par_str);
 
     return s;
 }

--- a/qucs/components/vdmos.cpp
+++ b/qucs/components/vdmos.cpp
@@ -139,7 +139,7 @@ VDMOS::VDMOS() {
                               QObject::tr("Thermal model") + " [on,off]"));
 
 
-    createSymbol();
+    VDMOS::createSymbol();
     tx = x2 + 4;
     ty = y1 + 4;
     Model = "VDMOS";

--- a/qucs/components/vdmos.cpp
+++ b/qucs/components/vdmos.cpp
@@ -172,7 +172,7 @@ QString VDMOS::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
       pin_seq<<1<<0<<2; // Pin sequence: DGS
     }
     // output all node names
-    for (int pin : pin_seq) {
+    for (int pin : std::as_const(pin_seq)) {
         QString nam = Ports.at(pin)->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names

--- a/qucs/components/verilogfile.cpp
+++ b/qucs/components/verilogfile.cpp
@@ -175,7 +175,7 @@ bool Verilog_File::createSubNetlist(QTextStream *stream)
   QString FileName = Props.front()->Value;
   if(FileName.isEmpty()) {
     ErrText += QObject::tr("ERROR: No file name in %1 component \"%2\".").
-      arg(Model).arg(Name);
+      arg(Model, Name);
     return false;
   }
 
@@ -186,7 +186,7 @@ bool Verilog_File::createSubNetlist(QTextStream *stream)
   QFile f(FileName);
   if(!f.open(QIODevice::ReadOnly)) {
     ErrText += QObject::tr("ERROR: Cannot open %1 file \"%2\".").
-      arg(Model).arg(FileName);
+      arg(Model, FileName);
     return false;
   }
 

--- a/qucs/components/vexp.cpp
+++ b/qucs/components/vexp.cpp
@@ -91,7 +91,7 @@ QString vExp::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names

--- a/qucs/components/vexp.cpp
+++ b/qucs/components/vexp.cpp
@@ -104,6 +104,6 @@ QString vExp::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::
     QString Tr = spicecompat::normalize_value(Props.at(4)->Value);
     QString Tf = spicecompat::normalize_value(Props.at(5)->Value);
 
-    s += QStringLiteral(" DC 0 EXP(%1 %2 %3 %4 %5 %6) AC 0\n").arg(U1).arg(U2).arg(T1).arg(Tr).arg(T2).arg(Tf);
+    s += QStringLiteral(" DC 0 EXP(%1 %2 %3 %4 %5 %6) AC 0\n").arg(U1, U2, T1, Tr, T2, Tf);
     return s;
 }

--- a/qucs/components/vfile.cpp
+++ b/qucs/components/vfile.cpp
@@ -120,7 +120,7 @@ QString vFile::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     QString modname = "mod_" + Model + Name;
     QString p1 = spicecompat::normalize_node_name(Ports.at(0)->Connection->Name);
     QString p2 = spicecompat::normalize_node_name(Ports.at(1)->Connection->Name);
-    s += QStringLiteral(" %vd([%1 %2]) %3\n").arg(p1).arg(p2).arg(modname);
+    s += QStringLiteral(" %vd([%1 %2]) %3\n").arg(p1, p2, modname);
     QString file = getSubcircuitFile();
     QString sc = getProperty("G")->Value;
     QString step = "false";
@@ -128,7 +128,7 @@ QString vFile::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     if (getProperty("Interpolator")->Value != "linear") step = "true";
     s += QStringLiteral(".MODEL %1 filesource (file=\"%2\" amplscale=[%3] amplstep=%4 "
                  "amploffset=[0] timeoffset=%5 timescale=1)\n")
-            .arg(modname).arg(file).arg(sc).arg(step).arg(delay);
+            .arg(modname, file, sc, step, delay);
 
     return s;
 }

--- a/qucs/components/vfile.cpp
+++ b/qucs/components/vfile.cpp
@@ -99,7 +99,7 @@ QString vFile::netlist()
   QString s = Model+":"+Name;
 
   // output all node names
-  for (Port *p1 : Ports)
+  for (Port *p1 : std::as_const(Ports))
     s += " "+p1->Connection->Name;   // node names
 
   // output file properties

--- a/qucs/components/vhdlfile.cpp
+++ b/qucs/components/vhdlfile.cpp
@@ -219,7 +219,7 @@ bool VHDL_File::createSubNetlist(QTextStream *stream)
   QString FileName = Props.front()->Value;
   if(FileName.isEmpty()) {
     ErrText += QObject::tr("ERROR: No file name in %1 component \"%2\".").
-      arg(Model).arg(Name);
+      arg(Model, Name);
     return false;
   }
 
@@ -230,7 +230,7 @@ bool VHDL_File::createSubNetlist(QTextStream *stream)
   QFile f(FileName);
   if(!f.open(QIODevice::ReadOnly)) {
     ErrText += QObject::tr("ERROR: Cannot open %1 file \"%2\".").
-      arg(Model).arg(FileName);
+      arg(Model, FileName);
     return false;
   }
 

--- a/qucs/components/vhdlfile.cpp
+++ b/qucs/components/vhdlfile.cpp
@@ -373,7 +373,7 @@ QString VHDL_File_Info::parsePorts(QString s, int j)
       t = t.mid(k+1);
     t = t.simplified();
     k = s.indexOf(';',l+2);
-    k = (s.mid(l,k-l).count(',')) + 1;
+    k = (QStringView(s).mid(l,k-l).count(',')) + 1;
     while (k-->0) types = types + t + ",";
     i--;
     l = i;
@@ -452,7 +452,7 @@ QString VHDL_File_Info::parseGenerics(QString s, int j)
       t = t.mid(k+1);
     t = t.simplified();
     k = s.indexOf(';',l+2);
-    k = (s.mid(l,k-l).count(',')) + 1;
+    k = (QStringView(s).mid(l,k-l).count(',')) + 1;
     while (k-->0) {
       types = types + t + ",";
       defs = defs + d + ",";

--- a/qucs/components/volt_ac.cpp
+++ b/qucs/components/volt_ac.cpp
@@ -109,7 +109,7 @@ QString Volt_ac::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
     QString TD = spicecompat::normalize_value(getProperty("TD")->Value);
 
     s += QStringLiteral(" DC %1 SIN(%1 %2 %3 %4 %5 %6) AC %7 ACPHASE %8\n")
-            .arg(VO).arg(volts).arg(freq).arg(TD).arg(theta).arg(phase).arg(volts).arg(phase);
+            .arg(VO, volts, freq, TD, theta, phase, volts, phase);
     return s;
 }
 

--- a/qucs/components/volt_ac.cpp
+++ b/qucs/components/volt_ac.cpp
@@ -88,7 +88,7 @@ QString Volt_ac::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names
@@ -118,7 +118,7 @@ QString Volt_ac::netlist()
   QString s = Model+":"+Name;
 
   // output all node names
-  for (Port *p1 : Ports)
+  for (Port *p1 : std::as_const(Ports))
     s += " "+p1->Connection->Name;   // node names
 
   // output all properties

--- a/qucs/components/volt_dc.cpp
+++ b/qucs/components/volt_dc.cpp
@@ -62,7 +62,7 @@ Component* Volt_dc::newOne()
 QString Volt_dc::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::SPICEDefault */)
 {
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names

--- a/qucs/components/vprobe.cpp
+++ b/qucs/components/vprobe.cpp
@@ -82,7 +82,7 @@ QString vProbe::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
 {
     Q_UNUSED(dialect);
 
-    QString s = QStringLiteral("E%1 %2 0 %3 %4 1.0\nR%1%2 %2 0 1E8\nR%1%3 %3 %4 1E8\n").arg(Name).arg(Name)
-            .arg(Ports.at(0)->Connection->Name).arg(Ports.at(1)->Connection->Name);
+    QString s = QStringLiteral("E%1 %2 0 %3 %4 1.0\nR%1%2 %2 0 1E8\nR%1%3 %3 %4 1E8\n").arg(Name, Name,
+            Ports.at(0)->Connection->Name, Ports.at(1)->Connection->Name);
     return s;
 }

--- a/qucs/components/vpulse.cpp
+++ b/qucs/components/vpulse.cpp
@@ -93,7 +93,7 @@ QString vPulse::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
     QString T2 = spicecompat::normalize_value(getProperty("T2")->Value); // T2
 
     s += QStringLiteral(" DC 0 PULSE(%1 %2 %3 %4 %5 {(%6)-(%3)-(%4)-(%5)}) AC 0\n")
-             .arg(VL).arg(VH).arg(T1).arg(Tr).arg(Tf).arg(T2);
+             .arg(VL, VH, T1, Tr, Tf, T2);
 
     return s;
 }

--- a/qucs/components/vpulse.cpp
+++ b/qucs/components/vpulse.cpp
@@ -79,7 +79,7 @@ QString vPulse::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
 
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names

--- a/qucs/components/vrect.cpp
+++ b/qucs/components/vrect.cpp
@@ -80,7 +80,7 @@ QString vRect::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
 
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names
@@ -119,7 +119,7 @@ QString vRect::netlist()
   QString s = Model+":"+Name;
 
   // output all node names
-  for (Port *p1 : Ports)
+  for (Port *p1 : std::as_const(Ports))
     s += " "+p1->Connection->Name;   // node names
 
   // output all properties

--- a/qucs/diagrams/curvediagram.cpp
+++ b/qucs/diagrams/curvediagram.cpp
@@ -43,7 +43,7 @@ CurveDiagram::CurveDiagram(int _cx, int _cy) : Diagram(_cx, _cy)
   x3 = 207;    // with some distance for right axes text
 
   Name = "Curve"; // BUG.
-  calcDiagram();
+  CurveDiagram::calcDiagram();
 }
 
 CurveDiagram::~CurveDiagram()

--- a/qucs/diagrams/diagram.cpp
+++ b/qucs/diagrams/diagram.cpp
@@ -114,23 +114,23 @@ void Diagram::paintDiagram(QPainter *painter) {
     painter->translate(cx, cy);
     painter->save();
 
-    for (qucs::Line* line : Lines) {
+    for (qucs::Line* line : std::as_const(Lines)) {
         painter->setPen(line->penHint());
         painter->drawLine(QLineF{line->x1, - line->y1, line->x2, - line->y2});
     }
 
-    for (qucs::Arc* arc : Arcs) {
+    for (qucs::Arc* arc : std::as_const(Arcs)) {
         painter->setPen(arc->penHint());
         painter->drawArc(QRectF{arc->x, - arc->y, arc->w, arc->h}, arc->angle, arc->arclen);
     }
 
     painter->scale(1.0, -1.0); // make Y-axis grow upwards
-    for (Graph *pg: Graphs) {
+    for (Graph *pg: std::as_const(Graphs)) {
         pg->paint(painter);
     }
     painter->restore();  // to translated(cx, cy) with no negative y-scale
 
-    for (Text *pt: Texts) {
+    for (Text *pt: std::as_const(Texts)) {
         painter->save();
 
         painter->setPen(pt->Color);
@@ -156,8 +156,8 @@ void Diagram::paintDiagram(QPainter *painter) {
 
 void Diagram::paintMarkers(QPainter *p, bool paintAll) {
     // draw markers last, so they are at the top of painting layers
-    for (Graph *pg: Graphs)
-        for (Marker *pm: pg->Markers)
+  for (Graph *pg: std::as_const(Graphs))
+      for (Marker *pm: std::as_const(pg->Markers))
             if (paintAll || (pm->Type & 1)) {
                 pm->paint(p);
             }
@@ -183,7 +183,7 @@ void Diagram::createAxisLabels() {
     y = -y1;
     if (xAxis.Label.isEmpty()) {
         // write all x labels ----------------------------------------
-        for (Graph *pg: Graphs) {
+        for (Graph *pg: std::as_const(Graphs)) {
             DataX const *pD = pg->axis(0);
             if (!pD) continue;
             y -= LineSpacing;
@@ -217,7 +217,7 @@ void Diagram::createAxisLabels() {
     y = y2 >> 1;
 
     QStringList used_kernels, used_simulations;
-    for (const auto pg: Graphs) {
+    for (const auto pg: std::as_const(Graphs)) {
       if (!pg->Var.contains("/")) continue; // Qucsator data
         QString kernel_name = pg->Var.section('/', 0, 0);
         QString var_name = pg->Var;
@@ -236,7 +236,7 @@ void Diagram::createAxisLabels() {
         // strip simulator name and simulation name like ngspice/ac.
         // if all graphs are from the same simulator and simulation
 
-        for (Graph *pg: Graphs) {
+        for (Graph *pg: std::as_const(Graphs)) {
             if (pg->yAxisNo != 0) continue;
             if (pg->cPointsY) {
                 QString var_name = pg->Var;
@@ -282,7 +282,7 @@ void Diagram::createAxisLabels() {
     y = y2 >> 1;
     if (zAxis.Label.isEmpty()) {
         // draw right y-label for all graphs ------------------------------
-        for (Graph *pg: Graphs) {
+        for (Graph *pg: std::as_const(Graphs)) {
             if (pg->yAxisNo != 1) continue;
             if (pg->cPointsY) {
                 QString var_name = pg->Var;
@@ -366,7 +366,7 @@ bool Diagram::insideDiagram(float x, float y) const {
 Marker *Diagram::setMarker(int x, int y) {
     if (getSelected(x, y)) {
         // test all graphs of the diagram
-        for (Graph *pg: Graphs) {
+        for (Graph *pg: std::as_const(Graphs)) {
             int n = pg->getSelected(x - cx, cy - y); // sic!
             if (n >= 0) {
                 assert(pg->parentDiagram() == this);
@@ -723,7 +723,7 @@ void Diagram::loadGraphData(const QString &defaultDataSet) {
     yAxis.max = zAxis.max = xAxis.max = -DBL_MAX;
 
     int No = 0;
-    for (Graph *pg: Graphs) {
+    for (Graph *pg: std::as_const(Graphs)) {
         qDebug() << "load GraphData load" << defaultDataSet << pg->Var;
         if (pg->loadDatFile(defaultDataSet) != 1)   // load data, determine max/min values
             No++;
@@ -766,7 +766,7 @@ void Diagram::recalcGraphData() {
     yAxis.numGraphs = zAxis.numGraphs = 0;
 
     // get maximum and minimum values
-    for (Graph *pg: Graphs)
+    for (Graph *pg: std::as_const(Graphs))
         getAxisLimits(pg);
 
     if (xAxis.min > xAxis.max) {
@@ -793,7 +793,7 @@ void Diagram::recalcGraphData() {
 void Diagram::updateGraphData() {
     int valid = calcDiagram();   // do not calculate graph data if invalid
 
-    for (Graph *pg: Graphs) {
+    for (Graph *pg: std::as_const(Graphs)) {
         pg->clear();
         if ((valid & (pg->yAxisNo + 1)) != 0)
             calcData(pg);   // calculate screen coordinates
@@ -807,7 +807,7 @@ void Diagram::updateGraphData() {
 
     // Setting markers must be done last, because in 3D diagram "Mem"
     // is released in "createAxisLabels()".
-    for (Graph *pg: Graphs) {
+    for (Graph *pg: std::as_const(Graphs)) {
         pg->createMarkerText();
     }
 }
@@ -1267,7 +1267,7 @@ QString Diagram::save() {
     // labels can contain spaces -> must be last items in the line
     s += " \"" + xAxis.Label + "\" \"" + yAxis.Label + "\" \"" + zAxis.Label + "\">\n";
 
-    for (Graph *pg: Graphs)
+    for (Graph *pg: std::as_const(Graphs))
         s += pg->save() + "\n";
 
     s += "  </" + Name + ">";

--- a/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/diagrams/diagramdialog.cpp
@@ -917,7 +917,7 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
   // ...........................................................
   // put all graphs into the ListBox
   Row = 0;
-  for (Graph *pg : Diag->Graphs) {
+  for (Graph *pg : std::as_const(Diag->Graphs)) {
     GraphList->setRowCount(Row + 1);
 
     // Populate the table row with graph properties
@@ -1842,7 +1842,7 @@ void DiagramDialog::slotSetGraphStyle(int style) {
  *
  */
 void DiagramDialog::copyDiagramGraphs() {
-  for (Graph *pg : Diag->Graphs)
+  for (Graph *pg : std::as_const(Diag->Graphs))
     Graphs.emplace_back(pg->sameNewOne());
 }
 

--- a/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/diagrams/diagramdialog.cpp
@@ -497,8 +497,8 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
       GridOn->setChecked(Diag->xAxis.GridOn);
       if (!Diag->xAxis.GridOn)
         slotSetGridBox(0);
-      connect(GridOn, &QCheckBox::stateChanged, this,
-              &DiagramDialog::slotSetGridBox);
+        // connect(GridOn, &QCheckBox::checkStateChanged, this, &DiagramDialog::slotSetGridBox); - Use this after moving macOS to Qt > 6.7
+      connect(GridOn, &QCheckBox::stateChanged, this, &DiagramDialog::slotSetGridBox); // Drop this after moving macOS to Qt > 6.7
     } else {
       GridOn = 0;
       GridColorButt = 0;
@@ -676,8 +676,8 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
     manualX = new QCheckBox(tr("manual")); //, VBox1);
     VBox1Layout->addWidget(manualX);
     VBox1->setLayout(VBox1Layout);
-    connect(manualX, QOverload<int>::of(&QCheckBox::stateChanged), this,
-            &DiagramDialog::slotManualX);
+    // connect(manualX, &QCheckBox::checkStateChanged, this, &DiagramDialog::slotManualX); - Use this after moving macOS to Qt > 6.7
+    connect(manualX, &QCheckBox::stateChanged, this, &DiagramDialog::slotManualX); // Drop this after moving macOS to Qt > 6.7
 
     QWidget *VBox2 = new QWidget();
     axisXLayout->addWidget(VBox2);
@@ -719,8 +719,8 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
     VBox5Layout->addStretch();
     manualY = new QCheckBox(tr("manual"));
     VBox5Layout->addWidget(manualY);
-    connect(manualY, QOverload<int>::of(&QCheckBox::stateChanged), this,
-            &DiagramDialog::slotManualY);
+    // connect(manualY, &QCheckBox::checkStateChanged, this, &DiagramDialog::slotManualY); - Use this after moving macOS to Qt > 6.7
+    connect(manualY, &QCheckBox::stateChanged, this, &DiagramDialog::slotManualY); // Drop this after moving macOS to Qt > 6.7
 
     VBox5->setLayout(VBox5Layout);
 
@@ -768,8 +768,8 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
     VBox9Layout->addStretch();
     manualZ = new QCheckBox(tr("manual"));
     VBox9Layout->addWidget(manualZ);
-    connect(manualZ, QOverload<int>::of(&QCheckBox::stateChanged), this,
-            &DiagramDialog::slotManualZ);
+    // connect(manualZ, &QCheckBox::checkStateChanged, this, &DiagramDialog::slotManualZ); - Use this after moving macOS to Qt > 6.7
+    connect(manualZ, &QCheckBox::stateChanged, this, &DiagramDialog::slotManualZ); // Drop this after moving macOS to Qt > 6.7
 
     VBox9->setLayout(VBox9Layout);
 

--- a/qucs/diagrams/marker.cpp
+++ b/qucs/diagrams/marker.cpp
@@ -219,7 +219,6 @@ void Marker::createText()
   // independent variables
   Text = "";
   double *pp;
-  nVarPos = pGraph->numAxes();
   DataX const *pD;
 
   auto p = pGraph->findSample(VarPos);
@@ -228,7 +227,6 @@ void Marker::createText()
 
   double v=0.;   // needed for 2D graph in 3D diagram
   double *py=&v;
-  pD = pGraph->axis(0);
   if(pGraph->axis(1)) {
     *py = VarPos[1];
   }

--- a/qucs/diagrams/marker.cpp
+++ b/qucs/diagrams/marker.cpp
@@ -542,7 +542,7 @@ bool Marker::load(const QString& Line)
 
   do {
     j = n.indexOf('/', i);
-    VarPos[nVarPos++] = n.mid(i,j-i).toDouble(&ok);
+    VarPos[nVarPos++] = QStringView(n).mid(i,j-i).toDouble(&ok);
     if(!ok) return false;
     i = j+1;
   } while(j >= 0);

--- a/qucs/diagrams/rect3ddiagram.cpp
+++ b/qucs/diagrams/rect3ddiagram.cpp
@@ -390,7 +390,7 @@ void Rect3DDiagram::removeHiddenLines(char *zBuffer, tBound *Bounds)
   tPoint3D *p;
   int i, j, z, dx, dy, Size=0;
   // pre-calculate buffer size to avoid reallocations in the first step
-  for (Graph *g : Graphs)
+  for (Graph *g : std::as_const(Graphs))
     if(g->cPointsY)
       Size += g->axis(0)->count * g->countY;
 
@@ -410,7 +410,7 @@ void Rect3DDiagram::removeHiddenLines(char *zBuffer, tBound *Bounds)
   tPointZ *zp = zMem, *zp_tmp;
 
   // ...............................................................
-  for (Graph *g : Graphs) {
+  for (Graph *g : std::as_const(Graphs)) {
 
     pz = g->cPointsY;
     if(!pz) continue;
@@ -533,7 +533,7 @@ void Rect3DDiagram::removeHiddenLines(char *zBuffer, tBound *Bounds)
   tPoint3D *MemEnd = Mem + malloc_8xsize*2*Size - 5;   // limit of buffer
 
   zp = zMem;
-  for (Graph *g : Graphs) {
+  for (Graph *g : std::as_const(Graphs)) {
     if(!g->cPointsY) continue;
     dx = g->axis(0)->count;
     if(g->countY > 1)  dy = g->axis(1)->count;
@@ -788,7 +788,7 @@ void Rect3DDiagram::createAxis(Axis *Axis, bool Right,
   y = y1_ - int(double(valid)*cos_phi);
   if(Axis->Label.isEmpty()) {
     // write all labels ----------------------------------------
-    for (Graph *pg : Graphs) {
+    for (Graph *pg : std::as_const(Graphs)) {
       if(Axis != &zAxis) {
         if(!pg->cPointsY)  continue;
         if(valid < 0) {

--- a/qucs/diagrams/rectdiagram.cpp
+++ b/qucs/diagrams/rectdiagram.cpp
@@ -45,7 +45,7 @@ RectDiagram::RectDiagram(int _cx, int _cy) : Diagram(_cx, _cy)
   x3 = 247;    // with some distance for right axes text
 
   Name = "Rect"; // BUG
-  calcDiagram();
+  RectDiagram::calcDiagram();
 }
 
 RectDiagram::~RectDiagram()

--- a/qucs/diagrams/tabdiagram.cpp
+++ b/qucs/diagrams/tabdiagram.cpp
@@ -54,7 +54,7 @@ void TabDiagram::paintDiagram(QPainter *painter) {
   painter->save();
   painter->translate(cx, cy);
 
-  for (qucs::Line *pl : Lines) {
+  for (qucs::Line *pl : std::as_const(Lines)) {
     painter->setPen(pl->style);
     painter->drawLine(pl->x1, -pl->y1, pl->x2, -pl->y2);
   }
@@ -109,7 +109,7 @@ void TabDiagram::paintDiagram(QPainter *painter) {
 
 
   painter->setPen(Qt::black);
-  for (Text *pt : Texts) {
+  for (Text *pt : std::as_const(Texts)) {
     painter->drawText(pt->x, -pt->y, 1, 1, Qt::TextDontClip, pt->s);
   }
 
@@ -244,7 +244,7 @@ int TabDiagram::calcDiagram()
   firstGraph = g;
   // ................................................
   // all dependent variables
-  for (Graph *g : Graphs) {
+  for (Graph *g : std::as_const(Graphs)) {
     y = y2-tHeight-5;
     colWidth = 0;
 

--- a/qucs/diagrams/tabdiagram.cpp
+++ b/qucs/diagrams/tabdiagram.cpp
@@ -39,7 +39,7 @@ TabDiagram::TabDiagram(int _cx, int _cy) : Diagram(_cx, _cy)
   Name = "Tab";
   xAxis.limit_min = 0.0;  // scroll bar position (needs to be saved in file)
 
-  calcDiagram();
+  TabDiagram::calcDiagram();
 }
 
 TabDiagram::~TabDiagram()

--- a/qucs/diagrams/timingdiagram.cpp
+++ b/qucs/diagrams/timingdiagram.cpp
@@ -54,14 +54,14 @@ void TimingDiagram::paintDiagram(QPainter *painter) {
 
   painter->translate(cx, cy);
 
-  for (qucs::Line* line : Lines) {
+  for (qucs::Line* line : std::as_const(Lines)) {
     painter->setPen(line->style);
     painter->drawLine(line->x1, -line->y1, line->x2, -line->y2);
   }
 
   painter->setPen(Qt::black);
 
-  for (Text *pt : Texts) {
+  for (Text *pt : std::as_const(Texts)) {
     painter->drawText(pt->x, -pt->y, 1, 1, Qt::TextDontClip, pt->s);
   }
 
@@ -189,7 +189,7 @@ int TimingDiagram::calcDiagram()
 
   // First check the maximum bit number of all vectors.
   colWidth = 0;
-  for (Graph *g : Graphs)
+  for (Graph *g : std::as_const(Graphs))
     if(g->cPointsY) {
       if(g->Var.right(2) == ".X") {
         z = strlen((char*)g->cPointsY);
@@ -230,7 +230,7 @@ if(!firstGraph->isEmpty()) {
 
   y -= 5;
   // write all dependent variable names to get width of first column
-  for (Graph *g : Graphs) {
+  for (Graph *g : std::as_const(Graphs)) {
     if(y < tHeight)  break;
     Str = g->Var;
     colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
@@ -278,7 +278,7 @@ if(!firstGraph->isEmpty()) {
   QPen Pen;
   int  yLast, yNow;
   y = y2-tHeight-9;
-  for (Graph *g : Graphs) {
+  for (Graph *g : std::as_const(Graphs)) {
     if(y < tHeight) {
       // mark lack of space with a small arrow
       Lines.append(new qucs::Line(4, 6, 4, -7, QPen(Qt::red,2)));

--- a/qucs/diagrams/timingdiagram.cpp
+++ b/qucs/diagrams/timingdiagram.cpp
@@ -38,7 +38,7 @@ TimingDiagram::TimingDiagram(int _cx, int _cy) : TabDiagram(_cx, _cy)
   Name = "Time";
   xAxis.limit_min = 0.0;  // scroll bar position (needs to be saved in file)
 
-  calcDiagram();
+  TimingDiagram::calcDiagram();
 }
 
 TimingDiagram::~TimingDiagram()

--- a/qucs/diagrams/truthdiagram.cpp
+++ b/qucs/diagrams/truthdiagram.cpp
@@ -37,7 +37,7 @@ TruthDiagram::TruthDiagram(int _cx, int _cy) : TabDiagram(_cx, _cy)
   Name = "Truth";
   xAxis.limit_min = 0.0;  // scroll bar position (needs to be saved in file)
 
-  calcDiagram();
+  TruthDiagram::calcDiagram();
 }
 
 TruthDiagram::~TruthDiagram()

--- a/qucs/diagrams/truthdiagram.cpp
+++ b/qucs/diagrams/truthdiagram.cpp
@@ -154,7 +154,7 @@ int TruthDiagram::calcDiagram()
   firstGraph = g;
   // ................................................
   // all dependent variables
-  for (Graph *g : Graphs) {
+  for (Graph *g : std::as_const(Graphs)) {
     y = y2-tHeight-5;
 
     Str = g->Var;

--- a/qucs/dialogs/changedialog.cpp
+++ b/qucs/dialogs/changedialog.cpp
@@ -247,11 +247,9 @@ void ChangeDialog::slotButtReplace()
         pc->textSize(dx, dy);   // correct text position
         if(tx_Dist != 0) {
           pc->tx += tx_Dist-dx;
-          tx_Dist = dx;
         }
         if(ty_Dist != 0) {
           pc->ty += ty_Dist-dy;
-          ty_Dist = dy;
         }
 
         // apply changes to schematic symbol

--- a/qucs/dialogs/changedialog.cpp
+++ b/qucs/dialogs/changedialog.cpp
@@ -179,7 +179,7 @@ void ChangeDialog::slotButtReplace()
     if(matches(pc->Model)) {
       QRegularExpressionMatch match = Expr.match(pc->Name);
       if(match.hasMatch())
-        for(const auto& pp : pc->Props)
+        for(const auto& pp : std::as_const(pc->Props))
           if(pp->Name == PropNameEdit->currentText()) {
             pb = new QCheckBox(pc->Name);
             Dia_Box->addWidget(pb);
@@ -231,7 +231,7 @@ void ChangeDialog::slotButtReplace()
     for(Component* pc : *Doc->a_Components) {
       if(pb->text() != pc->Name)  continue;
 
-      for(auto pp : pc->Props) {
+      for(auto pp : std::as_const(pc->Props)) {
         if(pp->Name != PropNameEdit->currentText())  continue;
 
         int tx_Dist, ty_Dist, tmp;

--- a/qucs/dialogs/fillfromspicedialog.cpp
+++ b/qucs/dialogs/fillfromspicedialog.cpp
@@ -66,7 +66,7 @@ int fillFromSpiceDialog::parseModelcard()
   // tokenize modelcard
   QStringList tokens;
   QString tok;
-  for (const auto &c: ModelCard) {
+  for (const auto &c: std::as_const(ModelCard)) {
     if (c.isLetterOrNumber() || c == '_' ||
         c == '.' || c == '+' || c == '-') {
       tok += c;
@@ -171,7 +171,7 @@ QString fillFromSpiceDialog::convertNumNotation(const QString &value)
 
 void fillFromSpiceDialog::fillCompProps()
 {
-  for(Property *p : Comp->Props) {
+  for(Property *p : std::as_const(Comp->Props)) {
     QString name = p->Name;
     name = name.toLower();
     if (parsedProps.contains(name)) {

--- a/qucs/dialogs/librarydialog.cpp
+++ b/qucs/dialogs/librarydialog.cpp
@@ -507,7 +507,7 @@ void LibraryDialog::slotSave()
         if (!kern->checkSchematic(err_lst)) {
              ErrText->insertPlainText(QStringLiteral("Component %1 contains SPICE-incompatible components.\n"
                                 "Check these components: %2 \n")
-                    .arg(Doc->getDocName()).arg(err_lst.join("; ")));
+                    .arg(Doc->getDocName(), err_lst.join("; ")));
         }
         kern->createSubNetlist(ts,true);
         intoStream(Stream, tmp, "Spice");

--- a/qucs/dialogs/matchdialog.cpp
+++ b/qucs/dialogs/matchdialog.cpp
@@ -1944,7 +1944,7 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
       componentstr +=
           QStringLiteral("<.SP SP1 1 0 100 0 67 0 0 \"lin\" 1 \"%1\" 1 \"%2\" 1 "
                   "\"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n")
-              .arg((val_freq_start), (val_freq_stop));
+              .arg(val_freq_start, val_freq_stop);
 
       if (laddercode.indexOf("P2") == -1) // One port simulation
         componentstr += QStringLiteral("<Eqn Eqn1 1 200 100 -28 15 0 0 "

--- a/qucs/dialogs/matchdialog.cpp
+++ b/qucs/dialogs/matchdialog.cpp
@@ -1636,8 +1636,8 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
     // to handle such difference
     if (index != -1) // The component has two values
     {
-      value = component.mid(0, index).toDouble();
-      value2 = component.mid(index + 1).toDouble();
+      value = QStringView(component).mid(0, index).toDouble();
+      value2 = QStringView(component).mid(index + 1).toDouble();
     } else {
       if (!tag.compare("LBL")) // The value is a string
       {

--- a/qucs/dialogs/matchdialog.cpp
+++ b/qucs/dialogs/matchdialog.cpp
@@ -1773,8 +1773,7 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         componentstr +=
             QStringLiteral("<MLIN MS1 1 %3 -120 -26 20 0 0 \"Sub1\" 1 \"%1\" 1 \"%2\" "
                     "1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
-                .arg(val_width)
-                .arg(val_length)
+                .arg(val_width, val_length)
                 .arg(x_pos + 60);
       } else {
         // Add a prefix (although rarely needed here) and unit - 3 significant digits
@@ -1783,8 +1782,7 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         QString val_length = misc::num2str(value2, 3, "m");
         componentstr += QStringLiteral("<TLIN Line1 1 %3 -120 -26 20 0 0 \"%1\" 1 "
                                 "\"%2\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
-                            .arg(val_impedance)
-                            .arg(val_length)
+                            .arg(val_impedance, val_length)
                             .arg(x_pos + 60);
       }
       wirestr += QStringLiteral("<%1 -120 %2 -120 "
@@ -1811,8 +1809,7 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         componentstr +=
             QStringLiteral("<MLIN MS1 1 %3 -180 30 -30 0 1 \"Sub1\" 1 \"%1\" 1 \"%2\" "
                     "1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
-                .arg(val_width)
-                .arg(val_length)
+                .arg(val_width, val_length)
                 .arg(x_pos);
       } else {
         // Add a prefix (although rarely needed here) and unit - 3 significant digits
@@ -1821,8 +1818,7 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         QString val_length = misc::num2str(value2, 3, "m");
         componentstr += QStringLiteral("<TLIN Line1 1 %3 -180 30 -30 0 1 \"%1\" 1 "
                                 "\"%2\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
-                            .arg(val_impedance)
-                            .arg(val_length)
+                            .arg(val_impedance, val_length)
                             .arg(x_pos);
       }
       wirestr += QStringLiteral("<%1 -150 %1 -120 "
@@ -1849,8 +1845,7 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         componentstr +=
             QStringLiteral("<MLIN MS1 1 %3 -60 -26 30 0 1 \"Sub1\" 1 \"%1\" 1 \"%2\" "
                     "1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
-                .arg(val_width)
-                .arg(val_length)
+                .arg(val_width, val_length)
                 .arg(x_pos);
       } else {
         // Add a prefix (although rarely needed here) and unit - 3 significant digits
@@ -1859,8 +1854,7 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         QString val_length = misc::num2str(value2, 3, "m");
         componentstr += QStringLiteral("<TLIN Line1 1 %3 -60 -26 30 0 1 \"%1\" 1 "
                                 "\"%2\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
-                            .arg(val_impedance)
-                            .arg(val_length)
+                            .arg(val_impedance, val_length)
                             .arg(x_pos);
       }
       wirestr += QStringLiteral("<%1 -90 %1 -120 "
@@ -1884,16 +1878,14 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         componentstr +=
             QStringLiteral("<MLIN MS1 1 %3 -180 30 -30 0 1 \"Sub1\" 1 \"%1\" 1 \"%2\" "
                     "1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
-                .arg(val_width)
-                .arg(val_length)
+                .arg(val_width, val_length)
                 .arg(x_pos);
       } else {
         QString val_impedance = misc::num2str(value, 3, "Ohm");
         QString val_length = misc::num2str(value2, 3, "m");
         componentstr += QStringLiteral("<TLIN Line1 1 %3 -180 30 -30 0 1 \"%1\" 1 "
                                 "\"%2\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
-                            .arg(val_impedance)
-                            .arg(val_length)
+                            .arg(val_impedance, val_length)
                             .arg(x_pos);
       }
       componentstr += QStringLiteral("<GND * 1 %1 -210 0 0 0 2>\n").arg(x_pos);
@@ -1919,16 +1911,14 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
         componentstr +=
             QStringLiteral("<MLIN MS1 1 %3 -60 30 -30 0 1 \"Sub1\" 1 \"%1\" 1 \"%2\" "
                     "1 \"Hammerstad\" 0 \"Kirschning\" 0 \"26.85\" 0>\n")
-                .arg(val_width)
-                .arg(val_length)
+                .arg(val_width, val_length)
                 .arg(x_pos);
       } else {
         QString val_impedance = misc::num2str(value, 3, "Ohm");
         QString val_length = misc::num2str(value2, 3, "m");
         componentstr += QStringLiteral("<TLIN Line1 1 %3 -60 20 30 0 1 \"%1\" 1 "
                                 "\"%2\" 1 \"0 dB\" 0 \"26.85\" 0>\n")
-                            .arg(val_impedance)
-                            .arg(val_length)
+                            .arg(val_impedance, val_length)
                             .arg(x_pos);
       }
       componentstr += QStringLiteral("<GND * 1 %1 -30 0 0 0 0>\n").arg(x_pos);
@@ -1954,8 +1944,7 @@ void MatchDialog::SchematicParser(QString laddercode, int &x_pos, double Freq,
       componentstr +=
           QStringLiteral("<.SP SP1 1 0 100 0 67 0 0 \"lin\" 1 \"%1\" 1 \"%2\" 1 "
                   "\"300\" 1 \"no\" 0 \"1\" 0 \"2\" 0>\n")
-              .arg((val_freq_start))
-              .arg((val_freq_stop));
+              .arg((val_freq_start), (val_freq_stop));
 
       if (laddercode.indexOf("P2") == -1) // One port simulation
         componentstr += QStringLiteral("<Eqn Eqn1 1 200 100 -28 15 0 0 "

--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -1246,6 +1246,7 @@ void QucsSettingsDialog::slotAddPathWithSubFolders()
   layout->addWidget(pathList);
 
   // Keep "Select all" checkbox in sync with individual items
+  // Replace QCheckBox::stateChanged by QCheckBox::checkStateChanged when moving macOS build to Qt >= 6.7
   connect(selectAllCheck, &QCheckBox::stateChanged, [pathList](int state) {
     if (state == Qt::PartiallyChecked){
       return;

--- a/qucs/dialogs/qucsshortcutdialog.cpp
+++ b/qucs/dialogs/qucsshortcutdialog.cpp
@@ -174,7 +174,7 @@ void QucsShortcutDialog::fillMenu() {
   // Sort alphabetically
   categories.sort();
 
-  for (const QString &category : qAsConst(categories)) {
+  for (const QString &category : std::as_const(categories)) {
     QListWidgetItem *item = new QListWidgetItem(category);
     menuList->addItem(item);
   }
@@ -421,7 +421,7 @@ void QucsShortcutDialog::slotSearchShortcuts(const QString &text) {
   }
 
   // Otherwise, search all other categories
-  for (const QString &category : qAsConst(allCategories)) {
+  for (const QString &category : std::as_const(allCategories)) {
     if (category == currentCategory) {
       continue; // Already checked
     }
@@ -586,7 +586,7 @@ void QucsShortcutDialog::keyPressEvent(QKeyEvent *event) {
   QList<ShortcutConflict> conflicts = m_manager.findConflicts(newKey);
   if (!conflicts.isEmpty()) {
     QString msg = tr("This shortcut is already used by:\n\n");
-    for (const auto &conflict : qAsConst(conflicts)) {
+    for (const auto &conflict : std::as_const(conflicts)) {
       msg +=
           QString("  • %1: %2\n").arg(conflict.category, conflict.description);
     }

--- a/qucs/dialogs/selfromlibdialog.cpp
+++ b/qucs/dialogs/selfromlibdialog.cpp
@@ -138,7 +138,7 @@ void SelFromLibDialog::fillLibComboBox()
 {
   checkAndParseLibrary(QucsSettings.LibDir,true);
 
-  for(const auto &lib: parsedLibs) {
+  for(const auto &lib: std::as_const(parsedLibs)) {
     cbxLib->addItem(lib->name);
   }
 }
@@ -146,10 +146,10 @@ void SelFromLibDialog::fillLibComboBox()
 void SelFromLibDialog::slotShowComponents()
 {
   QString libname = cbxLib->currentText();
-  for(const auto &lib: parsedLibs) {
+  for(const auto &lib: std::as_const(parsedLibs)) {
     if (lib->name == libname) {
       lstComps->clear();
-      for (const auto &c: lib->components) {
+      for (const auto &c: std::as_const(lib->components)) {
         QString m = c.modelString;
         m.remove(0,1);
         m.chop(1);
@@ -170,9 +170,9 @@ void SelFromLibDialog::slotShowDescription()
   if (itm == nullptr) return;
   edtDescr->clear();
   QString compname = itm->text();
-  for(const auto &lib: parsedLibs) {
+  for(const auto &lib: std::as_const(parsedLibs)) {
     if (lib->name == libname) {
-      for (const auto &c: lib->components) {
+      for (const auto &c: std::as_const(lib->components)) {
         if (compname == c.name) {
           QString desc;
           QString def = c.definition;
@@ -208,7 +208,7 @@ void SelFromLibDialog::checkAndParseLibrary(const QString &libdir, bool relpath)
     if (result != QUCS_COMP_LIB_OK) return;
 
     bool found = false;
-    for(const auto &c: parsedlibrary->components) {
+    for(const auto &c: std::as_const(parsedlibrary->components)) {
       QString m = c.modelString;
       m.remove(0,1);
       m.chop(1);

--- a/qucs/dialogs/simmessage.cpp
+++ b/qucs/dialogs/simmessage.cpp
@@ -158,8 +158,8 @@ bool SimMessage::startProcess()
   ErrText->clear();
 
   QString txt = tr("Starting new simulation on %1 at %2").
-    arg(QDate::currentDate().toString("ddd dd. MMM yyyy")).
-    arg(QTime::currentTime().toString("hh:mm:ss:zzz"));
+    arg(QDate::currentDate().toString("ddd dd. MMM yyyy"),
+        QTime::currentTime().toString("hh:mm:ss:zzz"));
   ProgText->appendPlainText(txt + "\n");
 
   SimProcess.blockSignals(false);
@@ -817,14 +817,14 @@ void SimMessage::FinishSimulation(int Status)
 
   if(Status == 0) {
     QString txt = tr("Simulation ended on %1 at %2").
-      arg(d.toString("ddd dd. MMM yyyy")).
-      arg(t.toString("hh:mm:ss:zzz"));
+      arg(d.toString("ddd dd. MMM yyyy"),
+          t.toString("hh:mm:ss:zzz"));
     ProgText->appendPlainText("\n" + txt + "\n" + tr("Ready."));
   }
   else {
     QString txt = tr("Errors occurred during simulation on %1 at %2").
-      arg(d.toString("ddd dd. MMM yyyy")).
-      arg(t.toString("hh:mm:ss:zzz"));
+      arg(d.toString("ddd dd. MMM yyyy"),
+          t.toString("hh:mm:ss:zzz"));
     ProgText->appendPlainText("\n" + txt + "\n" + tr("Aborted."));
   }
 

--- a/qucs/dialogs/sweepdialog.cpp
+++ b/qucs/dialogs/sweepdialog.cpp
@@ -45,7 +45,6 @@ mySpinBox::mySpinBox(int Min, int Max, int Step, double *Val, QWidget *Parent)
 }
 
 
-#include <iostream>
 using namespace std;
 QString mySpinBox::textFromValue(int Val) const
 {

--- a/qucs/dialogs/tuner.cpp
+++ b/qucs/dialogs/tuner.cpp
@@ -125,7 +125,7 @@ tunerElement::tunerElement(QWidget *parent, Component *component, Property *pp, 
         //If one of the keywords appears in the description text, then the key of the map
         //is used as unit...
         bool found = false;
-        for(auto e : Keywords.keys())
+        for(const auto &e : Keywords.keys())
         {
           for (int i = 0; i < Keywords[e].length(); i++)
           {

--- a/qucs/dialogs/tuner.cpp
+++ b/qucs/dialogs/tuner.cpp
@@ -53,7 +53,7 @@ bool isPropertyTunable(Component* propertyOwner, Property* property) {
     return false; // String
   }
   // Check if the value contains symbols *, /, -, +
-  for (const auto& chr : property->Value) {
+  for (const auto& chr : std::as_const(property->Value)) {
     if (!chr.isLetterOrNumber() && (chr != '.') && (chr != ' ')) {
       return false;
     }

--- a/qucs/dialogs/tuner.cpp
+++ b/qucs/dialogs/tuner.cpp
@@ -95,7 +95,7 @@ tunerElement::tunerElement(QWidget *parent, Component *component, Property *pp, 
         if (val.at(i).isLetter())
         {
             units_index = i;//Select index
-            numValue = val.mid(0, i).toFloat();//Get the magnitude
+            numValue = QStringView(val).mid(0, i).toFloat();//Get the magnitude
             break;
         }
     }

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -208,7 +208,7 @@ void AbstractSpiceKernel::startNetlist(QTextStream &stream, spicecompat::SpiceDi
                 else continue;
                 QString ic = pw->label()->initValue;
                 if (!ic.isEmpty()) {
-                    QString ic_str = QStringLiteral(".IC v(%1)=%2\n").arg(label).arg(ic);
+                    QString ic_str = QStringLiteral(".IC v(%1)=%2\n").arg(label, ic);
                     stream<<ic_str;
                 }
             }
@@ -221,7 +221,7 @@ void AbstractSpiceKernel::startNetlist(QTextStream &stream, spicecompat::SpiceDi
                 else continue;
                 QString ic = pw->label()->initValue;
                 if (!ic.isEmpty()) {
-                    QString ic_str = QStringLiteral(".IC v(%1)=%2\n").arg(label).arg(ic);
+                    QString ic_str = QStringLiteral(".IC v(%1)=%2\n").arg(label, ic);
                     stream<<ic_str;
                 }
             }
@@ -1504,13 +1504,13 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
                 }
                 if (var_list.contains(var2)) {
                   // it is digtial variable
-                  ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var).arg(var2);
+                  ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var, var2);
                 } else {
                   // it is scalar
                   if (hasParSweep) {
-                    ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var).arg(swp_var);
+                    ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var, swp_var);
                   } else {
-                    ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(var).arg(var_length);
+                    ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(var, var_length);
                     is_scalar = true;
                   }
                 }
@@ -1519,7 +1519,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
                 extra_indep = true;
                 ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(var).arg(var_length);
               } else {
-                ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var_list.at(i)).arg(indep);
+                ds_stream<<QStringLiteral("<dep %1 %2>\n").arg(var_list.at(i), indep);
               }
             }
 

--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -400,7 +400,7 @@ QSet<QString> AbstractSpiceKernel::getActiveLabelledNets(spicecompat::SpiceDiale
         if (pc->isProbe && pc->isActive == COMP_IS_ACTIVE) {
             activeNets.insert(pc->getProbeVariable(dialect));
         }
-        for (Port *pp : pc->Ports) {
+        for (Port *pp : std::as_const(pc->Ports)) {
             insertNodeLabels(activeNets, pp->Connection);
         }
     }
@@ -424,7 +424,7 @@ QSet<QString> AbstractSpiceKernel::getValidNets(spicecompat::SpiceDialect dialec
     // log every discarded net for easier debug
     if (!discardedNets.empty()) {
         qDebug() << "Netlisting: filtering" << discardedNets.size() << "net(s) attached to disabled components.";
-        for (const QString &name : discardedNets) {
+        for (const QString &name : std::as_const(discardedNets)) {
             qDebug() << "    " << name;
         }
     }
@@ -560,7 +560,7 @@ void AbstractSpiceKernel::parseHBOutput(QString ngspice_file, QList<QList<double
                     vars1.removeFirst();
                     vars1.removeFirst();
                     QStringList norm_vars;
-                    for (const QString& v : vars1) { // Normalize variables
+                    for (const QString& v : std::as_const(vars1)) { // Normalize variables
                         QString nv = v;
                         nv.remove(0,3).chop(1); // extract variable between "Re|Im(" and ")"
                         if (!norm_vars.contains(nv))
@@ -616,7 +616,7 @@ void AbstractSpiceKernel::parseFourierOutput(QString ngspice_file, QList<QList<d
             if (lin.contains("Fourier analysis for")) {
                 QStringList tokens = lin.split(sep,Qt::SkipEmptyParts);
                 QString var; // TODO chech
-                for (const QString& var1 : tokens) {
+                for (const QString& var1 : std::as_const(tokens)) {
                     if (var1.contains('(')&&var1.contains(')')) {
                         var = var1;
                         break;
@@ -730,7 +730,7 @@ void AbstractSpiceKernel::parsePZOutput(QString ngspice_file, QList<QList<double
 
         if (lines.count("PZ analysis")>1) ParSwp = true;
 
-        for (const QString& lin : lines) {  // Extract poles
+        for (const QString& lin : std::as_const(lines)) {  // Extract poles
             if (lin.contains(var + "(")) {
                 if (!var_list.contains(var)) {
                     var_list.append(var+"_number");
@@ -806,7 +806,7 @@ void AbstractSpiceKernel::parseDC_OPoutput(QString ngspice_file)
     if (ofile.open(QFile::ReadOnly)) {
         QTextStream ngsp_data(&ofile);
         QStringList lines = ngsp_data.readAll().split("\n");
-        for (const QString& lin : lines) {
+        for (const QString& lin : std::as_const(lines)) {
             if (lin.contains('=')) {
                 QString nod = lin.section('=',0,0).remove(' ');
                 double val = lin.section('=',1,1).toDouble();
@@ -1300,7 +1300,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
 {
     if (a_DC_OP_only) { // Don't touch existing datasets when only DC was simulated
         // It's need to show DC bias on schematic only
-        for (const QString& outputfile : a_output_files) {
+        for (const QString& outputfile : std::as_const(a_output_files)) {
             QString full_outfile = a_workdir+QDir::separator()+outputfile;
             if (outputfile.endsWith(".dc_op")) {
                 parseDC_OPoutput(full_outfile);
@@ -1319,7 +1319,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
     QString sim,indep;
     QStringList indep_vars;
 
-    for (const QString& ngspice_output_filename : a_output_files) { // For every simulation convert results to Qucs dataset
+    for (const QString& ngspice_output_filename : std::as_const(a_output_files)) { // For every simulation convert results to Qucs dataset
         QList< QList<double> > sim_points;
         QStringList var_list, extra_vars;
         QString swp_var,swp_var2;
@@ -1454,7 +1454,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             }
 
             ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(swp_var).arg(swp_var_val.count());
-            for (const QString& val : swp_var_val) {
+            for (const QString& val : std::as_const(swp_var_val)) {
                 ds_stream<<val<<"\n";
             }
             ds_stream<<"</indep>\n";
@@ -1462,7 +1462,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
             else indep += " " + swp_var;
             if (hasDblParSweep) {
                 ds_stream<<QStringLiteral("<indep %1 %2>\n").arg(swp_var2).arg(swp_var2_val.count());
-                for (const QString& val : swp_var2_val) {
+                for (const QString& val : std::as_const(swp_var2_val)) {
                     ds_stream<<val<<"\n";
                 }
                 ds_stream<<"</indep>\n";
@@ -1583,7 +1583,7 @@ void AbstractSpiceKernel::convertToQucsData(const QString &qucs_dataset)
  */
 void AbstractSpiceKernel::removeAllSimulatorOutputs()
 {
-    for (const QString& output_filename : a_output_files) {
+    for (const QString& output_filename : std::as_const(a_output_files)) {
         QString full_outfile = a_workdir+QDir::separator()+output_filename;
         QFile::remove(full_outfile);
     }
@@ -1795,7 +1795,7 @@ QStringList AbstractSpiceKernel::collectSpiceLibraryFiles(Schematic *sch)
     } else {
       new_libs = pc->getSpiceLibraryFiles();
     }
-    for (const auto&lib: new_libs) {
+    for (const auto&lib: std::as_const(new_libs)) {
       if (!collected_spicelib.contains(lib)) {
         collected_spicelib.append(lib);
       }

--- a/qucs/extsimkernels/customsimdialog.cpp
+++ b/qucs/extsimkernels/customsimdialog.cpp
@@ -196,7 +196,7 @@ void CustomSimDialog::slotFindVars()
     QStringList strings = a_edtCode->toPlainText().split('\n');
     QRegularExpression let_pattern("^\\s*let\\s+[A-Za-z].*=.+");
 
-    for (const QString& line : strings) {
+    for (const QString& line : std::as_const(strings)) {
         if (let_pattern.match(line).hasMatch()) {
             QString var = line.section('=',0,0);
             var.remove("let ");
@@ -216,7 +216,7 @@ void CustomSimDialog::slotFindOutputs()
     if (a_isXyceScr) {
         QRegularExpression print_ex("^\\s*\\.print\\s.*", QRegularExpression::CaseInsensitiveOption);
         QRegularExpression file_ex("\\s*file\\s*=\\s*", QRegularExpression::CaseInsensitiveOption);
-        for (const QString& line : strings) {
+        for (const QString& line : std::as_const(strings)) {
             if (print_ex.match(line).hasMatch()) {
                 //file_ex.setCaseSensitivity(Qt::CaseInsensitive);
                 int p = line.indexOf(file_ex);
@@ -232,7 +232,7 @@ void CustomSimDialog::slotFindOutputs()
         write_ex.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
         QRegularExpression print_rx("^\\s*print\\s.*>.+");
         print_rx.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
-        for (const QString& line : strings) {
+        for (const QString& line : std::as_const(strings)) {
             if (write_ex.match(line).hasMatch()) {
                 outp = line.section(QRegularExpression("\\s"),1,1,QString::SectionSkipEmpty);
                 if ( !outp.isEmpty() ) if ( !outps.contains(outp) ) outps.append(outp);

--- a/qucs/extsimkernels/externsimdialog.cpp
+++ b/qucs/extsimkernels/externsimdialog.cpp
@@ -379,7 +379,7 @@ bool ExternSimDialog::logContainsError(const QString &out)
     default: err_patterns<<"error";
         break;
     }
-    for(const auto &err_str: err_patterns) {
+    for(const auto &err_str: std::as_const(err_patterns)) {
         if (out.contains(err_str)) {
             found = true;
             break;
@@ -404,7 +404,7 @@ bool ExternSimDialog::logContainsWarning(const QString &out)
     default: warn_patterns<<"warning";
         break;
     }
-    for(const auto &warn_str: warn_patterns) {
+    for(const auto &warn_str: std::as_const(warn_patterns)) {
         if (out.contains(warn_str)) {
             found = true;
             break;

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -316,7 +316,7 @@ void Ngspice::createNetlist(
 
         if ( sim_typ == ".DC" ) {
             QString out = "spice4qucs." + sim_name + ".ngspice.dc.print";
-            spiceNetlist.append(QStringLiteral("print %1 > %2\n").arg(nods).arg(out));
+            spiceNetlist.append(QStringLiteral("print %1 > %2\n").arg(nods, out));
             outputs.append(out);
         } 
         else if (sim_typ == ".NOISE") {
@@ -325,13 +325,13 @@ void Ngspice::createNetlist(
                 QString basenam = "spice4qucs";
                 QString filename;
                 if ( hasParSWP && hasDblSWP )
-                    filename = QStringLiteral("%1.%2._swp_swp.raw").arg(basenam).arg(sim_name);
+                    filename = QStringLiteral("%1.%2._swp_swp.raw").arg(basenam, sim_name);
                 else if ( hasParSWP )
-                    filename = QStringLiteral("%1.%2._swp.raw").arg(basenam).arg(sim_name);
+                    filename = QStringLiteral("%1.%2._swp.raw").arg(basenam, sim_name);
                 else
-                    filename = QStringLiteral("%1.%2.raw").arg(basenam).arg(sim_name);
+                    filename = QStringLiteral("%1.%2.raw").arg(basenam, sim_name);
                 filename.replace(' ', '_'); // Ngspice cannot understand spaces in filename
-                spiceNetlist.append(QStringLiteral("write %1 %2\n").arg(filename).arg(nods));
+                spiceNetlist.append(QStringLiteral("write %1 %2\n").arg(filename, nods));
                 outputs.append(filename);
             }
         }
@@ -341,13 +341,13 @@ void Ngspice::createNetlist(
                 QString basenam = "spice4qucs";
                 QString filename;
                 if ( hasParSWP && hasDblSWP )
-                    filename = QStringLiteral("%1.%2._swp_swp.plot").arg(basenam).arg(sim_name);
+                    filename = QStringLiteral("%1.%2._swp_swp.plot").arg(basenam, sim_name);
                 else if ( hasParSWP )
-                    filename = QStringLiteral("%1.%2._swp.plot").arg(basenam).arg(sim_name);
+                    filename = QStringLiteral("%1.%2._swp.plot").arg(basenam, sim_name);
                 else
-                    filename = QStringLiteral("%1.%2.plot").arg(basenam).arg(sim_name);
+                    filename = QStringLiteral("%1.%2.plot").arg(basenam, sim_name);
                 filename.replace(' ', '_'); // Ngspice cannot understand spaces in filename
-                spiceNetlist.append(QStringLiteral("write %1 %2\n").arg(filename).arg(nods));
+                spiceNetlist.append(QStringLiteral("write %1 %2\n").arg(filename, nods));
                 outputs.append(filename);
             }
         }

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -17,13 +17,10 @@
 
 
 #include "ngspice.h"
-#include "components/iprobe.h"
-#include "components/vprobe.h"
 #include "components/equation.h"
 #include "components/param_sweep.h"
 #include "components/subcircuit.h"
 #include "spicecomponents/sp_spiceinit.h"
-#include "spicecomponents/xsp_cmlib.h"
 #include "main.h"
 #include "misc.h"
 #include "qucs.h"

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -121,7 +121,7 @@ void Ngspice::createNetlist(
             QStringList osdi_ext;
             osdi_ext<<"*.osdi";
             QStringList osdi_files = QucsSettings.QucsWorkDir.entryList(osdi_ext,QDir::Files);
-            for(const auto &file : osdi_files) {
+            for(const auto &file : std::as_const(osdi_files)) {
                 QString abs_file = QucsSettings.QucsWorkDir.absolutePath() +
                         QDir::separator() + file;
                 stream<<QStringLiteral("pre_osdi '%1'\n").arg(abs_file);
@@ -164,7 +164,7 @@ void Ngspice::createNetlist(
         }
 
         QString nods;
-        for (const QString& nod : vars) {
+        for (const QString& nod : std::as_const(vars)) {
             if ( nod.endsWith("#branch") )
                 nods.append(QStringLiteral("i(%1) ").arg(nod.section('#', 0, 0)));
             else
@@ -227,7 +227,7 @@ void Ngspice::createNetlist(
             QRegularExpression pz_rx("^\\s*pz\\s.*", QRegularExpression::CaseInsensitiveOption);
 
             QStringList lines = pc->getSpiceNetlist().split('\n');
-            for ( const QString& line : lines ) {
+            for ( const QString& line : std::as_const(lines) ) {
                 if      ( ac_rx.match(line).hasMatch() )      freqSims++ ;
                 else if ( sp_rx.match(line).hasMatch() )      freqSims++ ;
                 else if ( noise_rx.match(line).hasMatch() )   freqSims++ ;

--- a/qucs/extsimkernels/ngspice.cpp
+++ b/qucs/extsimkernels/ngspice.cpp
@@ -581,7 +581,7 @@ void Ngspice::slotProcessOutput()
     QString s = a_simProcess->readAllStandardOutput();
     QRegularExpression percentage_pattern("^%\\d\\d*\\.\\d\\d.*$");
     if (percentage_pattern.match(s).hasMatch()) {
-        int percent = round(s.mid(1,5).toFloat());
+        int percent = round(QStringView(s).mid(1,5).toFloat());
         emit progress(percent);
     }
     a_output += s;

--- a/qucs/extsimkernels/qucs2spice.cpp
+++ b/qucs/extsimkernels/qucs2spice.cpp
@@ -154,10 +154,10 @@ QString qucs2spice::convert_diode(QString line,bool /*xyce*/)
     name =  name.right(name.size()-idx-1); // name
     QString K = lst.takeFirst();
     QString A = lst.takeFirst();
-    s += QStringLiteral("D%1 %2 %3 DMOD_%4 \n").arg(name).arg(A).arg(K).arg(name);
+    s += QStringLiteral("D%1 %2 %3 DMOD_%4 \n").arg(name, A, K, name);
     QString mod_params = lst.join(" ");
     mod_params.remove('\"');
-    s += QStringLiteral(".MODEL DMOD_%1 D(%2) \n").arg(name).arg(mod_params);
+    s += QStringLiteral(".MODEL DMOD_%1 D(%2) \n").arg(name, mod_params);
     return s;
 }
 
@@ -194,11 +194,10 @@ QString qucs2spice::convert_mosfet(QString line, bool xyce)
             par_lst.append(s1); // usual parameter
         }
     }
-    s += QStringLiteral("M%1 %2 %3 %4 %5 MMOD_%6 %7 %8 \n").arg(name).arg(D).arg(G).arg(S).arg(Sub)
-            .arg(name).arg(L).arg(W);
+    s += QStringLiteral("M%1 %2 %3 %4 %5 MMOD_%6 %7 %8 \n").arg(name, D, G, S, Sub, name, L, W);
     QString mod_params = par_lst.join(" ");
     mod_params.remove('\"');
-    s += QStringLiteral(".MODEL MMOD_%1 %2(%3) \n").arg(name).arg(Typ).arg(mod_params);
+    s += QStringLiteral(".MODEL MMOD_%1 %2(%3) \n").arg(name, Typ, mod_params);
     if (xyce) s.replace("Vt0=","VtO=");
     return s;
 }
@@ -226,10 +225,10 @@ QString qucs2spice::convert_jfet(const QString& line, bool xyce)
             par_lst.append(s1); // usual parameter
         }
     }
-    s += QStringLiteral("J%1 %2 %3 %4 JMOD_%5 \n").arg(name).arg(D).arg(G).arg(S).arg(name);
+    s += QStringLiteral("J%1 %2 %3 %4 JMOD_%5 \n").arg(name, D, G, S, name);
     QString mod_params = par_lst.join(" ");
     mod_params.remove('\"');
-    s += QStringLiteral(".MODEL JMOD_%1 %2(%3) \n").arg(name).arg(Typ).arg(mod_params);
+    s += QStringLiteral(".MODEL JMOD_%1 %2(%3) \n").arg(name, Typ, mod_params);
     if (xyce) s.replace(" Vt0="," VtO=");
     return s;
 }
@@ -268,10 +267,10 @@ QString qucs2spice::convert_bjt(const QString& line)
             if (!is_incompat) par_lst.append(s1); // usual parameter
         }
     }
-    s += QStringLiteral("Q%1 %2 %3 %4 %5 QMOD_%6 \n").arg(name).arg(C).arg(B).arg(E).arg(Sub).arg(name);
+    s += QStringLiteral("Q%1 %2 %3 %4 %5 QMOD_%6 \n").arg(name, C, B, E, Sub, name);
     QString mod_params = par_lst.join(" ");
     mod_params.remove('\"');
-    s += QStringLiteral(".MODEL QMOD_%1 %2(%3) \n").arg(name).arg(Typ).arg(mod_params);
+    s += QStringLiteral(".MODEL QMOD_%1 %2(%3) \n").arg(name, Typ, mod_params);
     return s;
 }
 
@@ -302,8 +301,8 @@ QString qucs2spice::convert_ccs(const QString& line, bool voltage)
     QString s;
     if (voltage) s="H";
     else s="F";
-    s += QStringLiteral("%1 %2 %3 V%4 %5\n").arg(name).arg(nod1).arg(nod2).arg(name).arg(val); // output source nodes
-    s += QStringLiteral("V%1 %2 %3 DC 0\n").arg(name).arg(nod0).arg(nod3);   // controlling 0V source
+    s += QStringLiteral("%1 %2 %3 V%4 %5\n").arg(name, nod1, nod2, name,val); // output source nodes
+    s += QStringLiteral("V%1 %2 %3 DC 0\n").arg(name, nod0, nod3);   // controlling 0V source
     return s;
 }
 
@@ -335,7 +334,7 @@ QString qucs2spice::convert_vcs(const QString& line,bool voltage)
     QString s;
     if (voltage) s="E";
     else s="G";
-    s += QStringLiteral("%1 %2 %3 %4 %5 %6\n").arg(name).arg(nod1).arg(nod2).arg(nod0).arg(nod3).arg(val);
+    s += QStringLiteral("%1 %2 %3 %4 %5 %6\n").arg(name, nod1, nod2, nod0, nod3, val);
     return s;
 }
 
@@ -382,16 +381,16 @@ QString qucs2spice::convert_edd(const QString& line, QStringList &EqnsAndVars)
         QString plus = nods.at(2*i+1);
         QString minus = nods.at(2*i);
 
-        s += QStringLiteral("BI%1_%2 %3 %4 I=%5\n").arg(nam).arg(i).arg(plus).arg(minus).arg(Itokens.join(""));
+        s += QStringLiteral("BI%1_%2 %3 %4 I=%5\n").arg(nam).arg(i).arg(plus, minus, Itokens.join(""));
         // charge part
         QString Qvar = line.section('"',2*i+3,2*i+3,QString::SectionSkipEmpty);
         QString Qeqn = EqnsAndVars.at(EqnsAndVars.indexOf(Qvar)+1);
         Qeqn.remove(' ');
         QRegularExpression zero_pattern("0+(\\.*0+|)");
         if (!zero_pattern.match(Qeqn).hasMatch()) {
-            s += QStringLiteral("G%1Q%2 %3 %4 n%1Q%2 %4 1.0\n").arg(nam).arg(i).arg(plus).arg(minus);
+            s += QStringLiteral("G%1Q%2 %3 %4 n%1Q%2 %4 1.0\n").arg(nam).arg(i).arg(plus, minus);
             s += QStringLiteral("L%1Q%2 n%1Q%2 %3 1.0\n").arg(nam).arg(i).arg(minus);
-            s += QStringLiteral("B%1Q%2 n%1Q%2 %3 I=-(%4)\n").arg(nam).arg(i).arg(minus).arg(Qeqn);
+            s += QStringLiteral("B%1Q%2 n%1Q%2 %3 I=-(%4)\n").arg(nam).arg(i).arg(minus, Qeqn);
         }
     }
 
@@ -426,7 +425,7 @@ QString qucs2spice::convert_subckt(QString line)
         it++;
         QString val = (*it);
         val.remove(' ');
-        s += QStringLiteral("%1=%2 ").arg(var).arg(val);
+        s += QStringLiteral("%1=%2 ").arg(var, val);
     }
     s += '\n';
 
@@ -444,8 +443,8 @@ QString qucs2spice::convert_gyrator(QString line)
     QString n3 = lst.takeFirst();
     QString n4 = lst.takeFirst();
     QString R = line.section('"',1,1);
-    s +=  QStringLiteral("B%1_1 %2 %3 I=(1/(%4))*(V(%5)-V(%6))\n").arg(Name).arg(n1).arg(n4).arg(R).arg(n2).arg(n3);
-    s +=  QStringLiteral("B%1_2 %2 %3 I=-1.0*(1/(%4))*(V(%5)-V(%6))\n").arg(Name).arg(n2).arg(n3).arg(R).arg(n1).arg(n4);
+    s +=  QStringLiteral("B%1_1 %2 %3 I=(1/(%4))*(V(%5)-V(%6))\n").arg(Name, n1, n4, R, n2, n3);
+    s +=  QStringLiteral("B%1_2 %2 %3 I=-1.0*(1/(%4))*(V(%5)-V(%6))\n").arg(Name, n2, n3, R, n1, n4);
     return s;
 }
 
@@ -485,7 +484,7 @@ void qucs2spice::subsVoltages(QStringList &tokens, QStringList& nods)
             QString minus = nods.at(2*(i-1));
             //if (plus=="gnd") plus="0";
             //if (minus=="gnd") minus="0";
-            *it = QStringLiteral("(V(%1)-V(%2))").arg(plus).arg(minus);
+            *it = QStringLiteral("(V(%1)-V(%2))").arg(plus, minus);
         }
     }
 }

--- a/qucs/extsimkernels/qucs2spice.cpp
+++ b/qucs/extsimkernels/qucs2spice.cpp
@@ -82,7 +82,7 @@ QString qucs2spice::convert_netlist(QString netlist, bool xyce)
 
     QStringList EqnsAndVars;
 
-    for (QString line : net_lst) {  // Find equations
+    for (QString line : std::as_const(net_lst)) {  // Find equations
         if (eqn_pattern.match(line).hasMatch()) {
             line.remove(QRegularExpression("^[ \t]*Eqn:[A-Za-z]+\\w+\\s+"));
             ExtractVarsAndValues(line,EqnsAndVars);
@@ -258,7 +258,7 @@ QString qucs2spice::convert_bjt(const QString& line)
             Typ = "PNP";
         } else {
             bool is_incompat = false;
-            for (const QString& incompat : spice_incompat) {
+            for (const QString& incompat : std::as_const(spice_incompat)) {
                if (s1.startsWith(incompat)) {
                    is_incompat = true;
                    break;
@@ -360,7 +360,7 @@ QString qucs2spice::convert_edd(const QString& line, QStringList &EqnsAndVars)
     QStringList nods;
     QString nam = lst.takeFirst().remove(':');
 
-    for (const QString& str : lst) {
+    for (const QString& str : std::as_const(lst)) {
         if (!str.contains('=')) {
             //str.replace("gnd","0");
             nods.append(str);

--- a/qucs/extsimkernels/qucs2spice.cpp
+++ b/qucs/extsimkernels/qucs2spice.cpp
@@ -20,9 +20,6 @@
 
 #include "qucs2spice.h"
 #include "spicecompat.h"
-#include "components/equation.h"
-
-#include "misc.h"
 
 /*!
   \file qucs2spice.cpp

--- a/qucs/extsimkernels/qucs2spice.cpp
+++ b/qucs/extsimkernels/qucs2spice.cpp
@@ -148,7 +148,7 @@ QString qucs2spice::convert_header(QString line)
     return s;
 }
 
-QString qucs2spice::convert_diode(QString line,bool xyce)
+QString qucs2spice::convert_diode(QString line,bool /*xyce*/)
 {
     QString s="";
     QStringList lst = line.split(" ", Qt::SkipEmptyParts);

--- a/qucs/extsimkernels/s2spice.cpp
+++ b/qucs/extsimkernels/s2spice.cpp
@@ -21,7 +21,6 @@
 #include <QtCore>
 #include <cmath>
 
-#include "misc.h"
 #include "s2spice.h"
 #include "main.h"
 

--- a/qucs/extsimkernels/s2spice.cpp
+++ b/qucs/extsimkernels/s2spice.cpp
@@ -62,7 +62,7 @@ bool S2Spice::convertTouchstone(QTextStream *stream)
 
     /* Find number of ports */
     QFileInfo inf(a_file);
-    ports = inf.suffix().mid(1,1).toInt();
+    ports = QStringView(inf.suffix()).mid(1,1).toInt();
     if ( (ports < 1) || (ports > MAXPORTS) ) {
         a_err_text = "Invalid port number in file: " + a_file + "\n";
         return false;

--- a/qucs/extsimkernels/spicecompat.cpp
+++ b/qucs/extsimkernels/spicecompat.cpp
@@ -1,6 +1,5 @@
 #include "spicecompat.h"
 #include "main.h"
-#include "misc.h"
 
 #include <QDebug>
 #include <QRegularExpression>

--- a/qucs/extsimkernels/spicecompat.cpp
+++ b/qucs/extsimkernels/spicecompat.cpp
@@ -296,7 +296,7 @@ int spicecompat::getPins(const QString &file, const QString &compname, QStringLi
           if (lin.startsWith("+")) {
             lin.remove(0,1);
             QStringList pins = lin.split(QRegularExpression("[ \\t]"),Qt::SkipEmptyParts);
-            for(const auto &pin: pins) {
+            for(const auto &pin: std::as_const(pins)) {
               if (pin.toLower() == "params:") {
                 header_start = false;
                 break;
@@ -320,7 +320,7 @@ int spicecompat::getPins(const QString &file, const QString &compname, QStringLi
             header_start = true;
             lst2.removeFirst();
             lst2.removeFirst();
-            for (const auto &s1: lst2) {
+            for (const auto &s1: std::as_const(lst2)) {
                 QString pp = s1;
                 if (pp.toLower() == "params:") header_start = false;
                 if (!s1.contains('=') &&
@@ -349,7 +349,7 @@ QString spicecompat::getSubcktName(const QString& subfilename)
         const QRegularExpression subckt_header("^\\s*\\.(S|s)(U|u)(B|b)(C|c)(K|k)(T|t)\\s.*");
         const QRegularExpression sep("\\s");
         QStringList lst = QString(sub_file.readAll()).split("\n");
-        for (const QString& str : lst) {
+        for (const QString& str : std::as_const(lst)) {
             if (subckt_header.match(str).hasMatch()) {
                 s = str.section(sep,1,1,QString::SectionSkipEmpty);
                 break;

--- a/qucs/extsimkernels/spicelibcompdialog.cpp
+++ b/qucs/extsimkernels/spicelibcompdialog.cpp
@@ -315,7 +315,7 @@ int SpiceLibCompDialog::parseLibFile(const QString &filename)
       if (line.startsWith("+")) {
         line.remove(0,1);
         QStringList pins = line.split(QRegularExpression("[ \\t]"),Qt::SkipEmptyParts);
-        for (const auto &s1: pins) {
+        for (const auto &s1: std::as_const(pins)) {
           if (s1 == "PARAMS:" || s1 == ".OPTIONAL:") {
             header_start = false;
           }
@@ -343,7 +343,7 @@ int SpiceLibCompDialog::parseLibFile(const QString &filename)
       } else continue;
       tokens.removeFirst();
       tokens.removeFirst();
-      for (const auto &s1: tokens) {
+      for (const auto &s1: std::as_const(tokens)) {
         if (s1 == "PARAMS:" || s1 == ".OPTIONAL:") {
           header_start = false;
         }
@@ -447,7 +447,7 @@ void SpiceLibCompDialog::slotTableCellDoubleClick()
   // Ports might not be in a linear range; use the actual indices directly
   // to ensure correct lookup
   QList<int> portIndices = a_symbol->getPortIndices();
-  for (int i : portIndices) {
+  for (int i : std::as_const(portIndices)) {
     bool pinAssigned = false;
     for(int j = 0; j < a_tbwPinsTable->rowCount(); j++) {
       if (j == r) continue;

--- a/qucs/extsimkernels/verilogawriter.cpp
+++ b/qucs/extsimkernels/verilogawriter.cpp
@@ -62,7 +62,7 @@ QString vacompat::normalize_voltage(QString &plus, QString &minus, bool left_sid
         if (left_side) s = QStringLiteral("V(%1)").arg(minus);
         else s = QStringLiteral("(-V(%1))").arg(minus);
     } else if (minus=="gnd") s = QStringLiteral("V(%1)").arg(plus);
-    else s = QStringLiteral("V(%1,%2)").arg(plus).arg(minus);
+    else s = QStringLiteral("V(%1,%2)").arg(plus, minus);
     return s;
 }
 
@@ -73,7 +73,7 @@ QString vacompat::normalize_current(QString &plus, QString &minus, bool left_sid
         if (left_side) s = QStringLiteral("I(%1)").arg(minus);
        else s = QStringLiteral("(-I(%1))").arg(minus);
     } else if (minus=="gnd") s = QStringLiteral("I(%1)").arg(plus);
-    else s = QStringLiteral("I(%1,%2)").arg(plus).arg(minus);
+    else s = QStringLiteral("I(%1,%2)").arg(plus, minus);
     return s;
 }
 
@@ -182,7 +182,7 @@ bool VerilogAwriter::createVA_module(QTextStream &stream, Schematic *sch)
     base.remove('-').remove(' ');
     nodes.removeAll("gnd"); // Exclude ground node
 
-    stream<<QStringLiteral("module %1(%2);\n").arg(base).arg(ports.join(", "));
+    stream<<QStringLiteral("module %1(%2);\n").arg(base, ports.join(", "));
     stream<<QStringLiteral("inout %1;\n").arg(ports.join(", "));
     stream<<QStringLiteral("electrical %1;\n").arg(nodes.join(", "));
 

--- a/qucs/extsimkernels/verilogawriter.cpp
+++ b/qucs/extsimkernels/verilogawriter.cpp
@@ -167,7 +167,7 @@ bool VerilogAwriter::createVA_module(QTextStream &stream, Schematic *sch)
             QString s = pc->Ports.first()->Connection->Name;
             if (!ports.contains(s)) ports.append(s);
         } else {
-            for (Port *pp : pc->Ports) { // Find all signals
+            for (Port *pp : std::as_const(pc->Ports)) { // Find all signals
                 QString s = pp->Connection->Name;
                 if (!nodes.contains(s)) nodes.append(s);
             }

--- a/qucs/extsimkernels/xyce.cpp
+++ b/qucs/extsimkernels/xyce.cpp
@@ -283,13 +283,13 @@ void Xyce::createNetlist(
     }
 
     QString filename;
-    if (hasParSweep) filename = QStringLiteral("%1.%2._swp.plot").arg(basenam).arg(sim);
-    else filename = QStringLiteral("%1.%2.plot").arg(basenam).arg(sim);
+    if (hasParSweep) filename = QStringLiteral("%1.%2._swp.plot").arg(basenam, sim);
+    else filename = QStringLiteral("%1.%2.plot").arg(basenam, sim);
     filename.remove(QRegularExpression("\\s")); // XYCE don't support spaces and quotes
     QString write_str;
     if (sim=="hb") {
         // write_str = QStringLiteral(".PRINT  %1 file=%2 %3\n").arg(sim).arg(filename).arg(nods);
-        write_str = QStringLiteral(".PRINT  %1 %2\n").arg(sim).arg(nods);
+        write_str = QStringLiteral(".PRINT  %1 %2\n").arg(sim, nods);
         outputs.append("spice4qucs.hb.cir.HB.FD.prn");
     } else if (sim=="noise") {
         filename += "_std";
@@ -315,7 +315,7 @@ void Xyce::createNetlist(
         write_str += "\n";
         outputs.append("spice4qucs_sparam.prn");
     } else {
-        write_str = QStringLiteral(".PRINT  %1 format=raw file=%2 %3\n").arg(sim).arg(filename).arg(nods);
+        write_str = QStringLiteral(".PRINT  %1 format=raw file=%2 %3\n").arg(sim, filename, nods);
         outputs.append(filename);
     }
     stream<<write_str;

--- a/qucs/extsimkernels/xyce.cpp
+++ b/qucs/extsimkernels/xyce.cpp
@@ -138,7 +138,7 @@ QSet<QString> Xyce::getActiveLabelledNets(spicecompat::SpiceDialect dialect/*=sp
         }
 
         // add every node name
-        for (Port *pp : pc->Ports) {
+        for (Port *pp : std::as_const(pc->Ports)) {
             Node *pn = pp->Connection;
             if (!pn || pn->Name == "gnd") continue;
             activeNets.insert(pn->Name);
@@ -305,7 +305,7 @@ void Xyce::createNetlist(
     } else if (sim=="sp") {
         write_str = ".PRINT ac format=std file=spice4qucs_sparam.prn ";
         if (hasParSweep) {
-            for (const auto &v: spar_vars) { // Bug in Xyce; cannot print Z-par if
+            for (const auto &v: std::as_const(spar_vars)) { // Bug in Xyce; cannot print Z-par if
                  // .STEP is activated; otherwise simulation error
                 if ( !v.startsWith("z(")) write_str += QStringLiteral("%1 ").arg(v);
             }
@@ -368,7 +368,7 @@ void Xyce::slotSimulate()
     QFile::remove(a_workdir+"spice4qucs.sens_tr.cir.SENS.prn");
     QFile::remove(a_workdir+"spice4qucs.sens_tr.cir.TRADJ.prn");
 
-    for (const QString& sim : a_simulationsQueue) {
+    for (const QString& sim : std::as_const(a_simulationsQueue)) {
         QStringList sim_lst;
         sim_lst.clear();
         sim_lst.append(sim);

--- a/qucs/healer.cpp
+++ b/qucs/healer.cpp
@@ -189,6 +189,7 @@ Node* GenericPort::node() const
     case PortType::Component:
       return m_port->Connection;
     }
+    return nullptr;
 }
 
 

--- a/qucs/healer.cpp
+++ b/qucs/healer.cpp
@@ -122,7 +122,7 @@ Node* GenericPort::replaceNodeWith(Node* new_node)
 
             // Ensure that only this and no other port of the component
             // is connected to the new node.
-            for (auto* p : m_comp->Ports) {
+            for (auto* p : std::as_const(m_comp->Ports)) {
                 if (p->Connection == new_node && p != m_port) {
                     p->Connection = nullptr;
                 }
@@ -327,7 +327,7 @@ Healer::HealerImpl::HealerImpl(const std::list<Component*>* components, const st
     , m_affectedCount{affected_count}
 {
     for (auto* comp : *components) {
-        for (auto* port : comp->Ports) {
+        for (auto* port : std::as_const(comp->Ports)) {
             m_port_groups[port->Connection].push_back(std::make_unique<GenericPort>(port, comp));
         }
     }

--- a/qucs/healer.cpp
+++ b/qucs/healer.cpp
@@ -445,7 +445,7 @@ vector<Healer::HealingAction> Healer::HealerImpl::processReshapingCase(Node* nod
     vector<HealingAction> actions;
     actions.push_back(make_unique<MoveNode>(node, *other_loc));
 
-    for (auto port : m_port_groups.at(node)) {
+    for (const auto &port : m_port_groups.at(node)) {
         if (port->center() == *other_loc) continue;
         actions.push_back(make_unique<MovePort>(port.get(), *other_loc));
     }
@@ -465,7 +465,7 @@ vector<Healer::HealingAction> Healer::HealerImpl::processGenericCase(Node* node,
         actions.push_back(make_unique<MoveNode>(node, node_loc));
     }
 
-    for (auto port : m_port_groups.at(node)) {
+    for (const auto &port : m_port_groups.at(node)) {
         if (port->center() == node_loc) continue;
 
         actions.push_back(make_unique<ReplaceNode>(port.get()));

--- a/qucs/healer.cpp
+++ b/qucs/healer.cpp
@@ -8,7 +8,6 @@
 
 #include <algorithm>
 #include <concepts>
-#include <limits>
 #include <memory>
 #include <ranges>
 #include <set>

--- a/qucs/magnetics/ja_core.cpp
+++ b/qucs/magnetics/ja_core.cpp
@@ -129,7 +129,7 @@ QString JA_core::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
   }
 
   QString s = "X_" + Name;
-  s += QString(" %1 %2 ja_core ").arg(h_node).arg(b_node);
+  s += QString(" %1 %2 ja_core ").arg(h_node, b_node);
   QString A = spicecompat::normalize_value(getProperty("A")->Value);
   QString K = spicecompat::normalize_value(getProperty("K")->Value);
   QString C = spicecompat::normalize_value(getProperty("C")->Value);
@@ -140,7 +140,7 @@ QString JA_core::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
   QString GAP = spicecompat::normalize_value(getProperty("GAP")->Value);
 
   s += QString("A=%1 K=%2 MS=%3 C=%4 alpha=%5 AREA=%6 PATH=%7 GAP=%8\n")
-           .arg(A).arg(K).arg(MS).arg(C).arg(alpha).arg(AREA).arg(PATH).arg(GAP);
+           .arg(A, K, MS, C, alpha, AREA, PATH, GAP);
 
   return s;
 }

--- a/qucs/magnetics/winding.cpp
+++ b/qucs/magnetics/winding.cpp
@@ -125,7 +125,7 @@ QString Winding::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
 
     s = "X_" + Name;
     s += QString(" %1 %2 %3 %4 winding N=%5 Rs=%6\n")
-             .arg(P1).arg(P2).arg(H_node).arg(B_node).arg(Nt).arg(Rs);
+             .arg(P1, P2, H_node, B_node, Nt, Rs);
     s += "\n";
 
     return s;

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -830,7 +830,7 @@ void createListComponentEntry(){
   Module::registerModules ();
   QStringList cats = Category::getCategories ();
   // table for quick reference, schematic and netlist entry
-  for (QString category: std::as_const(cats)) {
+  for (const QString &category: std::as_const(cats)) {
 
     QList<Module *> Comps;
     Comps = Category::getModules(category);

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -1037,7 +1037,7 @@ int main(int argc, char *argv[])
     setlocale (LC_NUMERIC, "C");
 
 #ifdef GIT
-    const QString applicationVersion(QString::fromUtf8("qucs s%1 (%2)").arg(PACKAGE_VERSION).arg(GIT));
+    const QString applicationVersion(QString::fromUtf8("qucs s%1 (%2)").arg(PACKAGE_VERSION, GIT));
 #else
     const QString applicationVersion(QString::fromUtf8("Qucs %1").arg(PACKAGE_VERSION));
 #endif

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -605,7 +605,7 @@ void createIcons() {
   Module::registerModules ();
   QStringList cats = Category::getCategories ();
 
-  for (const QString& category: cats) {
+  for (const QString& category: std::as_const(cats)) {
 
     QList<Module *> Comps;
     Comps = Category::getModules(category);
@@ -616,7 +616,7 @@ void createIcons() {
     char * File;
     QString Name;
 
-    for (Module *Mod: Comps) {
+    for (Module *Mod: std::as_const(Comps)) {
       if (Mod->info) {
 
         Element *e = (Mod->info) (Name, File, true);
@@ -739,7 +739,7 @@ void createDocData() {
   int nComps = 0;
 
   // table for quick reference, schematic and netlist entry
-  for (const QString& category: cats) {
+  for (const QString& category: std::as_const(cats)) {
 
     QList<Module *> Comps;
     Comps = Category::getModules(category);
@@ -759,7 +759,7 @@ void createDocData() {
 
     int num = 0; // component id inside category
 
-    for (Module *Mod: Comps) {
+    for (Module *Mod: std::as_const(Comps)) {
         num += 1;
 
         nComps += 1;
@@ -795,7 +795,7 @@ void createDocData() {
         QStringList compProps;
         compProps << "# Note: auto-generated file (changes will be lost on update)";
         compProps << QStringLiteral("# %1; %2; %3; %4").arg(  "Name", "Value", "Display", "Description");
-        for (Property *prop : c->Props) {
+        for (Property *prop : std::as_const(c->Props)) {
           compProps << QStringLiteral("%1; \"%2\"; %3; \"%4\"").arg(
                          prop->Name,
                          prop->Value,
@@ -830,7 +830,7 @@ void createListComponentEntry(){
   Module::registerModules ();
   QStringList cats = Category::getCategories ();
   // table for quick reference, schematic and netlist entry
-  for (QString category: cats) {
+  for (QString category: std::as_const(cats)) {
 
     QList<Module *> Comps;
     Comps = Category::getModules(category);
@@ -841,7 +841,7 @@ void createListComponentEntry(){
     char * File;
     QString Name;
 
-    for (Module *Mod: Comps) {
+    for (Module *Mod: std::as_const(Comps)) {
       Element *e = (Mod->info) (Name, File, true);
       Component *c = (Component* ) e;
 
@@ -850,7 +850,7 @@ void createListComponentEntry(){
 
       // add dummy ports/wires, avoid segfault
       int port = 0;
-      for (Port *p: c->Ports) {
+      for (Port *p: std::as_const(c->Ports)) {
         Node *n = new Node(0,0);
         n->Name="_net"+QString::number(port);
         p->Connection = n;

--- a/qucs/misc.cpp
+++ b/qucs/misc.cpp
@@ -212,7 +212,7 @@ void misc::str2num(const QString& s_, double& Number, QString& Unit, double& Fac
       i = j;
     }
 
-  Number = str.left(i).toDouble();
+  Number = QStringView(str).left(i).toDouble();
   Unit   = str.mid(i).trimmed();
   if(Unit.length()>0)
   {
@@ -299,7 +299,7 @@ void misc::convert2Unicode(QString& Text)
   unsigned short ch;
   while((i=Text.indexOf("\\x", i)) >= 0) {
     n = Text.mid(i, 6);
-    ch = n.mid(2).toUShort(&ok, 16);
+    ch = QStringView(n).mid(2).toUShort(&ok, 16);
     if(ok)  Text.replace(n, QChar(ch));
     i++;
   }

--- a/qucs/misc.cpp
+++ b/qucs/misc.cpp
@@ -346,7 +346,7 @@ QString misc::properAbsFileName(const QString& filename, Schematic* sch)
   fileInfo.setFile(QucsSettings.QucsWorkDir.filePath(fName));
   if ( fileInfo.exists() ) return fileInfo.canonicalFilePath();
 
-  for (const QString& path : qucsPathList) {
+  for (const QString& path : std::as_const(qucsPathList)) {
     fileInfo.setFile(QDir(path).filePath(fName));
     if ( fileInfo.exists() ) return fileInfo.canonicalFilePath();
   }
@@ -688,7 +688,7 @@ bool misc::simulatorExists(const QString &exe_file)
     QStringList paths;
     bool found = false;
     if (p != nullptr) paths = QString(p).split(':');
-    for (const auto &pp : paths) {
+    for (const auto &pp : std::as_const(paths)) {
         inf.setFile(pp + QDir::separator() + exe_file);
         if (inf.exists()) {
             found = true;
@@ -707,7 +707,7 @@ QString misc::unwrapExePath(const QString &exe_file)
     QStringList paths;
     QString abs_exe_path = exe_file;
     if (p != nullptr) paths = QString(p).split(':');
-    for (const auto &pp : paths) {
+    for (const auto &pp : std::as_const(paths)) {
         inf.setFile(pp + QDir::separator() + exe_file);
         if (inf.exists()) {
             abs_exe_path = inf.canonicalFilePath();
@@ -722,7 +722,7 @@ void misc::getSymbolPatternsList(QStringList &symbols)
   QString dir_name = QucsSettings.BinDir + "/../share/" QUCS_NAME "/symbols/";
   QDir sym_dir(dir_name);
   QStringList sym_files = sym_dir.entryList(QDir::Files);
-  for (const QString& file : sym_files) {
+  for (const QString& file : std::as_const(sym_files)) {
     QFileInfo inf(file);
     symbols.append(inf.baseName());
   }

--- a/qucs/mnemo.cpp
+++ b/qucs/mnemo.cpp
@@ -94,18 +94,18 @@ void encode_String(const QString &Input, QString &Output) {
 
   Output = "";
   while ((Begin = Input.indexOf('\\', Begin)) >= 0) {
-    Output += Input.mid(End, Begin - End);
+    Output += QStringView(Input).mid(End, Begin - End);
     End = Begin++;
 
     for (const auto &sc : SpecialChars) { // test all special characters
-      if (Input.mid(Begin).startsWith(sc.Mnemonic)) {
+      if (QStringView(Input).mid(Begin).startsWith(QLatin1String(sc.Mnemonic))) {
         Output += QChar(sc.Unicode);
         End = Begin + strlen(sc.Mnemonic);
         break;
       }
     }
   }
-  Output += Input.mid(End);
+  Output += QStringView(Input).mid(End);
 }
 
 // This function replaces the unicode of special characters

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -52,7 +52,6 @@
 #include <QMessageBox>
 #include <QMouseEvent>
 #include <QTextStream>
-#include <numeric>
 
 #include <climits>
 #include <cstdlib>

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1527,8 +1527,8 @@ void MouseActions::MReleaseResizeDiagram(Schematic *Doc, QMouseEvent *Event)
 
     Diagram *pd = (Diagram *) focusElement;
     pd->updateGraphData();
-    for (Graph *pg : pd->Graphs)
-        for (Marker *pm : pg->Markers) {
+    for (Graph *pg : std::as_const(pd->Graphs))
+        for (Marker *pm : std::as_const(pg->Markers)) {
             pm->x1 += MAx3; // correct changes due to move of diagram corner
             pm->y1 += MAy3;
         }

--- a/qucs/node.cpp
+++ b/qucs/node.cpp
@@ -97,7 +97,7 @@ bool Node::moveCenter(int dx, int dy) noexcept
     donor->m_wires.clear();
 
     for (auto* c : donor->components()) {
-        for (auto* p : c->Ports) {
+        for (auto* p : std::as_const(c->Ports)) {
             if (p->Connection == donor) {
                 p->Connection = this;
             }

--- a/qucs/paintings/ellipse.cpp
+++ b/qucs/paintings/ellipse.cpp
@@ -166,13 +166,12 @@ QString qucs::Ellipse::saveCpp()
 {
   QString b = filled ?
     QString (", QBrush (QColor (\"%1\"), %2)").
-    arg(brush.color().name()).arg(toBrushString(brush.style())) : "";
+    arg(brush.color().name(), toBrushString(brush.style())) : "";
   QString s =
     QString ("new Area (%1, %2, %3, %4, "
 	     "QPen (QColor (\"%5\"), %6, %7)%8)").
     arg(x1).arg(y1).arg(x2 - x1).arg(y2 - y1).
-    arg(pen.color().name()).arg(pen.width()).arg(toPenString(pen.style())).
-    arg(b);
+    arg(pen.color().name()).arg(pen.width()).arg(toPenString(pen.style()), b);
   s = "Ellips.append (" + s + ");";
   return s;
 }
@@ -181,14 +180,13 @@ QString qucs::Ellipse::saveJSON()
 {
   QString b = filled ?
     QString ("\"colorfill\" : \"%1\", \"stylefill\" : \"%2\"").
-    arg(brush.color().name()).arg(toBrushString(brush.style())) : "";
+    arg(brush.color().name(), toBrushString(brush.style())) : "";
   QString s =
     QStringLiteral("{\"type\" : \"ellipse\", "
     "\"x\" : %1, \"y\" : %2, \"w\" : %3, \"h\" : %4,"
     "\"color\" : \"%5\", \"thick\" : %6, \"style\" : \"%7\", %8},").
     arg(x1).arg(y1).arg(x2 - x1).arg(y2 - y1).
-    arg(pen.color().name()).arg(pen.width()).arg(toPenString(pen.style())).
-    arg(b);
+    arg(pen.color().name()).arg(pen.width()).arg(toPenString(pen.style()), b);
   return s;
 }
 

--- a/qucs/paintings/graphictext.cpp
+++ b/qucs/paintings/graphictext.cpp
@@ -138,8 +138,8 @@ QString GraphicText::saveCpp()
     QString s = QStringLiteral("new Text (%1, %2, \"%3\", QColor (\"%4\"), %5, %6, %7)")
                     .arg(x1)
                     .arg(y1)
-                    .arg(t)
-                    .arg(color.name())
+                    .arg(t,
+                    color.name())
                     .arg(font.pointSize())
                     .arg(cos(pi * angle / 180.0))
                     .arg(sin(pi * angle / 180.0));
@@ -157,8 +157,8 @@ QString GraphicText::saveJSON()
                         "\"color\" : \"%4\", \"size\" : %5, \"cos\" : %6, \"sin\" : %7},")
                     .arg(x1)
                     .arg(y1)
-                    .arg(t)
-                    .arg(color.name())
+                    .arg(t,
+                    color.name())
                     .arg(font.pointSize())
                     .arg(cos(pi * angle / 180.0))
                     .arg(sin(pi * angle / 180.0));

--- a/qucs/paintings/rectangle.cpp
+++ b/qucs/paintings/rectangle.cpp
@@ -165,13 +165,12 @@ QString qucs::Rectangle::saveCpp()
 {
   QString b = filled ?
     QString (", QBrush (QColor (\"%1\"), %2)").
-    arg(brush.color().name()).arg(toBrushString(brush.style())) : "";
+    arg(brush.color().name(), toBrushString(brush.style())) : "";
   QString s =
     QString ("new Area (%1, %2, %3, %4, "
 	     "QPen (QColor (\"%5\"), %6, %7)%8)").
     arg(x1).arg(y1).arg(x2 - x1).arg(y2 - y1).
-    arg(pen.color().name()).arg(pen.width()).arg(toPenString(pen.style())).
-    arg(b);
+    arg(pen.color().name()).arg(pen.width()).arg(toPenString(pen.style()), b);
   s = "Rects.append (" + s + ");";
   return s;
 }
@@ -180,15 +179,14 @@ QString qucs::Rectangle::saveJSON()
 {
   QString b = filled ?
     QString ("\"colorfill\" : \"%1\", \"stylefill\" : \"%2\"").
-    arg(brush.color().name()).arg(toBrushString(brush.style())) : "";
+    arg(brush.color().name(), toBrushString(brush.style())) : "";
 
   QString s =
     QStringLiteral("{\"type\" : \"rectangle\", "
       "\"x\" : %1, \"y\" : %2, \"w\" : %3, \"h\" : %4, "
       "\"color\" : \"%5\", \"thick\" : %6, \"style\" : \"%7\", %8},").
       arg(x1).arg(y1).arg(x2 - x1).arg(y2 - y1).
-      arg(pen.color().name()).arg(pen.width()).arg(toPenString(pen.style())).
-      arg(b);
+      arg(pen.color().name()).arg(pen.width()).arg(toPenString(pen.style()), b);
   return s;
 }
 

--- a/qucs/qt3_compat/q3scrollview.cpp
+++ b/qucs/qt3_compat/q3scrollview.cpp
@@ -249,7 +249,7 @@ void Q3ScrollViewData::hideOrShowAll(Q3ScrollView* sv, bool isScroll)
         clipped_viewport->move(nx,ny);
         clipped_viewport->update();
     }
-    for (QSVChildRec *r : children) {
+    for (QSVChildRec *r : std::as_const(children)) {
         r->hideOrShow(sv, clipped_viewport);
     }
 }
@@ -260,7 +260,7 @@ void Q3ScrollViewData::moveAllBy(int dx, int dy)
         clipped_viewport->move(clipped_viewport->x()+dx,
                                 clipped_viewport->y()+dy);
     } else {
-        for (QSVChildRec *r : children) {
+        for (QSVChildRec *r : std::as_const(children)) {
             r->child->move(r->child->x()+dx,r->child->y()+dy);
         }
         if (static_bg)
@@ -270,7 +270,7 @@ void Q3ScrollViewData::moveAllBy(int dx, int dy)
 
 bool Q3ScrollViewData::anyVisibleChildren()
 {
-    for (QSVChildRec *r : children) {
+    for (QSVChildRec *r : std::as_const(children)) {
         if (r->child->isVisible()) return true;
     }
     return false;

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -4043,7 +4043,7 @@ void QucsApp::runPostSimCommands(Schematic* sch)
     // Join multi-line commands into a single shell statement, skipping comments and blank lines
     QStringList lines = cmd.split('\n', Qt::SkipEmptyParts);
     QStringList filteredLines;
-    for (const QString& line : qAsConst(lines)) {
+    for (const QString& line : std::as_const(lines)) {
       QString trimmed = line.trimmed();
       if (trimmed.isEmpty() || trimmed.startsWith('#'))
         continue;

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -648,7 +648,7 @@ bool QucsApp::populateLibTreeFromDir(const QString &LibDirPath, QList<QTreeWidge
     QDir LibDir(LibDirPath);
     QStringList LibFiles = LibDir.entryList(QStringList("*.lib"), QDir::Files, QDir::Name);
     QStringList blacklist = getBlacklistedLibraries(QucsSettings.LibDir);
-    for (const QString& ss: blacklist) { // exclude blacklisted files
+    for (const QString& ss: std::as_const(blacklist)) { // exclude blacklisted files
         LibFiles.removeAll(ss);
     }
     // create top level library items, base on the library names
@@ -768,7 +768,7 @@ int QucsApp::fillComboBox(bool setAll) {
         CompChoose->insertItem(CompChoose->count(), QObject::tr("paintings"));
     } else {
         QStringList cats = Category::getCategories();
-        for (const QString &it: cats) {
+        for (const QString &it: std::as_const(cats)) {
             CompChoose->insertItem(CompChoose->count(), it);
         }
         idx = CompChoose->findText(currentText);
@@ -1003,7 +1003,7 @@ void QucsApp::slotSearchComponent(const QString &searchText)
 
     QStringList cats = Category::getCategories ();
     int catIdx = 0;
-    for (const QString& it : cats) {
+    for (const QString& it : std::as_const(cats)) {
       // this will go also over the "verilog-a user devices" category, if present
       //   but since modules there have no 'info' function it won't handle them
       Comps = Category::getModules(it);
@@ -1362,7 +1362,7 @@ void QucsApp::slotCMenuDelete()
 
          // We only want column 0 items (file names)
   QSet<QString> filesToDelete; // Use QSet to avoid duplicates
-  for (const QModelIndex &index : selected) {
+  for (const QModelIndex &index : std::as_const(selected)) {
     if (index.column() == 0 && index.parent().isValid()) {
       QString filename = index.sibling(index.row(), 0).data().toString();
       filesToDelete.insert(filename);
@@ -1887,7 +1887,7 @@ bool QucsApp::saveAs()
               << tr("Any File")+" (*)";
       Filter = Filters.join("");
       bool found = false;
-      for (const auto &ss: Filters) {
+      for (const auto &ss: std::as_const(Filters)) {
         if (ss.contains(file_ext)) {
           found = true;
           selfilter = ss;
@@ -2943,7 +2943,7 @@ void QucsApp::slotOpenContent(const QModelIndex &idx)
     QSet<QString> openedFiles; // To avoid opening duplicates
 
      // We only want column 0 items (file names)
-    for (const QModelIndex &index : selected) {
+    for (const QModelIndex &index : std::as_const(selected)) {
       if (index.column() == 0 && index.parent().isValid()) {
         QString filename = index.sibling(index.row(), 0).data().toString();
         QString note = index.sibling(index.row(), 1).data().toString();
@@ -4077,7 +4077,7 @@ void QucsApp::runPostSimCommands(Schematic* sch)
         terms = {"konsole", "gnome-terminal", "xfce4-terminal", "lxterminal", "xterm", "qterminal", "ptyxis"};
       }
       bool launched = false;
-      for (const QString& term : terms) {
+      for (const QString& term : std::as_const(terms)) {
         QString exe = QStandardPaths::findExecutable(term);
         if (exe.isEmpty()) {
           continue;

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -845,7 +845,7 @@ void QucsApp::slotShowLastNetlist() {
         QDir::toNativeSeparators(QucsSettings.S4Qworkdir + "/spice4qucs.cir"));
     break;
   case spicecompat::simXyce: // Xyce generates one netlist for every simulation
-    for (const auto &sim : sim_lst) {
+    for (const auto &sim : std::as_const(sim_lst)) {
       netlists.append(QDir::toNativeSeparators(QucsSettings.S4Qworkdir +
                                                "/spice4qucs." + sim + ".cir"));
     }

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -956,7 +956,7 @@ void QucsApp::launchTool(const QString &prog, const QString &progDesc,
 #endif
 
   // Validate if the file exists before attempting to execute
-  if (!QFileInfo(cmd).exists()) {
+  if (!QFileInfo::exists(cmd)) {
     QMessageBox::critical(
         this, tr("Error"),
         tr("Executable %1 not found! \n\n(%2)").arg(progDesc, cmd));

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -62,7 +62,6 @@
 #include "spicecomponents/sp_nutmeg.h"
 #include "textdoc.h"
 #include "wire.h"
-#include "wirelabel.h"
 
 #include "extsimkernels/xyce.h"
 

--- a/qucs/qucsdoc.h
+++ b/qucs/qucsdoc.h
@@ -20,6 +20,7 @@
 
 #include <QString>
 #include <QDateTime>
+#include <QMargins>
 
 class QucsApp;
 class QPrinter;
@@ -33,7 +34,7 @@ public:
   virtual void  setName(const QString&) {};
   virtual bool  load() { return true; };
   virtual int   save() { return 0; };
-  virtual void  print(QPrinter*, QPainter*, bool, bool) {};
+  virtual void print(QPrinter*, QPainter*, bool, bool, QMargins) {}
   virtual void  becomeCurrent(bool) {};
   virtual double zoomBy(double) { return 1.0; };
   virtual void  showAll() {};

--- a/qucs/qucslib_common.h
+++ b/qucs/qucslib_common.h
@@ -407,10 +407,10 @@ inline int parseSPICEComponentLibrary (QString libPath, ComponentLibrary &librar
             comp.name = lin.section(" ",1,1,QString::SectionSkipEmpty);
             // Form fake component definition
             comp.modelString = QStringLiteral("<SpLib X1 1 280 260 -29 -164 0 0 \"%1\" 0 \"%2\" 1 \"auto\" 1 \"%3\" 1>")
-                    .arg(filename).arg(comp.name).arg(pars);
+                    .arg(filename, comp.name, pars);
             comp.definition += QStringLiteral("<Component %1>\n").arg(comp.name);
             comp.definition += "<Description>\n";
-            comp.definition += QStringLiteral("%1 device from %2 library").arg(comp.name).arg(library.name);
+            comp.definition += QStringLiteral("%1 device from %2 library").arg(comp.name, library.name);
             comp.definition += "</Description>\n";
             comp.definition += "<Spice>\n";
             comp.definition += lin + "\n.ends\n";
@@ -454,8 +454,8 @@ inline int parseSPICEComponentLibrary (QString libPath, ComponentLibrary &librar
             QString visible = "1";
             for (const auto &p: mod_lines) {
                 if (lin_cnt>3) comp.modelString += QStringLiteral(" \"Line_%1=%2\" %3")
-                        .arg(lin_cnt+1).arg(p).arg(visible);
-                else comp.modelString += QStringLiteral(" \"%1\" %2").arg(p).arg(visible);
+                        .arg(lin_cnt+1).arg(p, visible);
+                else comp.modelString += QStringLiteral(" \"%1\" %2").arg(p, visible);
                 lin_cnt++;
                 visible = "0";
             }
@@ -466,7 +466,7 @@ inline int parseSPICEComponentLibrary (QString libPath, ComponentLibrary &librar
             comp.definition += QStringLiteral("%1 model from %2 library\n"
                                        "This component is model-only (.MODEL).\n"
                                        "No subcircuit definition!\n"
-                                       "Use appropriate device to attach this model.").arg(comp.name).arg(library.name);
+                                       "Use appropriate device to attach this model.").arg(comp.name, library.name);
             comp.definition += "</Description>\n";
             comp.definition += "<Spice>\n";
             comp.definition += mod_lines.join("\n");

--- a/qucs/qucsshortcutmanager.cpp
+++ b/qucs/qucsshortcutmanager.cpp
@@ -187,7 +187,7 @@ void QucsShortcutManager::removeShortcut(const QString &commandId) {
 }
 
 void QucsShortcutManager::resetToDefaults() {
-  for (const auto &cmd : qAsConst(m_commands)) {
+  for (const auto &cmd : std::as_const(m_commands)) {
     QKeySequence oldKey = cmd->currentKeySequence();
     cmd->resetToDefault();
     QKeySequence newKey = cmd->currentKeySequence();
@@ -202,7 +202,7 @@ void QucsShortcutManager::resetToDefaults() {
 void QucsShortcutManager::resetCategory(const QString &category) {
   QList<QucsCommand *> commands = commandsInCategory(category);
 
-  for (QucsCommand *cmd : qAsConst(commands)) {
+  for (QucsCommand *cmd : std::as_const(commands)) {
     QKeySequence oldKey = cmd->currentKeySequence();
     cmd->resetToDefault();
     QKeySequence newKey = cmd->currentKeySequence();
@@ -224,7 +224,7 @@ QucsShortcutManager::findConflicts(const QKeySequence &key) const {
 
   QList<QString> commandIds = m_shortcutIndex.values(key);
 
-  for (const QString &id : qAsConst(commandIds)) {
+  for (const QString &id : std::as_const(commandIds)) {
     if (QucsCommand *cmd = command(id)) {
       ShortcutConflict conflict;
       conflict.commandId = cmd->id();
@@ -247,7 +247,7 @@ bool QucsShortcutManager::hasConflict(const QKeySequence &key,
   // O(k) lookup
   QList<QString> commandIds = m_shortcutIndex.values(key);
 
-  for (const QString &id : qAsConst(commandIds)) {
+  for (const QString &id : std::as_const(commandIds)) {
     if (id != excludeCommandId) {
       return true;
     }

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -527,7 +527,7 @@ void Schematic::drawPostPaintEvents(QPainter* painter) {
    * Paint actions can only be called from within the paint event, so they
    * are put into a QList (PostedPaintEvents) and processed here
    */
-    for (auto p : a_PostedPaintEvents) {
+    for (auto p : std::as_const(a_PostedPaintEvents)) {
         QPen pen(Qt::black);
         painter->setPen(Qt::black);
         switch (p.pe) {
@@ -605,7 +605,7 @@ void Schematic::contentsMouseMoveEvent(QMouseEvent *Event)
         // TODO: Currently only rectangular diagrams are supported.
         if (diagram->getSelected(xpos, ypos) && diagram->Name == "Rect") {
             bool hasY1, hasY2 = false;
-            for (auto graph: diagram->Graphs) {
+            for (auto graph: std::as_const(diagram->Graphs)) {
                 hasY1 |= graph->yAxisNo == 0;
                 hasY2 |= graph->yAxisNo == 1;
             }
@@ -846,12 +846,12 @@ void Schematic::paintSchToViewpainter(QPainter* painter, bool printAll) {
         }
 
         // if graph or marker is selected, deselect during printing
-        for (Graph* pg : diagram->Graphs) {
+        for (Graph* pg : std::as_const(diagram->Graphs)) {
             if (pg->isSelected) {
                 pg->Type |= 1; // remember selection
             }
             pg->isSelected = false;
-            for (Marker* pm : pg->Markers) {
+            for (Marker* pm : std::as_const(pg->Markers)) {
                 if (pm->isSelected) {
                     pm->Type |= 1; // remember selection
                 }
@@ -861,12 +861,12 @@ void Schematic::paintSchToViewpainter(QPainter* painter, bool printAll) {
         draw_preserve_selection(diagram, painter);
 
         // revert selection of graphs and markers
-        for (Graph* pg : diagram->Graphs) {
+        for (Graph* pg : std::as_const(diagram->Graphs)) {
             if (pg->Type & 1) {
                 pg->isSelected = true;
             }
             pg->Type &= -2;
-            for (Marker* pm : pg->Markers) {
+            for (Marker* pm : std::as_const(pg->Markers)) {
                 if (pm->Type & 1) {
                     pm->isSelected = true;
                 }
@@ -1142,8 +1142,8 @@ void Schematic::updateAllBoundingRect()
     for (auto* pd : *a_Diagrams) {
         internal::unite(totalBounds, pd->boundingRect());
 
-        for (auto* pg : pd->Graphs)
-            for (auto* pm : pg->Markers) {
+      for (auto* pg : std::as_const(pd->Graphs))
+            for (auto* pm : std::as_const(pg->Markers)) {
                 internal::unite(totalBounds, pm->boundingRect());
             }
     }
@@ -1206,8 +1206,8 @@ Schematic::Selection Schematic::currentSelection() const {
             internal::unite(totalBounds, pd->boundingRect());
         }
 
-        for (Graph* pg : pd->Graphs) {
-            for (Marker* pm : pg->Markers) {
+        for (Graph* pg : std::as_const(pd->Graphs)) {
+            for (Marker* pm : std::as_const(pg->Markers)) {
                 if (!pm->isSelected) continue;
                 selection.markers.push_back(pm);
                 internal::unite(totalBounds, pm->boundingRect());
@@ -1250,7 +1250,7 @@ Schematic::Selection Schematic::elementsToSelection(const std::list<Element*> &e
             if (auto* pc = dynamic_cast<Component*>(element)) {
                 addElement(pc, selection.components);
                 // add all port nodes to ownedNodes set
-                for (auto* port : pc->Ports) {
+                for (auto* port : std::as_const(pc->Ports)) {
                     ownedNodes.emplace(port->Connection);
                 }
             } else if (auto* pw = dynamic_cast<Wire*>(element)) {
@@ -2043,7 +2043,7 @@ void Schematic::contentsDropEvent(QDropEvent *Event)
     bool changed = d->getDocChanged();
     d->setDocChanged(true);
 
-    for (const QUrl &url : urls) {
+    for (const QUrl &url : std::as_const(urls)) {
       QString filePath = QDir::toNativeSeparators(url.toLocalFile());
       QString lower = filePath.toLower();
 

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -116,7 +116,7 @@ public:
 
   void setName(const QString&);
   void setChanged(bool, bool fillStack=false, char Op='*');
-  void print(QPrinter*, QPainter*, bool printAll, bool fitToPage, QMargins margins={});
+  void print(QPrinter*, QPainter*, bool printAll, bool fitToPage, QMargins margins={}) override;
 
   void paintSchToViewpainter(QPainter* painter, bool printAll);
 

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -2415,7 +2415,6 @@ int Schematic::placeNodeLabel(WireLabel *pl)
 // labeled element.
 Element* Schematic::getWireLabel(Node *pn_)
 {
-    Wire *pw;
     Node *pNode;
     std::list<Node*> Cons;
 

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -1975,11 +1975,11 @@ void Schematic::insertComponentNodes(Component *component, bool noOptimize)
 
     // if component over wire then delete this wire
     QListIterator<Port *> iport(component->Ports);
-    // omit the first element
-    Port *component_port = iport.next();
+
+    iport.next(); // omit the first element
     std::vector<Wire*> dead_wires;
     while (iport.hasNext()) {
-        component_port = iport.next();
+        Port *component_port = iport.next();
 
         // At first iterate over all port's connections to find wires
         // connecting this port to another port of the same component.

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -2254,7 +2254,7 @@ void Schematic::detachComp(Component *c, bool remove_orphans, bool keepNodeLabel
     auto compStatus = disconnectComp(c, remove_orphans, keepNodeLabel);
 
     // loop over all ports, and delete if orphan
-    for (size_t i = 0; i < c->Ports.size(); ++i) {
+    for (auto i = 0; i < c->Ports.size(); ++i) {
         if (compStatus.ports[i].removed) {
             delete c->Ports[i]->Connection;
         }
@@ -2306,7 +2306,7 @@ void Schematic::decoupleComp(Component* component, bool keepNodeLabel)
     auto compStatus = disconnectComp(component, /*remove_orphans=*/true, keepNodeLabel);
 
     // Loop over all ports, and create new (isolated) nodes for all ports that got disconnected
-    for (size_t i = 0; i < component->Ports.size(); ++i) {
+    for (auto i = 0; i < component->Ports.size(); ++i) {
         if (compStatus.ports[i].disconnected) {
             Node* new_node = createNode(portPos[i]);
             new_node->connect(component);

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -259,7 +259,7 @@ bool allComponentsAreConsistent(const std::list<Component*>* components)
 {
     bool is_ok = true;
     for (auto* c : *components) {
-        for (auto* p : c->Ports) {
+        for (auto* p : std::as_const(c->Ports)) {
             if (p->Connection == nullptr) {
                 qCritical() << "Incostistent component is found!"
                             << "port->Connection == nullptr"
@@ -284,7 +284,7 @@ bool geometryIsInOrder(const std::list<Component*>* components, const std::list<
 {
     bool is_ok = true;
     for (auto* c : *components) {
-        for (auto* p : c->Ports) {
+        for (auto* p : std::as_const(c->Ports)) {
             auto port_loc = c->center() + QPoint{p->x, p->y};
             if (p->Connection->center() != port_loc) {
                 qCritical() << "Crooked geometry! Port and node locations don't match."
@@ -921,10 +921,10 @@ Element* Schematic::selectElement(float fX, float fY, bool flag, int *index)
     for (Diagram* pd : *a_Diagrams)
     {
 
-        for (Graph *pg : pd->Graphs)
+      for (Graph *pg : std::as_const(pd->Graphs))
         {
             // test markers of graphs
-            for (Marker *pm : pg->Markers)
+        for (Marker *pm : std::as_const(pg->Markers))
             {
                 if(pm->getSelected(x-pd->cx, y-pd->cy))
                 {
@@ -988,7 +988,7 @@ Element* Schematic::selectElement(float fX, float fY, bool flag, int *index)
             }
 
             // test graphs of diagram
-            for (Graph *pg : pd->Graphs)
+            for (Graph *pg : std::as_const(pd->Graphs))
             {
                 if(pg->getSelected(x-pd->cx, pd->cy-y) >= 0)
                 {
@@ -1269,12 +1269,12 @@ int Schematic::selectElements(const QRect& selection_rect, bool append, bool ent
     }
 
     for (Diagram *diagram : *a_Diagrams) {
-        for (Graph *graph: diagram->Graphs) {
+        for (Graph *graph: std::as_const(diagram->Graphs)) {
             if (graph->isSelected &= append) {
                 selected_count++;
             }
 
-            for (Marker *marker: graph->Markers) {
+            for (Marker *marker: std::as_const(graph->Markers)) {
                 if (select_element(marker, marker->boundingRect())) {
                     selected_count++;
                 }
@@ -1300,8 +1300,8 @@ int Schematic::selectElements(const QRect& selection_rect, bool append, bool ent
 void Schematic::selectMarkers() const
 {
     for(Diagram *pd : *a_Diagrams)
-        for (Graph *pg : pd->Graphs)
-            for (Marker *pm : pg->Markers)
+    for (Graph *pg : std::as_const(pd->Graphs))
+            for (Marker *pm : std::as_const(pg->Markers))
                 pm->isSelected = true;
 }
 
@@ -1909,7 +1909,7 @@ void Schematic::decoupleElements(Selection selection, bool keepNodeLabel)
     // decouple all components and save nodes
     for (auto* pc : selection.components) {
         decoupleComp(pc, keepNodeLabel);
-        for (auto* port : pc->Ports) {
+        for (auto* port : std::as_const(pc->Ports)) {
             nodeSet.insert(port->Connection);
         }
     }
@@ -1966,7 +1966,7 @@ void Schematic::insertComponentNodes(Component *component, bool noOptimize)
     if (component->Ports.empty()) return;
 
     // connect every node of the component to corresponding schematic node
-    for (Port *pp : component->Ports) {
+    for (Port *pp : std::as_const(component->Ports)) {
         pp->Connection = provideNode(pp->x+component->cx, pp->y+component->cy);
         pp->Connection->connect(component);
     }
@@ -2028,7 +2028,7 @@ void Schematic::recreateComponent(Component* comp)
 {
     auto qpoint_hash = [](const QPoint& p) { return std::hash<int>{}(p.x()) ^ std::hash<int>{}(p.y()); };
     std::unordered_map<QPoint,std::unique_ptr<WireLabel>,decltype(qpoint_hash)> saved_labels(10, qpoint_hash);
-    for (auto* port : comp->Ports) {
+    for (auto* port : std::as_const(comp->Ports)) {
         if (port->Connection->hasLabel() && port->Connection->conn_count() == 1) {
             saved_labels[port->Connection->center()] = port->Connection->releaseLabel();
         }
@@ -2065,7 +2065,7 @@ void Schematic::recreateComponent(Component* comp)
     comp->tx = tx;
     comp->ty = ty;
 
-    for (auto* port : comp->Ports) {
+    for (auto* port : std::as_const(comp->Ports)) {
         if (saved_labels.contains(port->Connection->center())) {
             port->Connection->acquireLabel(std::move(saved_labels[port->Connection->center()]));
         }
@@ -2282,7 +2282,7 @@ void Schematic::deleteComp(Component *c, bool remove_orphans)
 Schematic::CompDisconnectResult Schematic::disconnectComp(Component* component, bool remove_orphans, bool keepNodeLabel)
 {
     CompDisconnectResult result;
-    for (auto* port : component->Ports) {
+    for (auto* port : std::as_const(component->Ports)) {
         result.ports.push_back(disconnectNode(port->Connection,  component, remove_orphans, keepNodeLabel));
     }
     return result;
@@ -2299,7 +2299,7 @@ void Schematic::decoupleComp(Component* component, bool keepNodeLabel)
 {
     // store all port position
     std::vector<QPoint> portPos;
-    for (auto* port : component->Ports) {
+    for (auto* port : std::as_const(component->Ports)) {
         portPos.push_back(port->Connection->center());
     }
 

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -193,7 +193,7 @@ bool Schematic::pasteFromClipboard(QTextStream *stream, std::list<Element*> *pe)
   // Check for file URLs (drag and drop from file manager)
   if (mimeData->hasUrls()) {
     QList<QUrl> urls = mimeData->urls();
-    for (const QUrl& url : urls) {
+    for (const QUrl& url : std::as_const(urls)) {
       if (url.isLocalFile()) {
         QString filePath = url.toLocalFile();
         if (isImageFilePath(filePath)) {
@@ -941,7 +941,7 @@ bool Schematic::loadProperties(QTextStream *stream)
 void Schematic::simpleInsertComponent(Component *c)
 {
   // connect every node of component
-  for (Port *pp : c->Ports) {
+  for (Port *pp : std::as_const(c->Ports)) {
     Node* pn = provideNode(c->cx + pp->x, c->cy + pp->y);
 
     pn->connect(c);  // connect schematic node to component node
@@ -1573,7 +1573,7 @@ bool Schematic::throughAllComps(QTextStream *stream, int& countInit,
         {
           i = 0;
           // apply in/out signal types of subcircuit
-          for (Port *pp : pc->Ports)
+          for (Port *pp : std::as_const(pc->Ports))
           {
             pp->Type = it.value().PortTypes[i];
             pp->Connection->DType = pp->Type;
@@ -1611,7 +1611,7 @@ bool Schematic::throughAllComps(QTextStream *stream, int& countInit,
       {
         i = 0;
         // save in/out signal types of subcircuit
-        for (Port *pp : pc->Ports)
+        for (Port *pp : std::as_const(pc->Ports))
         {
             //if(i>=d->a_PortTypes.count())break;
             pp->Type = d->a_PortTypes[i];

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -1717,8 +1717,7 @@ bool Schematic::throughAllComps(QTextStream *stream, int& countInit,
       s = pc->Props.front()->Value;
       if(s.isEmpty()) {
         ErrText->appendPlainText(QObject::tr("ERROR: No file name in %1 component \"%2\".").
-          arg(pc->Model).
-          arg(pc->Name));
+          arg(pc->Model, pc->Name));
         return false;
       }
       QString f = pc->getSubcircuitFile();
@@ -2147,7 +2146,7 @@ bool Schematic::createSubNetlist(QTextStream *stream, int& countInit,
       if (!kern->checkSchematic(err_lst)) {
           QString s = QStringLiteral("Subcircuit %1 contains SPICE-incompatible components.\n"
                               "Check these components: %2 \n")
-                  .arg(this->a_DocName).arg(err_lst.join("; "));
+                  .arg(this->a_DocName, err_lst.join("; "));
           ErrText->insertPlainText(s);
           return false;
       }

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -39,7 +39,6 @@
 #include "components/vhdlfile.h"
 #include "components/verilogfile.h"
 #include "components/libcomp.h"
-#include "components/sparamfile.h"
 #include "module.h"
 #include "misc.h"
 #include "extsimkernels/abstractspicekernel.h"
@@ -1516,7 +1515,6 @@ void Schematic::propagateNode(QStringList& Collect,
   Cons.clear();
 }
 
-#include <iostream>
 
 /*!
  * \brief Schematic::throughAllComps

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -831,8 +831,19 @@ int Schematic::saveDocument()
       // Append _sym.json into _props.json, save into _symbol.json
       QFile f1(QucsSettings.QucsWorkDir.filePath(fileBase()+"_props.json"));
       QFile f2(QucsSettings.QucsWorkDir.filePath(fileBase()+"_sym.json"));
-      f1.open(QIODevice::ReadOnly | QIODevice::Text);
-      f2.open(QIODevice::ReadOnly | QIODevice::Text);
+
+      if (!f1.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QMessageBox::critical(this, tr("Error"),
+                              tr("Cannot open %1").arg(f1.fileName()));
+        return -1;
+      }
+
+      if (!f2.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QMessageBox::critical(this, tr("Error"),
+                              tr("Cannot open %1").arg(f2.fileName()));
+        f1.close();
+        return -1;
+      }
 
       QString dat1 = QString(f1.readAll());
       QString dat2 = QString(f2.readAll());
@@ -842,7 +853,14 @@ int Schematic::saveDocument()
       finalJSON = finalJSON.replace("}{", "");
 
       QFile f3(QucsSettings.QucsWorkDir.filePath(fileBase()+"_symbol.json"));
-      f3.open(QIODevice::WriteOnly | QIODevice::Text);
+      if (!f3.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QMessageBox::critical(this, tr("Error"),
+                              tr("Cannot write %1").arg(f3.fileName()));
+        f1.close();
+        f2.close();
+        return -1;
+      }
+
       QTextStream out(&f3);
       out << finalJSON;
 

--- a/qucs/settings.h
+++ b/qucs/settings.h
@@ -42,7 +42,7 @@ public:
       return value(key).value<T>();
     }
 
-    for (auto alias : m_Aliases[key]) {
+    for (const auto &alias : m_Aliases[key]) {
       if (contains(alias)) {
         // qDebug() << "Found alias: " << alias;
         return value(alias).value<T>();

--- a/qucs/spicecomponents/BJT_SPICE.cpp
+++ b/qucs/spicecomponents/BJT_SPICE.cpp
@@ -41,7 +41,7 @@ BJT_SPICE::BJT_SPICE()
     Props.append(new Property("Model_Line 4", "", false,"+ continuation line 3"));
     Props.append(new Property("Model_Line 5", "", false,"+ continuation line 4"));
 
-    createSymbol();
+    BJT_SPICE::createSymbol();
     tx = x1+4;
     ty = y2+4;
 

--- a/qucs/spicecomponents/BJT_SPICE.cpp
+++ b/qucs/spicecomponents/BJT_SPICE.cpp
@@ -192,7 +192,7 @@ QString BJT_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
 
     QString ltr =getProperty("Letter")->Value;
     QString s = spicecompat::check_refdes(Name,ltr);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/C_SPICE.cpp
+++ b/qucs/spicecomponents/C_SPICE.cpp
@@ -40,7 +40,7 @@ C_SPICE::C_SPICE()
     Props.append(new Property("Pins", "2", true,"[2,3] Pins count"));
     Props.append(new Property("Letter", "C", true,"[C,X,N] SPICE letter"));
 
-    createSymbol();
+    C_SPICE::createSymbol();
     tx = x1+4;
     ty = y2+4;
 

--- a/qucs/spicecomponents/C_SPICE.cpp
+++ b/qucs/spicecomponents/C_SPICE.cpp
@@ -115,7 +115,7 @@ QString C_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
 
     QString ltr = getProperty("Letter")->Value;
     QString s = spicecompat::check_refdes(Name,ltr);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/DIODE_SPICE.cpp
+++ b/qucs/spicecomponents/DIODE_SPICE.cpp
@@ -40,7 +40,7 @@ DIODE_SPICE::DIODE_SPICE()
     Props.append(new Property("Pins", "2", true,"[2,3] Pins count"));
     Props.append(new Property("Letter", "D", true,"[D,X,N] SPICE letter"));
 
-    createSymbol();
+    DIODE_SPICE::createSymbol();
     tx = x1+4;
     ty = y2+4;
 }

--- a/qucs/spicecomponents/DIODE_SPICE.cpp
+++ b/qucs/spicecomponents/DIODE_SPICE.cpp
@@ -120,7 +120,7 @@ QString DIODE_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicec
 
     QString ltr = getProperty("Letter")->Value;
     QString s = spicecompat::check_refdes(Name,ltr);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/K_SPICE.cpp
+++ b/qucs/spicecomponents/K_SPICE.cpp
@@ -81,7 +81,7 @@ QString K_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
 
-    for (Port *p1 : Ports)
+    for (Port *p1 : std::as_const(Ports))
     {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";

--- a/qucs/spicecomponents/K_SPICE.cpp
+++ b/qucs/spicecomponents/K_SPICE.cpp
@@ -92,7 +92,7 @@ QString K_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
     QString Ind2 = Props.at(1) ->Value;
     QString K = spicecompat::normalize_value(Props.at(2)->Value);
 
-    s+= QStringLiteral(" %1 %2 %3 \n").arg(Ind1).arg(Ind2).arg(K);
+    s+= QStringLiteral(" %1 %2 %3 \n").arg(Ind1, Ind2, K);
 
     return s;
 }

--- a/qucs/spicecomponents/LTL_SPICE.cpp
+++ b/qucs/spicecomponents/LTL_SPICE.cpp
@@ -126,7 +126,7 @@ QString LTL_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
     if (dialect == spicecompat::SPICEXyce) {
       s += "\n"; // Xyce doesn't support IC
     } else {
-      s += QStringLiteral(" IC=%5, %6, %7, %8 \n").arg(V1).arg(I1).arg(V2).arg(I2);
+      s += QStringLiteral(" IC=%5, %6, %7, %8 \n").arg(V1, I1, V2, I2);
     }
 
     return s;

--- a/qucs/spicecomponents/LTL_SPICE.cpp
+++ b/qucs/spicecomponents/LTL_SPICE.cpp
@@ -95,7 +95,7 @@ QString LTL_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names

--- a/qucs/spicecomponents/LTRA_SPICE.cpp
+++ b/qucs/spicecomponents/LTRA_SPICE.cpp
@@ -99,7 +99,7 @@ QString LTRA_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/L_SPICE.cpp
+++ b/qucs/spicecomponents/L_SPICE.cpp
@@ -88,7 +88,7 @@ QString L_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/MESFET_SPICE.cpp
+++ b/qucs/spicecomponents/MESFET_SPICE.cpp
@@ -91,7 +91,7 @@ QString MESFET_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spice
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/MOS_SPICE.cpp
+++ b/qucs/spicecomponents/MOS_SPICE.cpp
@@ -37,7 +37,7 @@ MOS_SPICE::MOS_SPICE()
   Props.append(new Property("M_Line 4", "", false,"+ continuation line 3"));
   Props.append(new Property("M_Line 5", "", false,"+ continuation line 4"));
 
-  createSymbol();
+  MOS_SPICE::createSymbol();
 
     tx = x1+4;
     ty = y2+4;

--- a/qucs/spicecomponents/MOS_SPICE.cpp
+++ b/qucs/spicecomponents/MOS_SPICE.cpp
@@ -230,7 +230,7 @@ QString MOS_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,Props.at(0)->Value);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/NJF_SPICE.cpp
+++ b/qucs/spicecomponents/NJF_SPICE.cpp
@@ -98,7 +98,7 @@ QString NJF_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/NMOS_SPICE.cpp
+++ b/qucs/spicecomponents/NMOS_SPICE.cpp
@@ -107,7 +107,7 @@ QString NMOS_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/NPN_SPICE.cpp
+++ b/qucs/spicecomponents/NPN_SPICE.cpp
@@ -99,7 +99,7 @@ QString NPN_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/PJF_SPICE.cpp
+++ b/qucs/spicecomponents/PJF_SPICE.cpp
@@ -98,7 +98,7 @@ QString PJF_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/PMF_MESFET_SPICE.cpp
+++ b/qucs/spicecomponents/PMF_MESFET_SPICE.cpp
@@ -91,7 +91,7 @@ QString PMF_MESFET_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = s
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/PMOS_SPICE.cpp
+++ b/qucs/spicecomponents/PMOS_SPICE.cpp
@@ -107,7 +107,7 @@ QString PMOS_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/PNP_SPICE.cpp
+++ b/qucs/spicecomponents/PNP_SPICE.cpp
@@ -100,7 +100,7 @@ QString PNP_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/R_SPICE.cpp
+++ b/qucs/spicecomponents/R_SPICE.cpp
@@ -119,7 +119,7 @@ QString R_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
 
     QString ltr = getProperty("Letter")->Value;
     QString s = spicecompat::check_refdes(Name,ltr);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " " + nam + " ";   // node names

--- a/qucs/spicecomponents/R_SPICE.cpp
+++ b/qucs/spicecomponents/R_SPICE.cpp
@@ -39,7 +39,7 @@ R_SPICE::R_SPICE()
     Props.append(new Property("Pins", "2", true,"[2,3] Pins count"));
     Props.append(new Property("Letter", "R", true,"[R,X,N] SPICE letter"));
 
-    createSymbol();
+    R_SPICE::createSymbol();
 
     tx = x1+4;
     ty = y2+4;

--- a/qucs/spicecomponents/S4Q_I.cpp
+++ b/qucs/spicecomponents/S4Q_I.cpp
@@ -81,7 +81,7 @@ QString S4Q_I::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/S4Q_Ieqndef.cpp
+++ b/qucs/spicecomponents/S4Q_Ieqndef.cpp
@@ -92,7 +92,7 @@ QString S4Q_Ieqndef::spice_netlist(spicecompat::SpiceDialect dialect /* = spicec
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam  + " ";   // node names

--- a/qucs/spicecomponents/S4Q_Ieqndef.cpp
+++ b/qucs/spicecomponents/S4Q_Ieqndef.cpp
@@ -105,7 +105,7 @@ QString S4Q_Ieqndef::spice_netlist(spicecompat::SpiceDialect dialect /* = spicec
     QString Line_4 = Props.at(3)->Value;
     QString Line_5 = Props.at(4)->Value;
 
-    s += QStringLiteral(" %1 = %2 \n").arg(VI).arg(VI2);
+    s += QStringLiteral(" %1 = %2 \n").arg(VI, VI2);
     if(  Line_2.length() > 0 )   s += QStringLiteral("%1").arg(Line_2);
     if(  Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_3);
     if(  Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_4);
@@ -124,7 +124,7 @@ QString S4Q_Ieqndef::va_code()
     if (Props.at(0)->Name=="I") Src = vacompat::normalize_current(plus,minus,true);
     else Src = vacompat::normalize_voltage(plus,minus); // Voltage contribution is reserved for future
     // B-source may be polar
-    if (plus=="gnd") s = QStringLiteral(" %1 <+ -(%2); // %3 source\n").arg(Src).arg(Props.at(0)->Value).arg(Name);
-    else s = QStringLiteral(" %1 <+ %2; // %3 source\n").arg(Src).arg(Props.at(0)->Value).arg(Name);
+    if (plus=="gnd") s = QStringLiteral(" %1 <+ -(%2); // %3 source\n").arg(Src, Props.at(0)->Value, Name);
+    else s = QStringLiteral(" %1 <+ %2; // %3 source\n").arg(Src, Props.at(0)->Value, Name);
     return s;
 }

--- a/qucs/spicecomponents/S4Q_S.cpp
+++ b/qucs/spicecomponents/S4Q_S.cpp
@@ -98,7 +98,7 @@ QString S4Q_S::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/S4Q_V.cpp
+++ b/qucs/spicecomponents/S4Q_V.cpp
@@ -81,7 +81,7 @@ QString S4Q_V::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/S4Q_W.cpp
+++ b/qucs/spicecomponents/S4Q_W.cpp
@@ -86,7 +86,7 @@ QString S4Q_W::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/UDRCTL_SPICE.cpp
+++ b/qucs/spicecomponents/UDRCTL_SPICE.cpp
@@ -93,7 +93,7 @@ QString UDRCTL_SPICE::spice_netlist(spicecompat::SpiceDialect dialect /* = spice
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/eNL.cpp
+++ b/qucs/spicecomponents/eNL.cpp
@@ -87,7 +87,7 @@ QString eNL::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::S
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/iAmpMod.cpp
+++ b/qucs/spicecomponents/iAmpMod.cpp
@@ -105,6 +105,6 @@ QString iAmpMod::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
     QString Fc = spicecompat::normalize_value(Props.at(3)->Value);
     QString Td = spicecompat::normalize_value(Props.at(4)->Value);
 
-    s += QStringLiteral(" AM(0 %2 %1 %3 %4 %5)\n").arg(Va).arg(Vo).arg(Mf).arg(Fc).arg(Td);
+    s += QStringLiteral(" AM(0 %2 %1 %3 %4 %5)\n").arg(Va, Vo, Mf, Fc, Td);
     return s;
 }

--- a/qucs/spicecomponents/iAmpMod.cpp
+++ b/qucs/spicecomponents/iAmpMod.cpp
@@ -93,7 +93,7 @@ QString iAmpMod::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names

--- a/qucs/spicecomponents/iTRNOISE.cpp
+++ b/qucs/spicecomponents/iTRNOISE.cpp
@@ -102,7 +102,7 @@ QString iTRNOISE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecomp
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names

--- a/qucs/spicecomponents/iTRNOISE.cpp
+++ b/qucs/spicecomponents/iTRNOISE.cpp
@@ -116,7 +116,6 @@ QString iTRNOISE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecomp
     QString Rtscapt = spicecompat::normalize_value(Props.at(4)->Value);
     QString Rtsemt = spicecompat::normalize_value(Props.at(4)->Value);
 
-    s += QStringLiteral(" DC 0 AC 0 TRNOISE(%1 %2 %3 %4 %5  %6 %7) \n").arg(Na).arg(Nt).arg(Nalpha).arg(Namp).
-                                arg(Rtsam).arg(Rtscapt).arg(Rtsemt);
+    s += QStringLiteral(" DC 0 AC 0 TRNOISE(%1 %2 %3 %4 %5  %6 %7) \n").arg(Na, Nt, Nalpha, Namp, Rtsam, Rtscapt, Rtsemt);
     return s;
 }

--- a/qucs/spicecomponents/isffm.cpp
+++ b/qucs/spicecomponents/isffm.cpp
@@ -108,6 +108,6 @@ QString iSffm::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     QString Mdi = spicecompat::normalize_value(Props.at(3)->Value);
     QString Fs  = spicecompat::normalize_value(Props.at(4)->Value);
 
-    s += QStringLiteral(" DC 0 SFFM(%1 %2 %3 %4 %5 ) AC 0\n").arg(I0).arg(Ia).arg(Fc).arg(Mdi).arg(Fs);
+    s += QStringLiteral(" DC 0 SFFM(%1 %2 %3 %4 %5 ) AC 0\n").arg(I0, Ia, Fc, Mdi, Fs);
     return s;
 }

--- a/qucs/spicecomponents/isffm.cpp
+++ b/qucs/spicecomponents/isffm.cpp
@@ -96,7 +96,7 @@ QString iSffm::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names

--- a/qucs/spicecomponents/sp_csparameter.cpp
+++ b/qucs/spicecomponents/sp_csparameter.cpp
@@ -77,7 +77,7 @@ QString SpiceCSParam::getExpression(spicecompat::SpiceDialect dialect /* = spice
 
     QString s;
     s.clear();
-    for (Property *pp : Props) {
+    for (Property *pp : std::as_const(Props)) {
         s += QStringLiteral(".CSPARAM %1 = %2\n").arg(pp->Name, pp->Value);
     }
     return s;

--- a/qucs/spicecomponents/sp_csparameter.cpp
+++ b/qucs/spicecomponents/sp_csparameter.cpp
@@ -78,7 +78,7 @@ QString SpiceCSParam::getExpression(spicecompat::SpiceDialect dialect /* = spice
     QString s;
     s.clear();
     for (Property *pp : Props) {
-        s += QStringLiteral(".CSPARAM %1 = %2\n").arg(pp->Name).arg(pp->Value);
+        s += QStringLiteral(".CSPARAM %1 = %2\n").arg(pp->Name, pp->Value);
     }
     return s;
 }

--- a/qucs/spicecomponents/sp_disto.cpp
+++ b/qucs/spicecomponents/sp_disto.cpp
@@ -86,8 +86,7 @@ QString SpiceDisto::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
             points = Props.at(3)->Value;
         }
 
-        s = QStringLiteral("disto %1 %2 %3 %4 %5\n").arg(swp).arg(points).arg(fstart).arg(fstop)
-                                             .arg(Props.at(4)->Value.simplified());
+        s = QStringLiteral("disto %1 %2 %3 %4 %5\n").arg(swp, points, fstart, fstop, Props.at(4)->Value.simplified());
     } else {
         s.clear();
     }

--- a/qucs/spicecomponents/sp_fourier.cpp
+++ b/qucs/spicecomponents/sp_fourier.cpp
@@ -61,9 +61,9 @@ QString SpiceFourier::spice_netlist(spicecompat::SpiceDialect dialect /* = spice
     QString out = "spice4qucs." + Name.toLower() + ".four";
     if (dialect != spicecompat::SPICEXyce) {
         s = QStringLiteral("set nfreqs=%1\n").arg(Props.at(1)->Value);
-        s += QStringLiteral("fourier %1 %2 > %3\n").arg(f0).arg(Props.at(3)->Value).arg(out);
+        s += QStringLiteral("fourier %1 %2 > %3\n").arg(f0, Props.at(3)->Value, out);
     } else {
-        s = QStringLiteral(".FOUR %1 %2\n").arg(f0).arg(Props.at(3)->Value);
+        s = QStringLiteral(".FOUR %1 %2\n").arg(f0, Props.at(3)->Value);
     }
 
     return s;

--- a/qucs/spicecomponents/sp_func.cpp
+++ b/qucs/spicecomponents/sp_func.cpp
@@ -76,7 +76,7 @@ QString SpiceFunc::getExpression(spicecompat::SpiceDialect dialect /* = spicecom
 
     QString s;
     s.clear();
-    for (Property *pp : Props) {
+    for (Property *pp : std::as_const(Props)) {
         if (dialect == spicecompat::SPICEXyce)
             s += QStringLiteral(".FUNC %1 %2\n").arg(pp->Name, pp->Value);
         else s += QStringLiteral(".FUNC %1 = %2\n").arg(pp->Name, pp->Value);

--- a/qucs/spicecomponents/sp_func.cpp
+++ b/qucs/spicecomponents/sp_func.cpp
@@ -78,8 +78,8 @@ QString SpiceFunc::getExpression(spicecompat::SpiceDialect dialect /* = spicecom
     s.clear();
     for (Property *pp : Props) {
         if (dialect == spicecompat::SPICEXyce)
-            s += QStringLiteral(".FUNC %1 %2\n").arg(pp->Name).arg(pp->Value);
-        else s += QStringLiteral(".FUNC %1 = %2\n").arg(pp->Name).arg(pp->Value);
+            s += QStringLiteral(".FUNC %1 %2\n").arg(pp->Name, pp->Value);
+        else s += QStringLiteral(".FUNC %1 = %2\n").arg(pp->Name, pp->Value);
     }
     return s;
 }

--- a/qucs/spicecomponents/sp_globalpar.cpp
+++ b/qucs/spicecomponents/sp_globalpar.cpp
@@ -78,7 +78,7 @@ QString SpiceGlobalParam::getExpression(spicecompat::SpiceDialect dialect /* = s
     s.clear();
     for (Property *pp : Props) {
         s += QStringLiteral(".%1PARAM %2 = %3\n")
-            .arg(dialect == spicecompat::CDL ? "" : "GLOBAL_").arg(pp->Name).arg(pp->Value);
+            .arg(dialect == spicecompat::CDL ? "" : "GLOBAL_").arg(pp->Name, pp->Value);
     }
     return s;
 }

--- a/qucs/spicecomponents/sp_globalpar.cpp
+++ b/qucs/spicecomponents/sp_globalpar.cpp
@@ -76,7 +76,7 @@ QString SpiceGlobalParam::getExpression(spicecompat::SpiceDialect dialect /* = s
 
     QString s;
     s.clear();
-    for (Property *pp : Props) {
+    for (Property *pp : std::as_const(Props)) {
         s += QStringLiteral(".%1PARAM %2 = %3\n")
             .arg(dialect == spicecompat::CDL ? "" : "GLOBAL_").arg(pp->Name, pp->Value);
     }

--- a/qucs/spicecomponents/sp_ic.cpp
+++ b/qucs/spicecomponents/sp_ic.cpp
@@ -75,7 +75,7 @@ QString SpiceIC::getExpression(spicecompat::SpiceDialect dialect /* = spicecompa
 
     QString s;
     s.clear();
-    for (Property *pp : Props) {
+    for (Property *pp : std::as_const(Props)) {
         s += QStringLiteral(".IC %1 = %2\n").arg(pp->Name, pp->Value);
     }
     return s;

--- a/qucs/spicecomponents/sp_ic.cpp
+++ b/qucs/spicecomponents/sp_ic.cpp
@@ -76,7 +76,7 @@ QString SpiceIC::getExpression(spicecompat::SpiceDialect dialect /* = spicecompa
     QString s;
     s.clear();
     for (Property *pp : Props) {
-        s += QStringLiteral(".IC %1 = %2\n").arg(pp->Name).arg(pp->Value);
+        s += QStringLiteral(".IC %1 = %2\n").arg(pp->Name, pp->Value);
     }
     return s;
 }

--- a/qucs/spicecomponents/sp_include.cpp
+++ b/qucs/spicecomponents/sp_include.cpp
@@ -81,7 +81,7 @@ QString S4Q_Include::getSpiceLibrary()
     QString s;
     s.clear();
 
-    for (Property *pp : Props) {
+    for (Property *pp : std::as_const(Props)) {
         QString val = pp->Value;
         if (!val.isEmpty()) {
             // manually expand env. vars for Xyce
@@ -106,7 +106,7 @@ QString S4Q_Include::getSpiceLibrary()
 QStringList S4Q_Include::getSpiceLibraryFiles()
 {
   QStringList files;
-  for (Property *pp : Props) {
+  for (Property *pp : std::as_const(Props)) {
     QString val = pp->Value;
     if (!val.isEmpty()) {
       val = misc::properAbsFileName(val, containingSchematic);

--- a/qucs/spicecomponents/sp_include.cpp
+++ b/qucs/spicecomponents/sp_include.cpp
@@ -91,10 +91,10 @@ QString S4Q_Include::getSpiceLibrary()
             val = misc::properAbsFileName(val, containingSchematic);
             switch (QucsSettings.DefaultSimulator) {
             case spicecompat::simSpiceOpus: // Spice Opus doesn't support quotes
-                s += QStringLiteral("%1 %2\n").arg(SpiceModel).arg(val);
+                s += QStringLiteral("%1 %2\n").arg(SpiceModel, val);
                 break;
             default:
-                s += QStringLiteral("%1 \"%2\"\n").arg(SpiceModel).arg(val);
+                s += QStringLiteral("%1 \"%2\"\n").arg(SpiceModel, val);
                 break;
             }
         }

--- a/qucs/spicecomponents/sp_lib.cpp
+++ b/qucs/spicecomponents/sp_lib.cpp
@@ -85,7 +85,7 @@ QString S4Q_Lib::getSpiceLibrary()
     }
     file = misc::properAbsFileName(file, containingSchematic);
     QString sec = getProperty("Section")->Value;
-    s += QStringLiteral("%1 \"%2\" %3\n").arg(SpiceModel).arg(file).arg(sec);
+    s += QStringLiteral("%1 \"%2\" %3\n").arg(SpiceModel, file, sec);
   }
 
   return s;

--- a/qucs/spicecomponents/sp_model.cpp
+++ b/qucs/spicecomponents/sp_model.cpp
@@ -82,7 +82,7 @@ QString S4Q_Model::getSpiceModel()
 
     QString s;
     s.clear();
-    for (Property *pp : Props) {
+    for (Property *pp : std::as_const(Props)) {
         if (!pp->Value.isEmpty())
             s += pp->Value + "\n";
     }

--- a/qucs/spicecomponents/sp_nodeset.cpp
+++ b/qucs/spicecomponents/sp_nodeset.cpp
@@ -76,7 +76,7 @@ QString SpiceNodeset::getExpression(spicecompat::SpiceDialect dialect /* = spice
     QString s;
     s.clear();
     for (Property *pp : Props) {
-        s += QStringLiteral(".NODESET %1 = %2\n").arg(pp->Name).arg(pp->Value);
+        s += QStringLiteral(".NODESET %1 = %2\n").arg(pp->Name, pp->Value);
     }
     return s;
 }

--- a/qucs/spicecomponents/sp_nodeset.cpp
+++ b/qucs/spicecomponents/sp_nodeset.cpp
@@ -75,7 +75,7 @@ QString SpiceNodeset::getExpression(spicecompat::SpiceDialect dialect /* = spice
 
     QString s;
     s.clear();
-    for (Property *pp : Props) {
+    for (Property *pp : std::as_const(Props)) {
         s += QStringLiteral(".NODESET %1 = %2\n").arg(pp->Name, pp->Value);
     }
     return s;

--- a/qucs/spicecomponents/sp_noise.cpp
+++ b/qucs/spicecomponents/sp_noise.cpp
@@ -91,8 +91,8 @@ QString SpiceNoise::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
     }
 
     QString pts_per_sum = getProperty("PtsPerSummary")->Value;
-    s = QStringLiteral("noise %1 %2 %3 %4 %5 %6 %7\n").arg(Props.at(4)->Value).arg(Props.at(5)->Value)
-            .arg(swp).arg(points).arg(fstart).arg(fstop).arg(pts_per_sum);
+    s = QStringLiteral("noise %1 %2 %3 %4 %5 %6 %7\n").arg(Props.at(4)->Value, Props.at(5)->Value,
+            swp, points, fstart, fstop, pts_per_sum);
     QString out = "spice4qucs." + Name.toLower() + ".cir.noise";
     if (dialect != spicecompat::SPICEXyce) {
         s += QStringLiteral("print inoise_total onoise_total >> %1\n").arg(out);

--- a/qucs/spicecomponents/sp_nutmeg.cpp
+++ b/qucs/spicecomponents/sp_nutmeg.cpp
@@ -88,7 +88,7 @@ QString NutmegEquation::getEquations(QString sim, QStringList &dep_vars)
         auto pp = Props.begin();
         pp++;
         for ( ; pp != Props.end() ; ++pp) {
-            s += QStringLiteral("let %1 = %2\n").arg((*pp)->Name).arg((*pp)->Value);
+            s += QStringLiteral("let %1 = %2\n").arg((*pp)->Name, (*pp)->Value);
           dep_vars.append((*pp)->Name);
         }
     }

--- a/qucs/spicecomponents/sp_options.cpp
+++ b/qucs/spicecomponents/sp_options.cpp
@@ -80,12 +80,12 @@ QString SpiceOptions::getExpression(spicecompat::SpiceDialect dialect /* = spice
     if (dialect == spicecompat::SPICEXyce) {
         s += QStringLiteral(".OPTIONS %1 ").arg(Props.at(0)->Value);
         for (int i=1;i<Props.count();i++) {
-            s += QStringLiteral(" %1 = %2 ").arg(Props.at(i)->Name).arg(Props.at(i)->Value);
+            s += QStringLiteral(" %1 = %2 ").arg(Props.at(i)->Name, Props.at(i)->Value);
         }
         s += "\n";
     } else {
         for (int i=1;i<Props.count();i++) {
-            s += QStringLiteral(".OPTION %1 = %2\n").arg(Props.at(i)->Name).arg(Props.at(i)->Value);
+            s += QStringLiteral(".OPTION %1 = %2\n").arg(Props.at(i)->Name, Props.at(i)->Value);
         }
     }
     return s;

--- a/qucs/spicecomponents/sp_parameter.cpp
+++ b/qucs/spicecomponents/sp_parameter.cpp
@@ -78,11 +78,11 @@ QString SpiceParam::getExpression(spicecompat::SpiceDialect dialect /* = spiceco
     for (Property *pp : Props) {
         if (dialect == spicecompat::CDL)
         {
-            s += QStringLiteral(".PARAM %1=%2\n").arg(pp->Name).arg(pp->Value);
+            s += QStringLiteral(".PARAM %1=%2\n").arg(pp->Name, pp->Value);
         }
         else
         {
-            s += QStringLiteral(".PARAM %1 = %2\n").arg(pp->Name).arg(pp->Value);
+            s += QStringLiteral(".PARAM %1 = %2\n").arg(pp->Name, pp->Value);
         }
     }
     return s;

--- a/qucs/spicecomponents/sp_parameter.cpp
+++ b/qucs/spicecomponents/sp_parameter.cpp
@@ -75,7 +75,7 @@ QString SpiceParam::getExpression(spicecompat::SpiceDialect dialect /* = spiceco
 
     QString s;
     s.clear();
-    for (Property *pp : Props) {
+    for (Property *pp : std::as_const(Props)) {
         if (dialect == spicecompat::CDL)
         {
             s += QStringLiteral(".PARAM %1=%2\n").arg(pp->Name, pp->Value);

--- a/qucs/spicecomponents/sp_pz.cpp
+++ b/qucs/spicecomponents/sp_pz.cpp
@@ -63,8 +63,8 @@ QString SpicePZ::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
     QString s;
     QString out = "spice4qucs." + Name.toLower() + ".cir.pz";
     if (dialect != spicecompat::SPICEXyce) {
-        s = QStringLiteral("pz %1 %2 %3 %4\n").arg(Props.at(0)->Value).arg(Props.at(1)->Value)
-                .arg(Props.at(2)->Value).arg(Props.at(3)->Value);
+        s = QStringLiteral("pz %1 %2 %3 %4\n").arg(Props.at(0)->Value, Props.at(1)->Value,
+                Props.at(2)->Value, Props.at(3)->Value);
         s += QStringLiteral("echo \"PZ analysis\" >> %1\n").arg(out);
         s += "let dummy_var = 0.0\n"; // To overcome featurebug of Ngspice when printing single variable
         s += QStringLiteral("print all >> %1\n").arg(out);

--- a/qucs/spicecomponents/sp_sens.cpp
+++ b/qucs/spicecomponents/sp_sens.cpp
@@ -72,19 +72,19 @@ QString SpiceSENS::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
         QString step = spicecompat::normalize_value(Props.at(4)->Value);
         QString output = "spice4qucs." + Name.toLower() + ".ngspice.sens.dc.prn";
         s += QStringLiteral("echo \"Start\">%1\n").arg(output);
-        s += QStringLiteral("let %1_start=%2\n").arg(sweepvar).arg(start);
+        s += QStringLiteral("let %1_start=%2\n").arg(sweepvar, start);
         s += QStringLiteral("let %1_sweep=%1_start\n").arg(sweepvar);
-        s += QStringLiteral("let %1_step=%2\n").arg(sweepvar).arg(step);
-        s += QStringLiteral("let %1_stop=%2\n").arg(sweepvar).arg(stop);
+        s += QStringLiteral("let %1_step=%2\n").arg(sweepvar, step);
+        s += QStringLiteral("let %1_stop=%2\n").arg(sweepvar, stop);
         s += QStringLiteral("while %1_sweep le %1_stop\n").arg(sweepvar);
         if (sweepvar.compare("temp",Qt::CaseInsensitive)) {
-            s += QStringLiteral("alter %1 = %2_sweep\n").arg(par).arg(sweepvar);
+            s += QStringLiteral("alter %1 = %2_sweep\n").arg(par, sweepvar);
         } else {
-            s += QStringLiteral("set %1 = $&%2_sweep\n").arg(par).arg(sweepvar);
+            s += QStringLiteral("set %1 = $&%2_sweep\n").arg(par, sweepvar);
         }
         s += QStringLiteral("sens %1\n").arg(Props.at(0)->Value);
         s += QStringLiteral("echo \"Sens analysis\">>%1\n").arg(output);
-        s += QStringLiteral("print %1_sweep>>%2\nprint all>>%2\n").arg(sweepvar).arg(output);
+        s += QStringLiteral("print %1_sweep>>%2\nprint all>>%2\n").arg(sweepvar, output);
         s += QStringLiteral("let %1_sweep = %1_sweep + %1_step\nend\n").arg(sweepvar);
 
     }

--- a/qucs/spicecomponents/sp_sens_ac.cpp
+++ b/qucs/spicecomponents/sp_sens_ac.cpp
@@ -68,8 +68,7 @@ QString SpiceSENS_AC::spice_netlist(spicecompat::SpiceDialect dialect /* = spice
         QString fstop = spicecompat::normalize_value(Props.at(3)->Value); // Stop freq.
         QString out = "spice4qucs." + Name.toLower() + ".sens.prn";
         s = QStringLiteral("sens %1 ac %2 %3 %4 %5\n")
-                .arg(Props.at(0)->Value).arg(Props.at(1)->Value).arg(Props.at(4)->Value)
-                .arg(fstart).arg(fstop);
+                .arg(Props.at(0)->Value, Props.at(1)->Value, Props.at(4)->Value, fstart, fstop);
         s += QStringLiteral("write %1 all\n").arg(out);
     }
 

--- a/qucs/spicecomponents/sp_sens_tr_xyce.cpp
+++ b/qucs/spicecomponents/sp_sens_tr_xyce.cpp
@@ -70,13 +70,13 @@ QString SpiceSENS_TR_Xyce::spice_netlist(spicecompat::SpiceDialect dialect /* = 
         QString start = spicecompat::normalize_value(Props.at(3)->Value);
         QString stop = spicecompat::normalize_value(Props.at(4)->Value);
         QString step = spicecompat::normalize_value(Props.at(5)->Value);
-        s = QStringLiteral(".tran %1 %2 %3").arg(start).arg(stop).arg(step);
+        s = QStringLiteral(".tran %1 %2 %3").arg(start, stop, step);
         if (Props.at(6)->Value=="yes") s +="\n";
         else s += " uic\n";
         if (Props.at(2)->Value=="direct") s += ".options sensitivity direct=1 adjoint=0\n";
         else s += ".options sensitivity direct=0 adjoint=1\n";
         s += QStringLiteral(".sens objfunc={%1} param=%2\n")
-                .arg(Props.at(0)->Value).arg(Props.at(1)->Value);
+                .arg(Props.at(0)->Value, Props.at(1)->Value);
         if (Props.at(2)->Value=="direct") {
             s += ".print sens\n";
         } else {

--- a/qucs/spicecomponents/sp_sens_xyce.cpp
+++ b/qucs/spicecomponents/sp_sens_xyce.cpp
@@ -70,8 +70,8 @@ QString SpiceSENS_Xyce::spice_netlist(spicecompat::SpiceDialect dialect /* = spi
         QString step = spicecompat::normalize_value(Props.at(5)->Value);
         s = QStringLiteral(".dc %3 %4 %5 %6\n"
                     ".sens objfunc={%1} param=%2\n"
-                    ".print sens\n").arg(Props.at(0)->Value).arg(Props.at(1)->Value)
-                .arg(Props.at(2)->Value).arg(start).arg(stop).arg(step);
+                    ".print sens\n").arg(Props.at(0)->Value, Props.at(1)->Value,
+                                         Props.at(2)->Value, start, stop, step);
     }
 
     return s;

--- a/qucs/spicecomponents/spicegeneric.cpp
+++ b/qucs/spicecomponents/spicegeneric.cpp
@@ -122,7 +122,7 @@ void SpiceGeneric::createSymbol()
   fHeight = metrics.lineSpacing();
   tx = x1+4;
   ty = y1 - fHeight - 4;
-  for (Property *pp : Props) {
+  for (Property *pp : std::as_const(Props)) {
       if (pp->display) ty -= fHeight;
   }
   changed = true;
@@ -140,7 +140,7 @@ QString SpiceGeneric::spice_netlist(spicecompat::SpiceDialect dialect /* = spice
 
     // form RefDes from unique device letter and device name
     QString s = Props.at(1)->Value + Name;
-    for (Port *pp : Ports) {
+    for (Port *pp : std::as_const(Ports)) {
         s += " " + spicecompat::normalize_node_name(pp->Connection->Name);
     }
 

--- a/qucs/spicecomponents/spicelibcomp.cpp
+++ b/qucs/spicecomponents/spicelibcomp.cpp
@@ -226,7 +226,7 @@ QString SpiceLibComp::spice_netlist(spicecompat::SpiceDialect dialect /* = spice
   QString pins = getProperty("PinAssign")->Value;
   QString sym = getProperty("SymPattern")->Value;
   if (sym == "auto" || pins.isEmpty()) {
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
       s += " " + spicecompat::normalize_node_name(p1->Connection->Name);
     }
   } else {
@@ -236,7 +236,7 @@ QString SpiceLibComp::spice_netlist(spicecompat::SpiceDialect dialect /* = spice
 
     // Extract port numbers and check for duplicates
     QList<int> uniquePortNumbers;
-    for (const QString &p : pin_nums) {
+    for (const QString &p : std::as_const(pin_nums)) {
       bool ok = false;
       int num = p.trimmed().toInt(&ok);
       if (!ok) {
@@ -264,7 +264,7 @@ QString SpiceLibComp::spice_netlist(spicecompat::SpiceDialect dialect /* = spice
     }
 
     // Normalize pin_nums to ranks (0-based)
-    for (const QString &p : pin_nums) {
+    for (const QString &p : std::as_const(pin_nums)) {
       bool ok = false;
       int num = p.trimmed().toInt(&ok);
       if (!ok) {

--- a/qucs/spicecomponents/spicelibcomp.cpp
+++ b/qucs/spicecomponents/spicelibcomp.cpp
@@ -281,7 +281,7 @@ QString SpiceLibComp::spice_netlist(spicecompat::SpiceDialect dialect /* = spice
       s += " " + spicecompat::normalize_node_name(pp->Connection->Name);
     }
   }
-  s += QStringLiteral(" %1 %2\n").arg(Props.at(1)->Value).arg(Props.at(3)->Value);
+  s += QStringLiteral(" %1 %2\n").arg(Props.at(1)->Value, Props.at(3)->Value);
   return s;
 }
 

--- a/qucs/spicecomponents/spicelibcomp.cpp
+++ b/qucs/spicecomponents/spicelibcomp.cpp
@@ -128,7 +128,6 @@ void SpiceLibComp::removeUnusedPorts()
     while (ip.hasNext()) {
       pp = ip.next();
       if(!pp->avail) {
-          pp = ip.peekNext();
           ip.remove();
       }
     }

--- a/qucs/spicecomponents/src_eqndef.cpp
+++ b/qucs/spicecomponents/src_eqndef.cpp
@@ -73,7 +73,7 @@ QString Src_eqndef::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam   + " ";   // node names

--- a/qucs/spicecomponents/src_eqndef.cpp
+++ b/qucs/spicecomponents/src_eqndef.cpp
@@ -86,7 +86,7 @@ QString Src_eqndef::spice_netlist(spicecompat::SpiceDialect dialect /* = spiceco
     QString Line_4 = Props.at(3)->Value;
     QString Line_5 = Props.at(4)->Value;
 
-    s += QStringLiteral(" %1 = %2 ").arg(VI).arg(VI2);
+    s += QStringLiteral(" %1 = %2 ").arg(VI, VI2);
     if(  Line_2.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_2);
     if(  Line_3.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_3);
     if(  Line_4.length() > 0 )   s += QStringLiteral("\n%1").arg(Line_4);
@@ -105,7 +105,7 @@ QString Src_eqndef::va_code()
     if (Props.at(0)->Name=="I") Src = vacompat::normalize_current(plus,minus,true);
     else Src = vacompat::normalize_voltage(plus,minus); // Voltage contribution is reserved for future
     // B-source may be polar
-    if (plus=="gnd") s = QStringLiteral(" %1 <+ -(%2); // %3 source\n").arg(Src).arg(Props.at(0)->Value).arg(Name);
-    else s = QStringLiteral(" %1 <+ %2; // %3 source\n").arg(Src).arg(Props.at(0)->Value).arg(Name);
+    if (plus=="gnd") s = QStringLiteral(" %1 <+ -(%2); // %3 source\n").arg(Src, Props.at(0)->Value, Name);
+    else s = QStringLiteral(" %1 <+ %2; // %3 source\n").arg(Src, Props.at(0)->Value, Name);
     return s;
 }

--- a/qucs/spicecomponents/vAmpMod.cpp
+++ b/qucs/spicecomponents/vAmpMod.cpp
@@ -94,7 +94,7 @@ QString vAmpMod::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names

--- a/qucs/spicecomponents/vAmpMod.cpp
+++ b/qucs/spicecomponents/vAmpMod.cpp
@@ -107,6 +107,6 @@ QString vAmpMod::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompa
    QString Td = spicecompat::normalize_value(Props.at(4)->Value);
 
 
-    s += QStringLiteral(" AM(0 %2 %1 %3 %4 %5)\n").arg(Va).arg(Vo).arg(Mf).arg(Fc).arg(Td);
+    s += QStringLiteral(" AM(0 %2 %1 %3 %4 %5)\n").arg(Va, Vo, Mf, Fc, Td);
     return s;
 }

--- a/qucs/spicecomponents/vPWL.cpp
+++ b/qucs/spicecomponents/vPWL.cpp
@@ -93,7 +93,7 @@ QString vPWL::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat::
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam+" ";   // node names

--- a/qucs/spicecomponents/vTRNOISE.cpp
+++ b/qucs/spicecomponents/vTRNOISE.cpp
@@ -114,7 +114,6 @@ QString vTRNOISE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecomp
    QString Rtsemt = spicecompat::normalize_value(Props.at(6)->Value);
 
 
-    s += QStringLiteral(" DC 0 AC 0 TRNOISE(%1 %2 %3 %4 %5  %6 %7) \n").arg(Na).arg(Nt).arg(Nalpha).arg(Namp).
-                                arg(Rtsam).arg(Rtscapt).arg(Rtsemt);
+    s += QStringLiteral(" DC 0 AC 0 TRNOISE(%1 %2 %3 %4 %5  %6 %7) \n").arg(Na, Nt, Nalpha, Namp, Rtsam, Rtscapt, Rtsemt);
     return s;
 }

--- a/qucs/spicecomponents/vTRNOISE.cpp
+++ b/qucs/spicecomponents/vTRNOISE.cpp
@@ -99,7 +99,7 @@ QString vTRNOISE::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecomp
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names

--- a/qucs/spicecomponents/vTRRANDOM.cpp
+++ b/qucs/spicecomponents/vTRRANDOM.cpp
@@ -101,7 +101,7 @@ QString vTRRANDOM::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names

--- a/qucs/spicecomponents/vTRRANDOM.cpp
+++ b/qucs/spicecomponents/vTRRANDOM.cpp
@@ -113,6 +113,6 @@ QString vTRRANDOM::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecom
     QString Param1 = spicecompat::normalize_value(Props.at(3)->Value);
     QString Param2 = spicecompat::normalize_value(Props.at(4)->Value);
 
-    s += QStringLiteral(" DC 0 AC 0 TRRANDOM(%1 %2 %3 %4 %5 ) \n").arg(Type).arg(Ts).arg(Td).arg(Param1).arg(Param2);
+    s += QStringLiteral(" DC 0 AC 0 TRRANDOM(%1 %2 %3 %4 %5 ) \n").arg(Type, Ts, Td, Param1, Param2);
     return s;
 }

--- a/qucs/spicecomponents/vsffm.cpp
+++ b/qucs/spicecomponents/vsffm.cpp
@@ -106,6 +106,6 @@ QString vSffm::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     QString Mdi = spicecompat::normalize_value(Props.at(3)->Value);
     QString Fs = spicecompat::normalize_value(Props.at(4)->Value);
 
-    s += QStringLiteral(" DC 0 SFFM(%1 %2 %3 %4 %5 ) AC 0\n").arg(Vo).arg(Va).arg(Fc).arg(Mdi).arg(Fs);
+    s += QStringLiteral(" DC 0 SFFM(%1 %2 %3 %4 %5 ) AC 0\n").arg(Vo, Va, Fc, Mdi, Fs);
     return s;
 }

--- a/qucs/spicecomponents/vsffm.cpp
+++ b/qucs/spicecomponents/vsffm.cpp
@@ -94,7 +94,7 @@ QString vSffm::spice_netlist(spicecompat::SpiceDialect dialect /* = spicecompat:
     Q_UNUSED(dialect);
 
     QString s = spicecompat::check_refdes(Name,SpiceModel);
-    for (Port *p1 : Ports) {
+    for (Port *p1 : std::as_const(Ports)) {
         QString nam = p1->Connection->Name;
         if (nam=="gnd") nam = "0";
         s += " "+ nam;   // node names

--- a/qucs/spicecomponents/xspicegeneric.cpp
+++ b/qucs/spicecomponents/xspicegeneric.cpp
@@ -78,7 +78,7 @@ void XspiceGeneric::createSymbol()
   QStringList t_ports = Props.at(0)->Value.split(',');
   QStringList n_ports;
   int k=0;
-  for (QString t_port : t_ports) {
+  for (QString t_port : std::as_const(t_ports)) {
       t_port.remove(']').remove('[');
       if ((t_port.remove(' ').endsWith('d'))&&
           (t_port!="d")) {
@@ -154,7 +154,7 @@ QString XspiceGeneric::spice_netlist(spicecompat::SpiceDialect dialect /* = spic
     QStringList t_ports = Props.at(0)->Value.split(',');
 
     int i=0;
-    for(QString t_port : t_ports) {
+    for(QString t_port : std::as_const(t_ports)) {
         QString nod =  spicecompat::normalize_node_name(Ports.at(i)->Connection->Name);
 
         if (t_port.contains('[')) { // Process array ports

--- a/qucs/spicecomponents/xspicegeneric.cpp
+++ b/qucs/spicecomponents/xspicegeneric.cpp
@@ -168,9 +168,9 @@ QString XspiceGeneric::spice_netlist(spicecompat::SpiceDialect dialect /* = spic
             (t_port!="d")) {
             i++;
             QString nod1 =  spicecompat::normalize_node_name(Ports.at(i)->Connection->Name);
-            s += QStringLiteral(" %%1(%2 %3) ").arg(t_port).arg(nod).arg(nod1);
+            s += QStringLiteral(" %%1(%2 %3) ").arg(t_port, nod, nod1);
         } else {
-            s += QStringLiteral(" %%1(%2) ").arg(t_port).arg(nod);
+            s += QStringLiteral(" %%1(%2) ").arg(t_port, nod);
         }
         if (closing_bracket) s += ']';
         i++;

--- a/qucs/symbolwidget.cpp
+++ b/qucs/symbolwidget.cpp
@@ -605,8 +605,7 @@ int SymbolWidget::analyseLine(const QString& Row)
       if (PortNames.contains(i3)) {
         qWarning() << QString("Port index %1 overridden, old port '%2' replaced by '%3'")
                       .arg(i3)
-                      .arg(getPortName(i3))
-                      .arg(portName);
+                      .arg(getPortName(i3),portName);
       }
       PortNames.insert(i3, portName);
     }

--- a/qucs/syntax.cpp
+++ b/qucs/syntax.cpp
@@ -207,37 +207,37 @@ void SyntaxHighlighter::setLanguage(int lang)
     break;
     }
 
-  for (const QString &pattern : reservedWordPattern) {
+  for (const QString &pattern : std::as_const(reservedWordPattern)) {
     rule.pattern = QRegularExpression(pattern);
     rule.format = reservedWordFormat;
     highlightingRules.append(rule);
   }
 
-  for (const QString &pattern : unitPattern) {
+  for (const QString &pattern : std::as_const(unitPattern)) {
     rule.pattern = QRegularExpression(pattern);
     rule.format = unitFormat;
     highlightingRules.append(rule);
   }
 
-  for (const QString &pattern : datatypePattern) {
+  for (const QString &pattern : std::as_const(datatypePattern)) {
     rule.pattern = QRegularExpression(pattern);
     rule.format = datatypeFormat;
     highlightingRules.append(rule);
   }
 
-  for (const QString &pattern : directivePattern) {
+  for (const QString &pattern : std::as_const(directivePattern)) {
     rule.pattern = QRegularExpression(pattern);
     rule.format = directiveFormat;
     highlightingRules.append(rule);
   }
 
-  for (const QString &pattern : functionPattern) {
+  for (const QString &pattern : std::as_const(functionPattern)) {
     rule.pattern = QRegularExpression(pattern);
     rule.format = functionFormat;
     highlightingRules.append(rule);
   }
 
-  for (const QString &pattern : commentPattern) {
+  for (const QString &pattern : std::as_const(commentPattern)) {
     rule.pattern = QRegularExpression(pattern);
     rule.format = commentFormat;
     highlightingRules.append(rule);
@@ -246,7 +246,7 @@ void SyntaxHighlighter::setLanguage(int lang)
 
 // ---------------------------------------------------
 void SyntaxHighlighter::highlightBlock(const QString &text) {
-    for (const HighlightingRule &rule : highlightingRules) {
+    for (const HighlightingRule &rule : std::as_const(highlightingRules)) {
         QRegularExpression expression(rule.pattern);
         QRegularExpressionMatchIterator iter = expression.globalMatch(text);
         while (iter.hasNext()) {


### PR DESCRIPTION
This PR addresses a number of clang-tidy/clazy/compiler warnings across the codebase. These warnings were found to be, by far, the most common:

- Use multi-arg instead [clazy-qstring-arg]
    - Replaced arg().arg() by arg(,)
- clazy-range-loop-detach warnings across the project. This happens in range-based for loops-
		- Fixed by using std::as_const() in the iterable

Other warnings
- Replace qAsConst (deprecated) with std::as_const
- Add comment about QCheckBox::stateChanged deprecation. It can't be cleared until the macOS build supports Qt > 6.7, the other builds are ok with this.
- Fix implicit capture of this via [=] (deprecated)
- Use midRef() instead of deprecated API (clazy-qstring-ref)
- Use static QFileInfo::exists() instead of constructing a QFileInfo object
- Remove dead code: Mainly assigned variables that were no longer read and unnecessary headers
- Fix clang-analyzer virtual call warnings in several constructors
- Avoid unnecessary copies in range-for loops. Fixed by using const with &