### PR TITLE
fix(abstractspicekernel): skip library collection for disabled subcircuits

### DIFF
--- a/qucs/extsimkernels/abstractspicekernel.cpp
+++ b/qucs/extsimkernels/abstractspicekernel.cpp
@@ -1756,6 +1756,8 @@ QString AbstractSpiceKernel::collectSpiceLibs(Schematic* sch)
   QStringList collected_spicelib;
   for(Component *pc : sch->a_DocComps) {
     if (pc->Model == "Sub") {
+      // skip if component is disabled
+      if (pc->isActive != COMP_IS_ACTIVE) continue;
       Schematic *sub = new Schematic(0, ((Subcircuit *)pc)->getSubcircuitFile());
       if(!sub->loadDocument())      // load document if possible
       {


### PR DESCRIPTION
## What

This skips the library dependency collection for disabled/non-active subcircuits

## Motivation

In some cases I use the same name for my subcircuits, but they might differ in the actual contents, e.g. parasittic RC extraction vs ideal schematic. However when I disabled my Qucs subcircuit I still got he `.INCLUDE` for that particular subcircuit, which then don't necessarily match the later definition. This PR avoids this name collision.

## Example

Let's say I have a circuit:

<img width="50%" height="50%" alt="top" src="https://github.com/user-attachments/assets/bc0e334d-eed8-474a-9373-8c67c37052b4" />

Which has the has the subcircuit:


<img width="50%" height="50%" alt="subckt" src="https://github.com/user-attachments/assets/5b67abea-8be6-49e0-8bb8-9b02f764cd30" />

Which is a SpiceLib component pointing to a netlist `netlist.cir`, which has the `.SUBCKT MYSUB` defined.

If I netlist this using NGSpice, I get:


### Currently

**Subcircuit enabled**

```
* Qucs 26.1.1  /home/torleif/top_subckt.sch
.INCLUDE "/usr/share/qucs-s/xspice_cmlib/include/ngspice_mathfunc.inc"
.INCLUDE "/tmp/netlist.cir"
.SUBCKT nested_subckt _net0 _net2 _net1 _net3 
XX1  _net0 _net1 _net2 _net3 MYSUB
.ENDS
XSUB1 P1 P2 P3 P4 nested_subckt
R1 VOUT R1  1K tc1=0.0 tc2=0.0 
R2 0 VOUT  1K tc1=0.0 tc2=0.0 
```

**Subcircuit disabled**

```
* Qucs 26.1.1  /home/torleif/top_subckt.sch
.INCLUDE "/usr/share/qucs-s/xspice_cmlib/include/ngspice_mathfunc.inc"
.INCLUDE "/tmp/netlist.cir"
R1 VOUT R1  1K tc1=0.0 tc2=0.0 
R2 0 VOUT  1K tc1=0.0 tc2=0.0 

.control

exit
.endc
.END
```

i.e. `.INCLUDE "/tmp/netlist.cir"` is still included, which means that `MYSUB` is still defined by the definition in `netlist.cir`

### This PR

**Subcircuit enabled**

```
* Qucs 26.1.1  /home/torleif/top_subckt.sch
.INCLUDE "/usr/share/qucs-s/xspice_cmlib/include/ngspice_mathfunc.inc"
.INCLUDE "/tmp/netlist.cir"
.SUBCKT nested_subckt _net0 _net2 _net1 _net3 
XX1  _net0 _net1 _net2 _net3 MYSUB
.ENDS
XSUB1 P1 P2 P3 P4 nested_subckt
R1 VOUT R1  1K tc1=0.0 tc2=0.0 
R2 0 VOUT  1K tc1=0.0 tc2=0.0 

.control

exit
.endc
.END
```

i.e. same as it was above

**Subcircuit disabled**

```
* Qucs 26.1.1  /home/torleif/top_subckt.sch
.INCLUDE "/usr/share/qucs-s/xspice_cmlib/include/ngspice_mathfunc.inc"
R1 VOUT R1  1K tc1=0.0 tc2=0.0 
R2 0 VOUT  1K tc1=0.0 tc2=0.0 

.control

exit
.endc
.END
```

i.e. `.INCLUDE "/tmp/netlist.cir"` is **not** included, which means that `MYSUB` is not defined in this current circuit anymore.