### PR TITLE
Add eu_polar capacitor

### DIFF
--- a/qucs/components/capacitor.cpp
+++ b/qucs/components/capacitor.cpp
@@ -30,7 +30,7 @@ Capacitor::Capacitor()
   Props.append(new Property("V", "", false,
     QObject::tr("initial voltage for transient simulation")));
   Props.append(new Property("Symbol", "neutral", false,
-  QObject::tr("schematic symbol")+" [neutral, polar]"));
+  QObject::tr("schematic symbol")+" [neutral, polar, eu_polar]"));
 
   Capacitor::createSymbol();
   tx = x1+4;
@@ -92,19 +92,28 @@ QString Capacitor::va_code()
 
 void Capacitor::createSymbol()
 {
-  if(Props.back()->Value.at(0) == 'n') {
+  if(Props.back()->Value ==  "neutral") {
     Lines.append(new qucs::Line( -4,-11, -4, 11,QPen(Qt::darkBlue,4)));
     Lines.append(new qucs::Line(  4,-11,  4, 11,QPen(Qt::darkBlue,4)));
-  }
-  else {
+  } else if(Props.back()->Value == "polar") {
     Lines.append(new qucs::Line(-11, -5,-11,-11,QPen(Qt::red,1)));
     Lines.append(new qucs::Line(-14, -8, -8, -8,QPen(Qt::red,1)));
     Lines.append(new qucs::Line( -4,-11, -4, 11,QPen(Qt::darkBlue,3)));
     Arcs.append(new qucs::Arc(4,-12, 20, 24, 16*122, 16*116,QPen(Qt::darkBlue,3)));
+  } else if(Props.back()->Value == "eu_polar") {
+    Lines.append(new qucs::Line( -2,-11, -2, 11,QPen(Qt::darkBlue,1)));
+    Lines.append(new qucs::Line( -5,-11, -5, 11,QPen(Qt::darkBlue,1)));
+    Lines.append(new qucs::Line( -5,-11, -2, -11,QPen(Qt::darkBlue,1)));
+    Lines.append(new qucs::Line( -5,11, -2, 11,QPen(Qt::darkBlue,1)));
+    Lines.append(new qucs::Line(-11, -5,-11,-11,QPen(Qt::black,1)));
+    Lines.append(new qucs::Line(-14, -8, -8, -8,QPen(Qt::black,1)));
+    for(int i=0; i<4; i++) {
+      Lines.append(new qucs::Line(  2+i,-11,  2+i, 11,QPen(Qt::darkBlue,1)));
+    }
   }
 
-  Lines.append(new qucs::Line(-30,  0, -4,  0,QPen(Qt::darkBlue,2)));
-  Lines.append(new qucs::Line(  4,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.append(new qucs::Line(-30,  0, -6,  0,QPen(Qt::darkBlue,2)));
+  Lines.append(new qucs::Line(  6,  0, 30,  0,QPen(Qt::darkBlue,2)));
 
   Ports.append(new Port(-30,  0));
   Ports.append(new Port( 30,  0));


### PR DESCRIPTION
This PR adds EU polar capacitor symbol variant. The capacitor symbol doesn't affect the simulation properties and has only cosmetic effect. The feature was suggested by @ElettroLinux user. 

<img width="767" height="192" alt="image" src="https://github.com/user-attachments/assets/bbd33868-33e7-46fe-9b40-f7ec54dd7d6f" />

