### PR TITLE
Fix INCLUDE SCRIPT relative paths

### DIFF
--- a/qucs/spicecomponents/CMakeLists.txt
+++ b/qucs/spicecomponents/CMakeLists.txt
@@ -193,6 +193,10 @@ spicelibcomp.h
 
 ADD_LIBRARY(spicecomponents STATIC ${COMPONENTS_HDRS} ${COMPONENTS_SRCS} ${COMPONENTS_MOC_SRCS} )
 
+ADD_EXECUTABLE(test_incl_script_directive_rewrite test_incl_script_directive_rewrite.cpp)
+TARGET_LINK_LIBRARIES(test_incl_script_directive_rewrite Qt6::Core)
+ADD_TEST(NAME InclScriptDirectiveRewriteTest COMMAND test_incl_script_directive_rewrite)
+
 
 
 

--- a/qucs/spicecomponents/incl_script.cpp
+++ b/qucs/spicecomponents/incl_script.cpp
@@ -15,6 +15,7 @@
  *                                                                         *
  ***************************************************************************/
 #include "incl_script.h"
+#include "incl_script_directive_rewrite.h"
 #include "main.h"
 #include "misc.h"
 #include <QFontInfo>
@@ -89,5 +90,13 @@ QString InclScript::getExpression(spicecompat::SpiceDialect dialect /* = spiceco
     if (dialect == spicecompat::SPICEXyce) {
       includeCode = misc::expandEnvVars(includeCode);
     }
+
+    includeCode = qucs_s::rewriteIncludeLines(
+        includeCode,
+        [this](const QString& f) {
+          return misc::properAbsFileName(f, containingSchematic);
+        },
+        QucsSettings.DefaultSimulator != spicecompat::simSpiceOpus);
+
     return includeCode + "\n";
 }

--- a/qucs/spicecomponents/incl_script_directive_rewrite.h
+++ b/qucs/spicecomponents/incl_script_directive_rewrite.h
@@ -1,0 +1,87 @@
+#ifndef INCL_SCRIPT_DIRECTIVE_REWRITE_H
+#define INCL_SCRIPT_DIRECTIVE_REWRITE_H
+
+#include <QFileInfo>
+#include <QRegularExpression>
+#include <QString>
+#include <QStringList>
+#include <functional>
+
+namespace qucs_s {
+
+inline QString
+rewriteIncludeLine(const QString& line,
+                   const std::function<QString(const QString&)>& resolveFile,
+                   bool quoteResolved) {
+  static const QRegularExpression prefixRe(
+      QStringLiteral("^(\\s*\\.include)(\\s+)"),
+      QRegularExpression::CaseInsensitiveOption);
+
+  const QRegularExpressionMatch m = prefixRe.match(line);
+  if (!m.hasMatch()) {
+    return line;
+  }
+
+  const int afterPrefix = m.capturedEnd(0);
+  const QString prefix  = line.left(afterPrefix);
+
+  QString token;
+  QString suffix;
+
+  if (afterPrefix < line.size() && line.at(afterPrefix) == QLatin1Char('"')) {
+    const int closeIdx = line.indexOf(QLatin1Char('"'), afterPrefix + 1);
+    if (closeIdx < 0) {
+      return line; // unterminated quote: malformed, leave unchanged
+    }
+    token  = line.mid(afterPrefix + 1, closeIdx - afterPrefix - 1);
+    suffix = line.mid(closeIdx + 1);
+  } else {
+    int idx = afterPrefix;
+    while (idx < line.size() && !line.at(idx).isSpace()) {
+      ++idx;
+    }
+    token  = line.mid(afterPrefix, idx - afterPrefix);
+    suffix = line.mid(idx);
+  }
+
+  if (token.isEmpty()) {
+    return line;
+  }
+
+  const QString resolved = resolveFile(token);
+  const bool changed     = (resolved != token);
+  const bool originalIsExistingAbsolute =
+      !changed && QFileInfo(token).isAbsolute() && QFileInfo(token).exists();
+
+  if (!changed && !originalIsExistingAbsolute) {
+    return line; // unresolved: missing file, typo, or env-var placeholder
+  }
+
+  QString rewritten = prefix;
+  if (quoteResolved) {
+    rewritten += QLatin1Char('"');
+    rewritten += resolved;
+    rewritten += QLatin1Char('"');
+  } else {
+    rewritten += resolved;
+  }
+  rewritten += suffix;
+  return rewritten;
+}
+
+inline QString
+rewriteIncludeLines(const QString& text,
+                    const std::function<QString(const QString&)>& resolveFile,
+                    bool quoteResolved) {
+  const QStringList lines = text.split(QLatin1Char('\n'));
+  QStringList result;
+  result.reserve(lines.size());
+  for (const QString& line : lines) {
+    result.append(rewriteIncludeLine(line, resolveFile, quoteResolved));
+  }
+  return result.join(QLatin1Char('\n'));
+}
+
+} // namespace qucs_s
+
+#endif

--- a/qucs/spicecomponents/test_incl_script_directive_rewrite.cpp
+++ b/qucs/spicecomponents/test_incl_script_directive_rewrite.cpp
@@ -1,0 +1,206 @@
+#include "incl_script_directive_rewrite.h"
+
+#include <QFileInfo>
+#include <QTemporaryFile>
+#include <cstdio>
+#include <functional>
+
+namespace {
+
+int failures = 0;
+
+void expectEqual(const QString& actual, const QString& expected,
+                 const char* testName) {
+  if (actual != expected) {
+    std::fprintf(stderr, "FAIL: %s\n  expected: %s\n  actual:   %s\n", testName,
+                 expected.toUtf8().constData(), actual.toUtf8().constData());
+    ++failures;
+  }
+}
+
+void expectTrue(bool cond, const char* testName) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", testName);
+    ++failures;
+  }
+}
+
+} // namespace
+
+int main() {
+  using qucs_s::rewriteIncludeLines;
+
+  // 1. Quoted relative path, resolver returns a different (resolved) string.
+  {
+    auto resolver = [](const QString& f) {
+      return QStringLiteral("/abs/dir/") + f;
+    };
+    const QString in  = QStringLiteral(".INCLUDE \"test file.inc\"\n");
+    const QString out = rewriteIncludeLines(in, resolver, true);
+    expectEqual(out, QStringLiteral(".INCLUDE \"/abs/dir/test file.inc\"\n"),
+                "quoted-relative-resolved");
+  }
+
+  // 2. Unquoted relative path, resolver returns a different string.
+  {
+    auto resolver = [](const QString& f) {
+      return QStringLiteral("/abs/dir/") + f;
+    };
+    const QString in  = QStringLiteral(".include test.inc\n");
+    const QString out = rewriteIncludeLines(in, resolver, true);
+    expectEqual(out, QStringLiteral(".include \"/abs/dir/test.inc\"\n"),
+                "unquoted-relative-resolved");
+  }
+
+  // 3. Resolver echoes the input back (not found) -> line unchanged.
+  {
+    auto echo         = [](const QString& f) { return f; };
+    const QString in  = QStringLiteral(".INCLUDE missing.inc\n");
+    const QString out = rewriteIncludeLines(in, echo, true);
+    expectEqual(out, in, "unresolved-left-untouched");
+  }
+
+  // 3b. Environment-variable-style token, resolver echoes back -> untouched.
+  {
+    auto echo         = [](const QString& f) { return f; };
+    const QString in  = QStringLiteral(".INCLUDE \"$HOME/lib.inc\"\n");
+    const QString out = rewriteIncludeLines(in, echo, true);
+    expectEqual(out, in, "env-var-left-untouched");
+  }
+
+  // 4. Token already an absolute, existing path; resolver echoes it back ->
+  // still requoted.
+  {
+    QTemporaryFile tmp;
+    expectTrue(tmp.open(), "temp-file-open");
+    const QString absPath  = QFileInfo(tmp).absoluteFilePath();
+    auto echo              = [](const QString& f) { return f; };
+    const QString in       = QStringLiteral(".include %1\n").arg(absPath);
+    const QString out      = rewriteIncludeLines(in, echo, true);
+    const QString expected = QStringLiteral(".include \"%1\"\n").arg(absPath);
+    expectEqual(out, expected, "absolute-existing-requoted");
+  }
+
+  // 5. quoteResolved = false -> no quotes even though resolved.
+  {
+    auto resolver = [](const QString& f) {
+      return QStringLiteral("/abs/dir/") + f;
+    };
+    const QString in  = QStringLiteral(".INCLUDE \"test.inc\"\n");
+    const QString out = rewriteIncludeLines(in, resolver, false);
+    expectEqual(out, QStringLiteral(".INCLUDE /abs/dir/test.inc\n"),
+                "quote-resolved-false");
+  }
+
+  // 6. Case-insensitivity, original keyword case preserved.
+  {
+    auto resolver = [](const QString& f) {
+      return QStringLiteral("/abs/dir/") + f;
+    };
+    const QString in  = QStringLiteral(".Include test.inc\n");
+    const QString out = rewriteIncludeLines(in, resolver, true);
+    expectEqual(out, QStringLiteral(".Include \"/abs/dir/test.inc\"\n"),
+                "case-insensitive-preserved-case");
+  }
+
+  // 7. Full-line comment left untouched; resolver never invoked.
+  {
+    int calls = 0;
+    std::function<QString(const QString&)> counting =
+        [&calls](const QString& f) {
+          ++calls;
+          return f;
+        };
+    const QString in  = QStringLiteral("* .INCLUDE foo.inc\n");
+    const QString out = rewriteIncludeLines(in, counting, true);
+    expectEqual(out, in, "comment-line-untouched");
+    expectTrue(calls == 0, "comment-line-resolver-not-called");
+  }
+
+  // 8. Mixed block: only .INCLUDE lines touched, others preserved exactly,
+  // order kept.
+  {
+    auto resolver = [](const QString& f) {
+      return QStringLiteral("/abs/") + f;
+    };
+    const QString in       = QStringLiteral(".PARAM rp = 1k\n"
+                                                  ".INCLUDE a.inc\n"
+                                                  ".FUNC prod(x,y) = {x*y}\n"
+                                                  "\n"
+                                                  ".INCLUDE b.inc\n");
+    const QString out      = rewriteIncludeLines(in, resolver, true);
+    const QString expected = QStringLiteral(".PARAM rp = 1k\n"
+                                            ".INCLUDE \"/abs/a.inc\"\n"
+                                            ".FUNC prod(x,y) = {x*y}\n"
+                                            "\n"
+                                            ".INCLUDE \"/abs/b.inc\"\n");
+    expectEqual(out, expected, "mixed-block-only-includes-touched");
+  }
+
+  // 9. Quoted filename with an embedded space: resolver receives the whole
+  // token.
+  {
+    QString capturedArg;
+    std::function<QString(const QString&)> capture =
+        [&capturedArg](const QString& f) {
+          capturedArg = f;
+          return QStringLiteral("/abs/") + f;
+        };
+    const QString in  = QStringLiteral(".INCLUDE \"lib file.inc\"\n");
+    const QString out = rewriteIncludeLines(in, capture, true);
+    expectEqual(capturedArg, QStringLiteral("lib file.inc"),
+                "space-token-captured-whole");
+    expectEqual(out, QStringLiteral(".INCLUDE \"/abs/lib file.inc\"\n"),
+                "space-token-requoted");
+  }
+
+  // 10. Unterminated quote -> left unchanged, resolver never invoked.
+  {
+    int calls = 0;
+    std::function<QString(const QString&)> counting =
+        [&calls](const QString& f) {
+          ++calls;
+          return f;
+        };
+    const QString in  = QStringLiteral(".INCLUDE \"broken.inc\n");
+    const QString out = rewriteIncludeLines(in, counting, true);
+    expectEqual(out, in, "unterminated-quote-untouched");
+    expectTrue(calls == 0, "unterminated-quote-resolver-not-called");
+  }
+
+  // 11. No trailing newline in input -> none in output either.
+  {
+    auto resolver = [](const QString& f) {
+      return QStringLiteral("/abs/") + f;
+    };
+    const QString in  = QStringLiteral(".INCLUDE a.inc");
+    const QString out = rewriteIncludeLines(in, resolver, true);
+    expectEqual(out, QStringLiteral(".INCLUDE \"/abs/a.inc\""),
+                "no-trailing-newline-preserved");
+  }
+
+  // 12. Indentation, directive case, inner spacing, trailing comment, and
+  // trailing newline are all preserved around a rewritten quoted path.
+  {
+    QString capturedArg;
+    std::function<QString(const QString&)> capture =
+        [&capturedArg](const QString& f) {
+          capturedArg = f;
+          return QStringLiteral("/abs/a.inc");
+        };
+    const QString in  = QStringLiteral("\t.Include   \"a.inc\" ; keep this\n");
+    const QString out = rewriteIncludeLines(in, capture, true);
+    expectEqual(capturedArg, QStringLiteral("a.inc"),
+                "surroundings-preserved-resolver-arg");
+    expectEqual(out,
+                QStringLiteral("\t.Include   \"/abs/a.inc\" ; keep this\n"),
+                "surroundings-preserved");
+  }
+
+  if (failures == 0) {
+    std::printf("All InclScriptDirectiveRewrite tests passed.\n");
+    return 0;
+  }
+  std::fprintf(stderr, "%d test(s) failed.\n", failures);
+  return 1;
+}


### PR DESCRIPTION
## Summary

Resolve relative `.INCLUDE` paths written inside an INCLUDE SCRIPT component against the directory of the containing schematic.

Unresolved or malformed directives remain unchanged. `.LIB` handling is intentionally outside the scope of this change.

## Reproduction

1. Save a schematic in a directory containing spaces.
2. Place an include file beside the schematic.
3. Add an INCLUDE SCRIPT component containing:

   `.INCLUDE "test file.inc"`

Before this change, the generated Ngspice netlist preserved the relative path and Ngspice reported:

`Error: Could not find include file test file.inc`

## Changes

- Resolve existing relative `.INCLUDE` files before generating the SPICE netlist.
- Preserve indentation, directive case, spacing, comments and newline structure.
- Preserve unresolved paths and malformed directives unchanged.
- Retain the existing Xyce environment-variable expansion and SpiceOpus quoting behavior.
- Add an isolated regression test with 12 cases.

## Verification

- Full Qucs-S debug build completed successfully.
- `GeometryTest` passed.
- `InclScriptDirectiveRewriteTest` passed.
- Manual Ngspice reproduction now completes successfully.
- The generated netlist contains:

  `.INCLUDE "/home/subi/Qucs Test/issue-1682/test file.inc"`

Fixes #1682.