### PR TITLE
Fix filled arrow heads in component symbols

### DIFF
--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 #include <cmath>
 
+#include "arrow_head.h"
 #include "component.h"
 #include "libcomp.h"
 #include "resistor.h"
@@ -1205,9 +1206,13 @@ int Component::analyseLine(const QString &Row, int numProps) {
         if (!getIntegers(Row, &i1, &i2, &i3, &i4, &i5, &i6)) return -1;
         if (!getPen(Row, Pen, 7)) return -1;
 
-        double beta = atan2(double(i6), double(i5));
-        double phi = atan2(double(i4), double(i3));
-        double Length = sqrt(double(i6 * i6 + i5 * i5));
+        QString headStyleStr = Row.section(' ', 10, 10);
+        bool filled = !headStyleStr.isEmpty() && headStyleStr.toInt() != 0;
+
+        double headHeight = i5;
+        double headWidth = i6;
+        double dx = i3;
+        double dy = i4;
 
         i3 += i1;
         i4 += i2;
@@ -1222,23 +1227,40 @@ int Component::analyseLine(const QString &Row, int numProps) {
 
         Lines.append(new qucs::Line(i1, i2, i3, i4, Pen));   // base line
 
-        double w = beta + phi;
-        i5 = i3 - int(Length * cos(w));
-        i6 = i4 - int(Length * sin(w));
-        Lines.append(new qucs::Line(i3, i4, i5, i6, Pen)); // arrow head
+        qucs_s::geom::ArrowHeadShape head = qucs_s::geom::computeArrowHeadShape(
+            i3, i4, dx, dy, headHeight, headWidth, filled);
+
+        i5 = i3 - int(head.wingOffset1.x);
+        i6 = i4 - int(head.wingOffset1.y);
+        if (!head.filled) {
+            Lines.append(new qucs::Line(i3, i4, i5, i6, Pen)); // arrow head
+        }
+        if (i5 < x1) x1 = i5;  // keep track of component boundings
+        if (i5 > x2) x2 = i5;
+        if (i6 < y1) y1 = i6;
+        if (i6 > y2) y2 = i6;
+        int wing1X = i5;
+        int wing1Y = i6;
+
+        i5 = i3 - int(head.wingOffset2.x);
+        i6 = i4 - int(head.wingOffset2.y);
+        if (!head.filled) {
+            Lines.append(new qucs::Line(i3, i4, i5, i6, Pen));
+        }
         if (i5 < x1) x1 = i5;  // keep track of component boundings
         if (i5 > x2) x2 = i5;
         if (i6 < y1) y1 = i6;
         if (i6 > y2) y2 = i6;
 
-        w = phi - beta;
-        i5 = i3 - int(Length * cos(w));
-        i6 = i4 - int(Length * sin(w));
-        Lines.append(new qucs::Line(i3, i4, i5, i6, Pen));
-        if (i5 < x1) x1 = i5;  // keep track of component boundings
-        if (i5 > x2) x2 = i5;
-        if (i6 < y1) y1 = i6;
-        if (i6 > y2) y2 = i6;
+        if (head.filled) {
+            std::vector<QPointF> headPoints{
+                QPointF(wing1X, wing1Y),
+                QPointF(i3, i4),
+                QPointF(i5, i6)
+            };
+            Polylines.append(new qucs::Polyline(
+                headPoints, Pen, QBrush(Pen.color())));
+        }
 
         return 1;
     } else if (s == "Ellipse") {

--- a/qucs/element.cpp
+++ b/qucs/element.cpp
@@ -41,7 +41,11 @@ void Ellips::draw(QPainter* painter) const {
 }
 
 void Polyline::draw(QPainter* painter) const {
-    painter->drawPolyline(points.data(), points.size());
+    if (brush.style() == Qt::NoBrush) {
+        painter->drawPolyline(points.data(), points.size());
+    } else {
+        painter->drawPolygon(points.data(), points.size());
+    }
 }
 
 } // namespace qucs

--- a/qucs/geometry/CMakeLists.txt
+++ b/qucs/geometry/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(geometry STATIC
     "multi_point.h"
     "one_point.h"
     "shapes.h"
+    "arrow_head.h"
     )
 
 add_executable(test_geometry test_geometry.cpp)

--- a/qucs/geometry/arrow_head.h
+++ b/qucs/geometry/arrow_head.h
@@ -1,0 +1,63 @@
+#ifndef GEOMETRY_ARROW_HEAD_H
+#define GEOMETRY_ARROW_HEAD_H
+
+#include <array>
+#include <cmath>
+
+namespace qucs_s {
+namespace geom {
+
+struct Point2D {
+    double x, y;
+};
+
+struct ArrowHeadShape {
+    bool filled;
+    // Open-head representation: two lines from the shaft tip to each wing.
+    Point2D wing1;
+    Point2D wing2;
+    // Offsets from the shaft end to each wing, exposed so callers can
+    // reproduce the original "shaftEnd - int(offset)" truncation order.
+    Point2D wingOffset1;
+    Point2D wingOffset2;
+    // Filled-head representation: one closed triangle {wing1, tip, wing2}.
+    std::array<Point2D, 3> headPoints;
+};
+
+// shaftEndX/shaftEndY: the arrow tip (shaft start offset by dx/dy).
+// dx/dy: the shaft direction vector (pre-offset deltas).
+// headHeight/headWidth: arrow head size fields.
+// filled: the requested headStyle.
+inline ArrowHeadShape computeArrowHeadShape(double shaftEndX, double shaftEndY,
+                                             double dx, double dy,
+                                             double headHeight,
+                                             double headWidth,
+                                             bool filled) noexcept {
+    double beta = std::atan2(headWidth, headHeight);
+    double phi = std::atan2(dy, dx);
+    double length = std::sqrt(headWidth * headWidth + headHeight * headHeight);
+
+    double w = beta + phi;
+    Point2D wingOffset1{length * std::cos(w), length * std::sin(w)};
+    Point2D wing1{shaftEndX - wingOffset1.x, shaftEndY - wingOffset1.y};
+
+    w = phi - beta;
+    Point2D wingOffset2{length * std::cos(w), length * std::sin(w)};
+    Point2D wing2{shaftEndX - wingOffset2.x, shaftEndY - wingOffset2.y};
+
+    ArrowHeadShape shape{};
+    shape.filled = filled;
+    shape.wing1 = wing1;
+    shape.wing2 = wing2;
+    shape.wingOffset1 = wingOffset1;
+    shape.wingOffset2 = wingOffset2;
+    shape.headPoints[0] = wing1;
+    shape.headPoints[1] = Point2D{shaftEndX, shaftEndY};
+    shape.headPoints[2] = wing2;
+    return shape;
+}
+
+} // namespace geom
+} // namespace qucs_s
+
+#endif

--- a/qucs/symbolwidget.cpp
+++ b/qucs/symbolwidget.cpp
@@ -22,6 +22,7 @@
 #include <QtGui>
 #include <QtWidgets>
 
+#include "arrow_head.h"
 #include "symbolwidget.h"
 #include "main.h"
 #include "qucslib_common.h"
@@ -139,6 +140,17 @@ void SymbolWidget::paintEvent(QPaintEvent*)
     Painter.drawLine(cx+pl->x1, cy+pl->y1, cx+pl->x2, cy+pl->y2);
   }
 
+  // paint all polylines
+  for(int i=0; i<Polylines.size(); i++) {
+    qucs::Polyline *pl = Polylines.at(i);
+    Painter.save();
+    Painter.translate(cx, cy);
+    Painter.setPen(pl->pen);
+    Painter.setBrush(pl->brush);
+    pl->draw(&Painter);
+    Painter.restore();
+  }
+
   // paint all arcs
   for(int i=0; i<Arcs.size(); i++) {
     qucs::Arc *pc = Arcs.at(i);
@@ -185,6 +197,7 @@ int SymbolWidget::createStandardSymbol(const QString& Lib_, const QString& Comp_
 {
   Arcs.clear();
   Lines.clear();
+  Polylines.clear();
   Rects.clear();
   Ellipses.clear();
   Texts.clear();
@@ -469,6 +482,7 @@ int SymbolWidget::setSymbol( QString& SymbolString,
 
   Arcs.clear();
   Lines.clear();
+  Polylines.clear();
   Rects.clear();
   Ellipses.clear();
   Texts.clear();
@@ -530,6 +544,7 @@ int SymbolWidget::loadSymFile(const QString &file)
 
   Arcs.clear();
   Lines.clear();
+  Polylines.clear();
   Rects.clear();
   Ellipses.clear();
   Texts.clear();
@@ -662,9 +677,14 @@ int SymbolWidget::analyseLine(const QString& Row)
     if(!getCompLineIntegers(Row, &i1, &i2, &i3, &i4, &i5, &i6))  return -1;
     if(!getPen(Row, Pen, 7))  return -1;
 
-    double beta   = atan2(double(i6), double(i5));
-    double phi    = atan2(double(i4), double(i3));
-    double Length = sqrt(double(i6*i6 + i5*i5));
+    QString headStyleStr = Row.section(' ', 10, 10);
+    bool filled =
+        !headStyleStr.isEmpty() && headStyleStr.toInt() != 0;
+
+    double headHeight = i5;
+    double headWidth  = i6;
+    double dx = i3;
+    double dy = i4;
 
     i3 += i1;
     i4 += i2;
@@ -679,23 +699,40 @@ int SymbolWidget::analyseLine(const QString& Row)
 
     Lines.append(new qucs::Line(i1, i2, i3, i4, Pen));   // base line
 
-    double w = beta+phi;
-    i5 = i3-int(Length*cos(w));
-    i6 = i4-int(Length*sin(w));
-    Lines.append(new qucs::Line(i3, i4, i5, i6, Pen)); // arrow head
+    qucs_s::geom::ArrowHeadShape head = qucs_s::geom::computeArrowHeadShape(
+        i3, i4, dx, dy, headHeight, headWidth, filled);
+
+    i5 = i3-int(head.wingOffset1.x);
+    i6 = i4-int(head.wingOffset1.y);
+    if(!head.filled) {
+      Lines.append(new qucs::Line(i3, i4, i5, i6, Pen)); // arrow head
+    }
+    if(i5 < x1)  x1 = i5;  // keep track of component boundings
+    if(i5 > x2)  x2 = i5;
+    if(i6 < y1)  y1 = i6;
+    if(i6 > y2)  y2 = i6;
+    int wing1X = i5;
+    int wing1Y = i6;
+
+    i5 = i3-int(head.wingOffset2.x);
+    i6 = i4-int(head.wingOffset2.y);
+    if(!head.filled) {
+      Lines.append(new qucs::Line(i3, i4, i5, i6, Pen));
+    }
     if(i5 < x1)  x1 = i5;  // keep track of component boundings
     if(i5 > x2)  x2 = i5;
     if(i6 < y1)  y1 = i6;
     if(i6 > y2)  y2 = i6;
 
-    w = phi-beta;
-    i5 = i3-int(Length*cos(w));
-    i6 = i4-int(Length*sin(w));
-    Lines.append(new qucs::Line(i3, i4, i5, i6, Pen));
-    if(i5 < x1)  x1 = i5;  // keep track of component boundings
-    if(i5 > x2)  x2 = i5;
-    if(i6 < y1)  y1 = i6;
-    if(i6 > y2)  y2 = i6;
+    if(head.filled) {
+      std::vector<QPointF> headPoints{
+          QPoint(wing1X, wing1Y),
+          QPoint(i3, i4),
+          QPoint(i5, i6)
+      };
+      Polylines.append(new qucs::Polyline(
+          headPoints, Pen, QBrush(Pen.color())));
+    }
 
     return 1;
   }

--- a/qucs/symbolwidget.h
+++ b/qucs/symbolwidget.h
@@ -88,6 +88,7 @@ private:
   int TextWidth, DragNDropWidth, TextHeight;
   int cx, cy, x1, x2, y1, y2;
   QList<qucs::Line *> Lines;
+  QList<qucs::Polyline *> Polylines;
   QList<qucs::Arc *> Arcs;
   QList<qucs::Rect *> Rects;
   QList<qucs::Ellips *> Ellipses;


### PR DESCRIPTION
## Summary

- Preserve the arrow `headStyle` when a symbol is loaded as a component.
- Render filled arrow heads in both placed components and the symbol preview.
- Keep legacy symbols without `headStyle` rendered with open arrow heads.
- Share the arrow-head geometry calculation for filled and open heads.

## Testing

- `cmake --build build/current-debug --parallel 4`
- `ctest --test-dir build/current-debug --output-on-failure`
- Manually verified that the filled arrow is rendered correctly in the
  original symbol and in a placed Subcircuit component.

Fixes #1683