### PR TITLE
Avoid DC bias labels over voltage probes

### DIFF
--- a/qucs/CMakeLists.txt
+++ b/qucs/CMakeLists.txt
@@ -149,11 +149,13 @@ SET(QUCS_SRCS
   imagewriter.cpp printerwriter.cpp projectView.cpp
   symbolwidget.cpp wire_planner.cpp
   qucsshortcutmanager.cpp
+  dcbiaslabel.cpp
 )
 
 SET(QUCS_HDRS
 element.h
 conductor.h
+dcbiaslabel.h
 healer.h
 main.h
 messagedock.h
@@ -268,6 +270,13 @@ TARGET_LINK_LIBRARIES( ${QUCS_NAME}
     components diagrams dialogs geometry paintings extsimkernels spicecomponents magnetics qt3_compat
     Qt6::Core  Qt6::Gui  Qt6::Widgets Qt6::Svg  Qt6::SvgWidgets Qt6::Xml  Qt6::PrintSupport )
 SET_TARGET_PROPERTIES(${QUCS_NAME} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
+add_executable(test_dcbiaslabel
+    test_dcbiaslabel.cpp
+    dcbiaslabel.cpp
+)
+target_link_libraries(test_dcbiaslabel PRIVATE Qt6::Core)
+add_test(NAME DcBiasLabelTest COMMAND test_dcbiaslabel)
 #
 # Prepare the installation
 #

--- a/qucs/dcbiaslabel.cpp
+++ b/qucs/dcbiaslabel.cpp
@@ -1,0 +1,10 @@
+#include "dcbiaslabel.h"
+
+bool shouldSuppressDcBiasLabel(const QString& componentModel,
+                               const QRect& labelRect,
+                               const QRect& componentRect) {
+  if (componentModel != QLatin1String("VProbe")) {
+    return false;
+  }
+  return labelRect.intersects(componentRect);
+}

--- a/qucs/dcbiaslabel.h
+++ b/qucs/dcbiaslabel.h
@@ -1,0 +1,11 @@
+#ifndef DCBIASLABEL_H
+#define DCBIASLABEL_H
+
+#include <QRect>
+#include <QString>
+
+bool shouldSuppressDcBiasLabel(const QString& componentModel,
+                               const QRect& labelRect,
+                               const QRect& componentRect);
+
+#endif

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -22,6 +22,7 @@
 #include "components/vafile.h"
 #include "components/verilogfile.h"
 #include "components/vhdlfile.h"
+#include "dcbiaslabel.h"
 #include "diagrams/diagram.h"
 #include "main.h"
 #include "mouseactions.h"
@@ -507,6 +508,18 @@ void Schematic::drawDcBiasPoints(QPainter* painter) {
 
         int rectX = x - rectWidth / 2;
         int rectY = y - rectHeight / 2;
+
+        const QRect labelRect(rectX, rectY, rectWidth, rectHeight);
+
+        const bool suppressLabel = std::ranges::any_of(
+            pn->components(), [&labelRect](const Component* component) {
+              return shouldSuppressDcBiasLabel(component->Model, labelRect,
+                                               component->boundingRect());
+            });
+
+        if (suppressLabel) {
+          continue;
+        }
 
         painter->setBrush(QBrush(QColor(230,230,230)));
         painter->setPen(Qt::NoPen);

--- a/qucs/test_dcbiaslabel.cpp
+++ b/qucs/test_dcbiaslabel.cpp
@@ -1,0 +1,27 @@
+#include "dcbiaslabel.h"
+
+#include <cassert>
+
+namespace testShouldSuppressDcBiasLabel {
+
+void run() {
+  const QRect labelRect(0, 0, 20, 10);
+  const QRect overlappingRect(5, 5, 20, 20);
+  const QRect farRect(500, 500, 20, 20);
+
+  assert(shouldSuppressDcBiasLabel(QStringLiteral("VProbe"), labelRect,
+                                   overlappingRect));
+  assert(!shouldSuppressDcBiasLabel(QStringLiteral("R"), labelRect,
+                                    overlappingRect));
+  assert(!shouldSuppressDcBiasLabel(QStringLiteral("IProbe"), labelRect,
+                                    overlappingRect));
+  assert(
+      !shouldSuppressDcBiasLabel(QStringLiteral("VProbe"), labelRect, farRect));
+}
+
+} // namespace testShouldSuppressDcBiasLabel
+
+int main() {
+  testShouldSuppressDcBiasLabel::run();
+  return 0;
+}


### PR DESCRIPTION
## Summary

- suppress a DC bias label when its rectangle overlaps a directly connected
  voltage probe;
- keep DC bias labels unchanged for other component types and for voltage
  probes that do not overlap the label;
- add focused tests for the probe-model and rectangle-intersection decision.

## Problem

DC bias labels are positioned relative to node coordinates. At voltage-probe
terminals, the voltage labels can overlap each other and cover the probe
symbol, making values such as `5V` and `0V` appear visually combined.

The calculated DC values are correct; this change only addresses their
rendering.

## Implementation

The renderer calculates the label rectangle before drawing it and checks the
components directly connected to the node.

The label is skipped only when:

- the connected component model is exactly `VProbe`; and
- the label rectangle intersects the component bounding rectangle.

This avoids suppressing labels merely because a voltage probe is connected to
the node.

## Testing

- `cmake --build build/current-debug --parallel 4`
- `ctest --test-dir build/current-debug --output-on-failure`
  - `DcBiasLabelTest`: passed
  - `GeometryTest`: passed
- manual verification with the reproduction schematic:
  - the labels no longer cover the `VProbe` terminals or symbol;
  - voltage and current labels elsewhere remain visible.

Fixes #1316

A broader automatic placement strategy for DC bias labels is tracked
separately in #1692.