### PR TITLE
Don't render probe labels for VProbe and DC bias mode

### DIFF
--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -487,6 +487,12 @@ void Schematic::drawDcBiasPoints(QPainter* painter) {
         if (pn->Name.isEmpty())
             continue;
 
+        // Skip render labels on voltage probe pins
+        // because probe pin labels duplicates node voltage
+        if (pn->components().size() ==  1) {
+          if (pn->components().front()->Model == "VProbe") continue;
+        }
+
         QString value = misc::formatValue(pn->Name, 4);
 
         x = pn->cx;


### PR DESCRIPTION
This PR fixes #1316 The voltage labels for show DC bias mode are disabled for VProbe to avoid overlap. The following cases are processed correctly:

<img width="1424" height="780" alt="image" src="https://github.com/user-attachments/assets/1a3a46e2-513c-472d-8e62-e1149ba8a2d0" />
