### PR TITLE
Allow loading simulator-incompatible schematics

### DIFF
--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -1785,6 +1785,14 @@ Component *getComponentFromName(QString &Line, Schematic *p) {
         c = Module::getComponent(cstr);
 
     if (!c) {
+        // Model is known but incompatible with the currently selected
+        // simulator: instantiate the real component type anyway so the
+        // schematic loads; Component::drawSymbol() renders it with
+        // WrongSimulatorPen and netlisting is rejected explicitly later.
+        c = Module::getComponentForLoad(cstr);
+    }
+
+    if (!c) {
         /// \todo enable user to load partial schematic, skip unknown components
         if (QucsMain != nullptr) {
             QMessageBox *msg = new QMessageBox(QMessageBox::Warning, QObject::tr("Warning"),

--- a/qucs/module.cpp
+++ b/qucs/module.cpp
@@ -35,6 +35,7 @@ QHash<QString, Module *> Module::Modules;
 QList<Category *> Category::Categories;
 
 QMap<QString, QString> Module::vaComponents;
+QHash<QString, pInfoFunc> Module::LoadFactories;
 
 // Constructor creates instance of module object.
 Module::Module () {
@@ -67,6 +68,13 @@ void Module::registerComponent(QString category, pInfoFunc info) {
   char* File;
   Component* c = (Component*)info(Name, File, true);
 
+  // register the factory unconditionally so that schematic loading can
+  // still recognize and instantiate this component model even when it is
+  // incompatible with the currently selected simulator
+  if (!LoadFactories.contains(c->Model)) {
+    LoadFactories.insert(c->Model, info);
+  }
+
   // put into category and the component hash
   if ((c->Simulator & QucsSettings.DefaultSimulator) ==
       QucsSettings.DefaultSimulator) {
@@ -98,6 +106,19 @@ Component * Module::getComponent (QString Model) {
               vacomponent::info (Name, vaBitmap, true, vaComponents[Model]);
     else
       return (Component *) m->info (Name, File, true);
+  }
+  return 0;
+}
+
+// Returns instantiated component based on the given "Model" name, ignoring
+// simulator compatibility. Used while loading a schematic so that a
+// previously-registered component model is never treated as unknown just
+// because it is incompatible with the currently selected simulator.
+Component* Module::getComponentForLoad(QString Model) {
+  if (LoadFactories.contains(Model)) {
+    QString Name;
+    char* File;
+    return (Component*)LoadFactories.value(Model)(Name, File, true);
   }
   return 0;
 }
@@ -644,6 +665,7 @@ void Module::unregisterModules(void) {
     }
   }
   Modules.clear();
+  LoadFactories.clear();
 }
 
 // Constructor creates instance of module object.

--- a/qucs/module.h
+++ b/qucs/module.h
@@ -39,11 +39,16 @@ class Module
   static void registerComponent (QString, pInfoFunc);
   static void intoCategory (Module *);
   static Component * getComponent (QString);
+  static Component* getComponentForLoad(QString);
   static void registerDynamicComponents(void);
 
  public:
   static QHash<QString, Module *> Modules;
   static QMap<QString, QString> vaComponents;
+  // Unconditional model name -> factory registry used only while loading a
+  // schematic, so that components incompatible with the currently selected
+  // simulator can still be recognized and instantiated as their real type.
+  static QHash<QString, pInfoFunc> LoadFactories;
 
  public:
   static void registerModules (void);

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -42,6 +42,7 @@
 #include "module.h"
 #include "misc.h"
 #include "extsimkernels/abstractspicekernel.h"
+#include "extsimkernels/spicecompat.h"
 #include "extsimkernels/s2spice.h"
 #include "osdi/osdi_0_3.h"
 
@@ -1555,6 +1556,21 @@ bool Schematic::throughAllComps(QTextStream *stream, int& countInit,
   for (auto* pc : a_DocComps) {
 
     if(pc->isActive != COMP_IS_ACTIVE) continue;
+
+    // reject netlisting an active component that is incompatible with the
+    // currently selected simulator, instead of silently emitting an
+    // incomplete netlist (e.g. a component loaded from CLI for a schematic
+    // whose default simulator does not support it)
+    if ((pc->Simulator & QucsSettings.DefaultSimulator) !=
+        QucsSettings.DefaultSimulator) {
+      ErrText->appendPlainText(
+          QObject::tr("ERROR: Component \"%1\" (%2) is not compatible with the "
+                      "selected simulator \"%3\".")
+              .arg(pc->Name, pc->Model,
+                   spicecompat::getDefaultSimulatorName(
+                       QucsSettings.DefaultSimulator)));
+      return false;
+    }
 
     if(pc->Model == "CMD") continue; // Skip "system command" component. It must not go to the simulation backend
 


### PR DESCRIPTION
## Summary

- recognize registered component models while loading, even when they are incompatible with the currently selected simulator;
- preserve the real component type and its properties instead of treating it as unknown;
- reject netlist generation explicitly when an active component is incompatible with the selected simulator;
- keep the existing simulator filtering of the component picker unchanged.

## Problem

Component registration currently filters `Module::Modules` by the selected simulator. When a schematic contains a known component for another simulator, loading can therefore treat that component as unknown and abort the entire schematic.

For example, opening `examples/ngspice/Devices/single_phase_transformer.sch` from the command line while Qucsator is selected fails because its `K_SPICE` components are not present in the simulator-filtered lookup.

The positional command-line form without `-i` already works on the current branch and was verified separately with absolute, relative, and quoted paths.

## Solution

Add a separate model-to-factory registry populated independently of simulator compatibility and use it only as a fallback during schematic loading.

This allows incompatible components to be instantiated as their real type, preserving their model and properties. Their existing incompatible-simulator rendering remains visible.

Before netlist generation, active components are checked against the selected simulator. An incompatible component now produces an explicit error instead of allowing an incomplete netlist.

The normal component registry and picker remain simulator-filtered.

## Validation

- `cmake --build build/current-debug --parallel 4`
- `ctest --test-dir build/current-debug --output-on-failure`
  - 1/1 test passed
- opened the transformer example from the CLI with Qucsator selected;
- confirmed `K12`, `K13`, and `K23` loaded and appeared attenuated;
- confirmed Qucsator simulation was explicitly rejected;
- switched to Ngspice and confirmed the components became compatible;
- saved and reopened the schematic;
- confirmed the serialized `K_SPICE` lines were preserved exactly;
- confirmed `git diff --check` is clean.

Resolves #973