### PR TITLE
Inline document rename

### DIFF
--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -1326,6 +1326,17 @@ void QucsApp::slotCMenuRename()
   QString file(QucsSettings.QucsWorkDir.filePath(filename));
   QFileInfo fileinfo(file);
 
+  int index=0;
+  QucsDoc* Doc = findDoc(file, &index);
+
+  if (Doc){
+    // The document is already open in the tab, so use the rename on tab feature
+    DocumentTab->startRename(index);
+    return;
+  }
+
+  // The file is not open
+
   if (findDoc(file)) {
     QMessageBox::critical(this, tr("Error"),
         tr("Cannot rename an open file!"));

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -1337,13 +1337,6 @@ void QucsApp::slotCMenuRename()
 
   // The file is not open
 
-  if (findDoc(file)) {
-    QMessageBox::critical(this, tr("Error"),
-        tr("Cannot rename an open file!"));
-    return;
-  }
-
-  QString suffix = fileinfo.suffix();
   QString base = fileinfo.completeBaseName();
   if(base.isEmpty()) {
     base = filename;
@@ -1352,18 +1345,46 @@ void QucsApp::slotCMenuRename()
   bool ok;
   QString s = QInputDialog::getText(this, tr("Rename file"), tr("Enter new filename:"), QLineEdit::Normal, base, &ok);
 
-  if(ok && !s.isEmpty()) {
-    if (!s.endsWith(suffix)) {
-      s += QStringLiteral(".") + suffix;
-    }
-    QDir dir(QucsSettings.QucsWorkDir.path());
-    if(!dir.rename(filename, s)) {
-      QMessageBox::critical(this, tr("Error"), tr("Cannot rename file: %1").arg(filename));
-      return;
-    }
+  if (!ok || s.isEmpty())
+    return;
 
+  if (!renameFileOnDisk(file, s).isEmpty()) {
     slotUpdateTreeview();
   }
+}
+
+QString QucsApp::renameFileOnDisk(const QString &oldPath, const QString &newBase)
+{
+  QFileInfo info(oldPath);
+  QString suffix = info.suffix();
+  QString base = info.completeBaseName();
+  if (base.isEmpty())
+    base = info.fileName();
+
+         // Allow callers to pass a name that already includes the extension.
+  QString requestedBase = newBase;
+  if (!suffix.isEmpty() && requestedBase.endsWith("." + suffix)) {
+    requestedBase.chop(suffix.length() + 1);
+  }
+
+  if (requestedBase.isEmpty() || requestedBase == base)
+    return QString(); // no change / cancel
+
+  QString newName = suffix.isEmpty() ? requestedBase : requestedBase + "." + suffix;
+  QDir dir = info.dir();
+  QString newPath = dir.filePath(newName);
+
+  if (QFile::exists(newPath)) {
+    QMessageBox::critical(this, tr("Error"),
+                          tr("A file named '%1' already exists!").arg(newName));
+    return QString();
+  }
+  if (!dir.rename(info.fileName(), newName)) {
+    QMessageBox::critical(this, tr("Error"),
+                          tr("Cannot rename file: %1").arg(info.fileName()));
+    return QString();
+  }
+  return newPath;
 }
 
 void QucsApp::slotCMenuDelete()
@@ -4152,35 +4173,15 @@ bool QucsApp::renameDocumentTab(int index, const QString &newBase)
     Doc->save();
   }
 
-  QFileInfo info(Doc->getDocName());
-  QString suffix = info.suffix();
-  QString base   = info.completeBaseName();
-
-  if (newBase.isEmpty() || newBase == base)
-    return false;   // no change / empty -> treat as cancel
-
-  QString newName = suffix.isEmpty() ? newBase : newBase + "." + suffix;
-  QDir dir = info.dir();
-  QString newPath = dir.filePath(newName);
-
-  if (QFile::exists(newPath)) {
-    QMessageBox::critical(this, tr("Error"),
-                          tr("A file named '%1' already exists!").arg(newName));
+  QString newPath = renameFileOnDisk(Doc->getDocName(), newBase);
+  if (newPath.isEmpty())
     return false;
-  }
-  if (!dir.rename(info.fileName(), newName)) {
-    QMessageBox::critical(this, tr("Error"),
-                          tr("Cannot rename file: %1").arg(info.fileName()));
-    return false;
-  }
 
   Doc->setName(newPath);
   DocumentTab->setTabText(index, misc::properFileName(newPath));
   DocumentTab->setTabToolTip(index, newPath);
-
   if (index == DocumentTab->currentIndex())
     slotChangeView();
-
   slotUpdateTreeview();
   updateRecentFilesList(newPath);
   return true;

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -4121,6 +4121,60 @@ void QucsApp::runPostSimCommands(Schematic* sch)
   }
 }
 
+bool QucsApp::renameDocumentTab(int index, const QString &newBase)
+{
+  QucsDoc *Doc = getDoc(index);
+  if (!Doc) return false;
+
+  // Check if the document has unsaved changes
+  if (Doc->getDocChanged()) {
+    QMessageBox::StandardButton answer = QMessageBox::warning(this, tr("Renaming Qucs-S document"),
+                         tr("The document contains unsaved changes!\n") +
+                             tr("Do you want to save and rename?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+
+    if (answer != QMessageBox::Yes){
+      // The user doesn't want to save and rename -> Cancel
+      return false;
+    }
+
+    // Save the document.
+    Doc->save();
+  }
+
+  QFileInfo info(Doc->getDocName());
+  QString suffix = info.suffix();
+  QString base   = info.completeBaseName();
+
+  if (newBase.isEmpty() || newBase == base)
+    return false;   // no change / empty -> treat as cancel
+
+  QString newName = suffix.isEmpty() ? newBase : newBase + "." + suffix;
+  QDir dir = info.dir();
+  QString newPath = dir.filePath(newName);
+
+  if (QFile::exists(newPath)) {
+    QMessageBox::critical(this, tr("Error"),
+                          tr("A file named '%1' already exists!").arg(newName));
+    return false;
+  }
+  if (!dir.rename(info.fileName(), newName)) {
+    QMessageBox::critical(this, tr("Error"),
+                          tr("Cannot rename file: %1").arg(info.fileName()));
+    return false;
+  }
+
+  Doc->setName(newPath);
+  DocumentTab->setTabText(index, misc::properFileName(newPath));
+  DocumentTab->setTabToolTip(index, newPath);
+
+  if (index == DocumentTab->currentIndex())
+    slotChangeView();
+
+  slotUpdateTreeview();
+  updateRecentFilesList(newPath);
+  return true;
+}
+
 QVariant QucsFileSystemModel::data( const QModelIndex& index, int role ) const
 {
     if (role == Qt::DecorationRole) { // it's an icon
@@ -4180,6 +4234,7 @@ ContextMenuTabWidget::ContextMenuTabWidget(QucsApp *parent) : QTabWidget(parent)
   App = parent;
   setContextMenuPolicy(Qt::CustomContextMenu);
   connect(this, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(showContextMenu(const QPoint&)));
+  connect(tabBar(), SIGNAL(tabBarDoubleClicked(int)), this, SLOT(startRename(int)));
 }
 
 void ContextMenuTabWidget::showContextMenu(const QPoint& point)
@@ -4209,6 +4264,8 @@ void ContextMenuTabWidget::showContextMenu(const QPoint& point)
     menu.addSeparator();
     APPEND_MENU(ActionCxMenuCopyPath, slotCxMenuCopyPath, "Copy full path")
     APPEND_MENU(ActionCxMenuOpenFolder, slotCxMenuOpenFolder, "Open containing folder")
+    APPEND_MENU(ActionCxMenuRename, slotCxMenuRename, "Rename")
+
 #undef APPEND_MENU
 
     menu.exec(tabBar()->mapToGlobal(point));
@@ -4263,4 +4320,73 @@ void ContextMenuTabWidget::slotCxMenuOpenFolder()
     QFileInfo Info(dName);
     QDesktopServices::openUrl(QUrl::fromLocalFile(Info.canonicalPath()));
   }
+}
+
+
+void ContextMenuTabWidget::startRename(int index)
+{
+  if (index < 0) return;
+
+  QucsDoc *Doc = App->getDoc(index);
+  if (!Doc || Doc->getDocName().isEmpty()) {
+    QMessageBox::information(this, tr("Info"),
+                             tr("Please save the document first before renaming it."));
+    return;
+  }
+
+  editIndex = index;
+
+  if (!tabEditor) {
+    tabEditor = new QLineEdit(tabBar());
+    tabEditor->setFrame(false);
+    connect(tabEditor, SIGNAL(editingFinished()), this, SLOT(commitRename()));
+    tabEditor->installEventFilter(this);
+  }
+
+  QFileInfo info(Doc->getDocName());
+  tabEditor->setGeometry(tabBar()->tabRect(index).adjusted(2, 2, -2, -2));
+  tabEditor->setText(info.completeBaseName());  // edit the base name only
+  tabEditor->show();
+  tabEditor->raise();
+  tabEditor->selectAll();
+  tabEditor->setFocus();
+}
+
+void ContextMenuTabWidget::commitRename()
+{
+  if (!tabEditor || editIndex < 0) return;
+
+  int idx = editIndex;
+  editIndex = -1;                 // guard against re-entrancy from hide()->focusOut
+  QString newBase = tabEditor->text();
+  tabEditor->hide();
+
+  App->renameDocumentTab(idx, newBase);   // does the actual file/Doc rename
+}
+
+void ContextMenuTabWidget::cancelRename()
+{
+  editIndex = -1;
+  if (tabEditor) tabEditor->hide();
+}
+
+bool ContextMenuTabWidget::eventFilter(QObject *obj, QEvent *ev)
+{
+  if (obj == tabEditor && (ev->type() == QEvent::KeyPress || ev->type() == QEvent::ShortcutOverride)) {
+    QKeyEvent *ke = static_cast<QKeyEvent*>(ev);
+    if (ke->key() == Qt::Key_Escape) {
+      if (ev->type() == QEvent::ShortcutOverride) {
+          ev->accept();
+          return true;
+      }
+      cancelRename();
+      return true;
+    }
+  }
+  return QTabWidget::eventFilter(obj, ev);
+}
+
+void ContextMenuTabWidget::slotCxMenuRename()
+{
+  startRename(contextTabIndex);
 }

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -344,6 +344,15 @@ private:
   static bool recurRemove(const QString &);
   void closeFile(int);
 
+  /// @brief Rename a file
+  /// @param oldPath Full path to the existing file to be renamed.
+  /// @param newBase Desired new base name (with or without extension).
+  /// @return The new full file path on success, or an empty QString if
+  /// the rename was a no-op, cancelled, or failed.
+  /// @details The file extension is preserved. This is called from QucsApp::renameDocumentTab
+  /// and QucsApp::slotCMenuRename
+  QString renameFileOnDisk(const QString &oldPath, const QString &newBase);
+
   void updateRecentFilesList(QString s);
   void updateRecentProjectsList(QString pathToProj);
   void updateRecentProjectsList();

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -103,6 +103,15 @@ public:
   bool closeAllLeft(int);
   bool closeAllRight(int);
   bool gotoPage(const QString &, bool reloadPage = false); // to load a document
+
+
+  /// @brief Renames the document displayed in the tab at @p index.
+  /// @param index   Index of the tab whose document should be renamed.
+  /// @param newBase New base filename (without extension).
+  /// @return true on success, false if skipped or failed.
+  bool renameDocumentTab(int index, const QString &newBase);
+
+
   QucsDoc *getDoc(int No = -1);
   QucsDoc *findDoc(QString, int *Pos = 0);
   QString fileType(const QString &);
@@ -584,10 +593,35 @@ public:
 public slots:
   void showContextMenu(const QPoint &point);
 
+protected:
+  bool eventFilter(QObject *obj, QEvent *ev) override;
+
 private:
   int contextTabIndex; // index of tab where context menu was opened
   QucsApp *App;        // the main application - parent widget
+
+  /// @brief Variables for renaming the tab
+  /// @{
+  QLineEdit *tabEditor = nullptr; ///< Inline editor overlaid on a tab during rename.
+  int editIndex = -1;             ///< Index of the tab currently being renamed.
+  /// @}
+
 private slots:
+  /// @brief Variables and functions for renaming the tab
+  /// @{
+  /// @brief Slot for the tab context menu's "Rename" entry.
+  void slotCxMenuRename();
+
+  /// @brief Begins inline editing of the tab label at @p index.
+  void startRename(int index);
+
+  /// @brief Commits the in-place tab rename currently in progress.
+  void commitRename();
+
+  /// @brief Aborts the in-place tab rename currently in progress.
+  void cancelRename();
+  /// @}
+
   void slotCxMenuClose();
   void slotCxMenuCloseOthers();
   void slotCxMenuCloseAll();

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -593,6 +593,11 @@ public:
 public slots:
   void showContextMenu(const QPoint &point);
 
+  /// @brief Begins inline editing of the tab label at @p index.
+  /// @details This needs to be public in order to rename open files from the project panel
+  /// @see commitRename() cancelRename
+  void startRename(int index);
+
 protected:
   bool eventFilter(QObject *obj, QEvent *ev) override;
 
@@ -611,9 +616,6 @@ private slots:
   /// @{
   /// @brief Slot for the tab context menu's "Rename" entry.
   void slotCxMenuRename();
-
-  /// @brief Begins inline editing of the tab label at @p index.
-  void startRename(int index);
 
   /// @brief Commits the in-place tab rename currently in progress.
   void commitRename();


### PR DESCRIPTION
This PR adds the ability to rename open documents, either by double-clicking the tab name or via the "Rename" entry in the tab's context menu. Previously, Qucs-S couldn't rename open files (even though this was technically possible). This PR fixes that.

When the document is open, its name is edited directly on the tab: a QLineEdit is temporarily created and placed there. If the file to rename isn't open, it can still be renamed from the project panel, as before, preserving the existing functionality.

The new renameDocumentTab() function shares some logic with the existing slotCMenuRename(). This shared logic has been moved into QucsApp::renameFileOnDisk(), which both functions now use, avoiding duplication.

**Rename action added to tab context menu**
<img width="453" height="400" alt="image" src="https://github.com/user-attachments/assets/08959970-fb63-4814-a723-543cc28b1eeb" />

**Screencast about the inline document rename feature**
[InlineRename.webm](https://github.com/user-attachments/assets/f4de82bc-eae9-4132-86e6-1ec946ebdecd)