### PR TITLE
Add pre-simulation schematic checks

### DIFF
--- a/qucs/CMakeLists.txt
+++ b/qucs/CMakeLists.txt
@@ -149,6 +149,7 @@ SET(QUCS_SRCS
   imagewriter.cpp printerwriter.cpp projectView.cpp
   symbolwidget.cpp wire_planner.cpp
   qucsshortcutmanager.cpp
+  schematicvalidator.cpp
 )
 
 SET(QUCS_HDRS
@@ -166,6 +167,7 @@ octave_window.h
 qucs.h
 qucsdoc.h
 qucsshortcutmanager.h
+schematicvalidator.h
 schematic.h
 settings.h
 syntax.h

--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -164,13 +164,20 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
         "Check the schematic for common issues before running the simulation."));
     appSettingsGrid->addWidget(enableSchematicValidation, 9, 1);
 
+    appSettingsGrid->addWidget(new QLabel(tr("Validate schematic after saving:"), appSettingsTab), 10, 0);
+    validateOnSave = new QCheckBox(appSettingsTab);
+    validateOnSave->setToolTip(tr(
+        "Check the schematic for common issues after saving."));
+    appSettingsGrid->addWidget(validateOnSave, 10, 1);
+
+
     t->addTab(appSettingsTab, tr("Settings"));
 
-    appSettingsGrid->addWidget(new QLabel(tr("Set custom shortcut:"), appSettingsTab), 10, 0);
+    appSettingsGrid->addWidget(new QLabel(tr("Set custom shortcut:"), appSettingsTab), 11, 0);
     ShortcutButton = new QPushButton(appSettingsTab);
     connect(ShortcutButton, SIGNAL(clicked()),
         parent, SLOT(slotShortcutDialog()));
-    appSettingsGrid->addWidget(ShortcutButton, 10, 1);
+    appSettingsGrid->addWidget(ShortcutButton, 11, 1);
 
     // ...........................................................
     // The appearance settings tab
@@ -551,6 +558,7 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     checkWiring->setChecked(QucsSettings.NodeWiring);
     allowFlexibleWires->setChecked(_settings::Get().item<bool>("AllowFlexibleWires"));
     enableSchematicValidation->setChecked(_settings::Get().item<bool>("EnableSchematicValidation"));
+    validateOnSave->setChecked(_settings::Get().item<bool>("ValidateOnSave"));
 
     ShortcutButton->setText("Custom Shortcut");
 
@@ -778,6 +786,7 @@ void QucsSettingsDialog::slotApply()
 
     _settings::Get().setItem("AllowFlexibleWires", allowFlexibleWires->isChecked());
     _settings::Get().setItem("EnableSchematicValidation", enableSchematicValidation->isChecked());
+    _settings::Get().setItem("ValidateOnSave", validateOnSave->isChecked());
 
     QucsSettings.FileTypes.clear();
     for (int row=0; row < fileTypesTableWidget->rowCount(); row++)
@@ -982,6 +991,7 @@ void QucsSettingsDialog::slotDefaultValues()
     checkWiring->setChecked(false);
     allowFlexibleWires->setChecked(_settings::Get().itemDefault<bool>("AllowFlexibleWires"));
     enableSchematicValidation->setChecked(_settings::Get().itemDefault<bool>("EnableSchematicValidation"));
+    validateOnSave->setChecked(_settings::Get().itemDefault<bool>("ValidateOnSave"));
     checkLoadFromFutureVersions->setChecked(false);
     checkAntiAliasing->setChecked(false);
     checkTextAntiAliasing->setChecked(true);

--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -158,13 +158,19 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     allowFlexibleWires = new QCheckBox(appSettingsTab);
     appSettingsGrid->addWidget(allowFlexibleWires, 8, 1);
 
+    appSettingsGrid->addWidget(new QLabel(tr("Validate schematic before simulating:"), appSettingsTab), 9, 0);
+    enableSchematicValidation = new QCheckBox(appSettingsTab);
+    enableSchematicValidation->setToolTip(tr(
+        "Check the schematic for common issues before running the simulation."));
+    appSettingsGrid->addWidget(enableSchematicValidation, 9, 1);
+
     t->addTab(appSettingsTab, tr("Settings"));
 
-    appSettingsGrid->addWidget(new QLabel(tr("Set custom shortcut:"), appSettingsTab), 9, 0);
+    appSettingsGrid->addWidget(new QLabel(tr("Set custom shortcut:"), appSettingsTab), 10, 0);
     ShortcutButton = new QPushButton(appSettingsTab);
     connect(ShortcutButton, SIGNAL(clicked()),
         parent, SLOT(slotShortcutDialog()));
-    appSettingsGrid->addWidget(ShortcutButton, 9, 1);
+    appSettingsGrid->addWidget(ShortcutButton, 10, 1);
 
     // ...........................................................
     // The appearance settings tab
@@ -544,6 +550,7 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     editorEdit->setText(QucsSettings.Editor);
     checkWiring->setChecked(QucsSettings.NodeWiring);
     allowFlexibleWires->setChecked(_settings::Get().item<bool>("AllowFlexibleWires"));
+    enableSchematicValidation->setChecked(_settings::Get().item<bool>("EnableSchematicValidation"));
 
     ShortcutButton->setText("Custom Shortcut");
 
@@ -770,6 +777,7 @@ void QucsSettingsDialog::slotApply()
     }
 
     _settings::Get().setItem("AllowFlexibleWires", allowFlexibleWires->isChecked());
+    _settings::Get().setItem("EnableSchematicValidation", enableSchematicValidation->isChecked());
 
     QucsSettings.FileTypes.clear();
     for (int row=0; row < fileTypesTableWidget->rowCount(); row++)
@@ -973,6 +981,7 @@ void QucsSettingsDialog::slotDefaultValues()
     editorEdit->setText(QucsSettings.BinDir + "qucs");
     checkWiring->setChecked(false);
     allowFlexibleWires->setChecked(_settings::Get().itemDefault<bool>("AllowFlexibleWires"));
+    enableSchematicValidation->setChecked(_settings::Get().itemDefault<bool>("EnableSchematicValidation"));
     checkLoadFromFutureVersions->setChecked(false);
     checkAntiAliasing->setChecked(false);
     checkTextAntiAliasing->setChecked(true);

--- a/qucs/dialogs/qucssettingsdialog.h
+++ b/qucs/dialogs/qucssettingsdialog.h
@@ -186,6 +186,9 @@ public:
     /// @brief Always prefixes the dataset with the simulation label.
     QCheckBox *alwaysPrefixDataset;
 
+    /// @brief Enables pre-simulation schematic validation checks
+    QCheckBox *enableSchematicValidation;
+
     /// @brief Selects the application language.
     QComboBox *LanguageCombo;
 

--- a/qucs/dialogs/qucssettingsdialog.h
+++ b/qucs/dialogs/qucssettingsdialog.h
@@ -186,8 +186,11 @@ public:
     /// @brief Always prefixes the dataset with the simulation label.
     QCheckBox *alwaysPrefixDataset;
 
-    /// @brief Enables pre-simulation schematic validation checks
+    /// @brief Enables pre-simulation schematic validation checks.
     QCheckBox *enableSchematicValidation;
+
+    /// @brief Enables checking the schematic before saving it.
+    QCheckBox *validateOnSave;
 
     /// @brief Selects the application language.
     QComboBox *LanguageCombo;

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -3854,14 +3854,13 @@ bool QucsApp::runSchematicChecks(QWidget *w, bool isPreSimulation)
       severity = QString("Minor");
       break;
     }
-    html += QString("<p><b>%1 #%2 [<span style='color:%3'>%4</span>]</b>"
-                    "<br><i>%5</i><br><b>Suggested fix</b>: %6</p>")
+    html += QString("<p><b>%1 #%2 - %3 [<span style='color:%4'>%5</span>]</b>"
+                    "<br><i>%6</i><br><b>Suggested fix</b>: %7</p>")
                 .arg(tr("Issue"))
                 .arg(i + 1)
-                .arg(severityColor.name())
-                .arg(severity)
-                .arg(issue.message.toHtmlEscaped())
-                .arg(issue.suggestedFix.toHtmlEscaped());
+                .arg(issue.title.toHtmlEscaped(), severityColor.name(),
+                     severity, issue.message.toHtmlEscaped(),
+                     issue.suggestedFix.toHtmlEscaped());
   }
   textArea->setHtml(html);
   layout->addWidget(textArea);

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -2710,8 +2710,8 @@ void QucsApp::slotSimulate(QWidget *w)
   QString backend = simulatorsCombobox->currentText().toLower();
 
   // Validate the schematic against that backend's known limitations before running the simulation.
-  // Schematic validation is skipped in "Tuning mode"
-  if (!TuningMode) {
+  // Schematic validation is skipped in "Tuning mode". It also needs to be enabled in the Settings panel.
+  if (!TuningMode && _settings::Get().item<bool>("EnableSchematicValidation")) {
     if (runPreSimulationChecks(w, backend))
       return;
   }

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -2706,6 +2706,14 @@ void QucsApp::slotSimulate(QWidget *w)
       }
   }
 
+  // Determine which backend will actually run this simulation
+  QString backend = simulatorsCombobox->currentText().toLower();
+
+  // Validate the schematic against that backend's known limitations
+  // before running the simulation
+  if (runPreSimulationChecks(w, backend))
+    return;
+
   if (QucsSettings.DefaultSimulator!=spicecompat::simQucsator && !isDigital) {
       slotSimulateWithSpice();
       return;
@@ -3784,6 +3792,77 @@ void QucsApp::slotSimulateWithSpice()
                 tr("Simulation of text document is not possible!"));
     }
 }
+
+bool QucsApp::runPreSimulationChecks(QWidget *w, const QString &backend)
+{
+  Schematic *sch = qobject_cast<Schematic*>(w);
+  if (!sch)
+    return false; // nothing to check on non-schematic documents
+
+  QVector<ValidationIssue> issues = a_validator.validate(sch, backend);
+  if (issues.isEmpty())
+    return false;
+
+  QDialog dlg(this);
+  dlg.setWindowTitle(tr("Cannot start simulation"));
+
+  QVBoxLayout *layout = new QVBoxLayout(&dlg);
+
+  QLabel *header = new QLabel(
+      tr("The schematic has %1 issue(s) that must be fixed before simulating:")
+          .arg(issues.size()), &dlg);
+  header->setWordWrap(true);
+  layout->addWidget(header);
+
+  QTextEdit *textArea = new QTextEdit(&dlg);
+  textArea->setReadOnly(true);
+
+  QString html;
+  for (int i = 0; i < issues.size(); ++i) {
+    const ValidationIssue &issue = issues[i];
+
+    // Severity formatting
+    QColor severityColor;
+    QString severity;
+    switch (issue.severity){
+      case 1: // Critical
+        severityColor = Qt::red;
+        severity = QString("Critical");
+        break;
+
+      case 2: // Warning
+        severityColor = Qt::darkYellow;
+        severity = QString("Warning");
+        break;
+
+      case 3: // Minor
+        severityColor = Qt::blue;
+        severity = QString("Minor");
+        break;
+    }
+
+    // Build HTML text
+    html += QString("<p><b>%1 #%2 (<span style='color:%3'>%4</span>)</b>"
+                    "<br><i>%5</i><br><b>Suggested fix</b>: %6</p>")
+                .arg(tr("Issue"))
+                .arg(i + 1)
+                .arg(severityColor.name())
+                .arg(severity)
+                .arg(issue.message.toHtmlEscaped())
+                .arg(issue.suggestedFix.toHtmlEscaped());
+  }
+  textArea->setHtml(html);
+  layout->addWidget(textArea);
+
+  QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok, &dlg);
+  connect(buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+  layout->addWidget(buttons);
+
+  dlg.resize(480, 280);
+  dlg.exec();
+  return true;
+}
+
 
 void QucsApp::slotSaveNetlist()
 {

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -3860,7 +3860,7 @@ bool QucsApp::runPreSimulationChecks(QWidget *w, const QString &backend) {
   QDialogButtonBox *buttons = new QDialogButtonBox(&dlg);
 
   // Go back to the schematic and fix the issues
-  QPushButton *fixButton = buttons->addButton(tr("Fix Issues"), QDialogButtonBox::AcceptRole);
+  QPushButton *fixButton = buttons->addButton(tr("Ok"), QDialogButtonBox::AcceptRole);
   fixButton->setToolTip(tr("Go back to the schematic and fix the issues"));
   connect(fixButton, &QPushButton::clicked, &dlg, &QDialog::reject);
 

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -1855,6 +1855,13 @@ bool QucsApp::saveFile(QucsDoc *Doc)
     updatePortNumber(Doc, Result);
   }
   slotUpdateTreeview();
+
+  // Schematic check
+  if (_settings::Get().item<bool>("ValidateOnSave")){
+    QWidget *w = DocumentTab->currentWidget();
+    runSchematicChecks(w, false);
+  }
+
   return true;
 }
 
@@ -2706,13 +2713,10 @@ void QucsApp::slotSimulate(QWidget *w)
       }
   }
 
-  // Determine which backend will actually run this simulation
-  QString backend = simulatorsCombobox->currentText().toLower();
-
   // Validate the schematic against that backend's known limitations before running the simulation.
   // Schematic validation is skipped in "Tuning mode". It also needs to be enabled in the Settings panel.
   if (!TuningMode && _settings::Get().item<bool>("EnableSchematicValidation")) {
-    if (runPreSimulationChecks(w, backend))
+    if (runSchematicChecks(w, true))
       return;
   }
 
@@ -3795,10 +3799,25 @@ void QucsApp::slotSimulateWithSpice()
     }
 }
 
-bool QucsApp::runPreSimulationChecks(QWidget *w, const QString &backend) {
+bool QucsApp::runSchematicChecks(QWidget *w, bool isPreSimulation)
+{
   Schematic *sch = qobject_cast<Schematic*>(w);
-  if (!sch)
-    return false; // nothing to check on non-schematic documents
+  if (!sch) {
+    // Nothing to check unless the document is an schematic
+    return false;
+  }
+
+  // Get the backend simulator
+  QString backend = simulatorsCombobox->currentText().toLower();
+
+  if (isPreSimulation && TuningMode) {
+    // Skip validation in tuning mode
+    return false;
+  }
+
+  const QString settingKey = isPreSimulation ? "EnableSchematicValidation" : "ValidateOnSave";
+  if (!_settings::Get().item<bool>(settingKey))
+    return false;
 
   a_validator.setSimulationBackend(backend);
   a_validator.setSchematic(sch);
@@ -3807,49 +3826,38 @@ bool QucsApp::runPreSimulationChecks(QWidget *w, const QString &backend) {
     return false;
 
   QDialog dlg(this);
-  dlg.setWindowTitle(tr("Issues found"));
-
+  dlg.setWindowTitle(isPreSimulation ? tr("Issues found") : tr("Schematic issues found"));
   QVBoxLayout *layout = new QVBoxLayout(&dlg);
-
-  QLabel *header = new QLabel(
-      tr("The schematic has %1 issue(s) that should be fixed before simulating:")
-          .arg(issues.size()), &dlg);
+  QLabel *header = new QLabel(tr("The schematic contains %1 issue(s)").arg(issues.size()), &dlg);
   header->setWordWrap(true);
   layout->addWidget(header);
 
   QTextEdit *textArea = new QTextEdit(&dlg);
   textArea->setReadOnly(true);
-
   QString html;
   for (int i = 0; i < issues.size(); ++i) {
     const ValidationIssue &issue = issues[i];
-
     // Severity formatting
     QColor severityColor;
     QString severity;
     switch (issue.severity){
-      case 1: // Critical
-        severityColor = Qt::red;
-        severity = QString("Critical");
-        break;
-
-      case 2: // Warning
-        severityColor = Qt::darkYellow;
-        severity = QString("Warning");
-        break;
-
-      case 3: // Minor
-        severityColor = Qt::blue;
-        severity = QString("Minor");
-        break;
+    case 1: // Critical
+      severityColor = Qt::red;
+      severity = QString("Critical");
+      break;
+    case 2: // Warning
+      severityColor = Qt::darkYellow;
+      severity = QString("Warning");
+      break;
+    case 3: // Minor
+      severityColor = Qt::blue;
+      severity = QString("Minor");
+      break;
     }
-
-    // Build HTML text
-    html += QString("<p><b>%1 #%2 - %3 [<span style='color:%4'>%5</span>]</b>"
-                    "<br><i>%6</i><br><b>Suggested fix</b>: %7</p>")
+    html += QString("<p><b>%1 #%2 [<span style='color:%3'>%4</span>]</b>"
+                    "<br><i>%5</i><br><b>Suggested fix</b>: %6</p>")
                 .arg(tr("Issue"))
                 .arg(i + 1)
-                .arg(issue.title.toHtmlEscaped())
                 .arg(severityColor.name())
                 .arg(severity)
                 .arg(issue.message.toHtmlEscaped())
@@ -3859,26 +3867,31 @@ bool QucsApp::runPreSimulationChecks(QWidget *w, const QString &backend) {
   layout->addWidget(textArea);
 
   QDialogButtonBox *buttons = new QDialogButtonBox(&dlg);
+  if (isPreSimulation) {
+    // Go back to the schematic and fix the issues
+    QPushButton *fixButton = buttons->addButton(tr("Ok"), QDialogButtonBox::AcceptRole);
+    fixButton->setToolTip(tr("Go back to the schematic and fix the issues"));
+    connect(fixButton, &QPushButton::clicked, &dlg, &QDialog::reject);
 
-  // Go back to the schematic and fix the issues
-  QPushButton *fixButton = buttons->addButton(tr("Ok"), QDialogButtonBox::AcceptRole);
-  fixButton->setToolTip(tr("Go back to the schematic and fix the issues"));
-  connect(fixButton, &QPushButton::clicked, &dlg, &QDialog::reject);
-
-  // Simulate anyway
-  QPushButton *proceedButton = buttons->addButton(tr("Simulate Anyway"), QDialogButtonBox::RejectRole);
-  proceedButton->setToolTip(tr("Run the simulation"));
-  connect(proceedButton, &QPushButton::clicked, &dlg, &QDialog::accept);
+    // Simulate anyway
+    QPushButton *proceedButton = buttons->addButton(tr("Simulate Anyway"), QDialogButtonBox::RejectRole);
+    proceedButton->setToolTip(tr("Run the simulation"));
+    connect(proceedButton, &QPushButton::clicked, &dlg, &QDialog::accept);
+  } else {
+    // The file is saved
+    QPushButton *okButton = buttons->addButton(tr("OK"), QDialogButtonBox::AcceptRole);
+    connect(okButton, &QPushButton::clicked, &dlg, &QDialog::accept);
+  }
   layout->addWidget(buttons);
 
   dlg.resize(480, 280);
   int result = dlg.exec();
 
-  if (result == QDialog::Accepted) {
+  if (!isPreSimulation) {
     return false;
-  } else {
-    return true;
   }
+
+  return result != QDialog::Accepted; // true = block simulation
 }
 
 

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -2709,10 +2709,12 @@ void QucsApp::slotSimulate(QWidget *w)
   // Determine which backend will actually run this simulation
   QString backend = simulatorsCombobox->currentText().toLower();
 
-  // Validate the schematic against that backend's known limitations
-  // before running the simulation
-  if (runPreSimulationChecks(w, backend))
-    return;
+  // Validate the schematic against that backend's known limitations before running the simulation.
+  // Schematic validation is skipped in "Tuning mode"
+  if (!TuningMode) {
+    if (runPreSimulationChecks(w, backend))
+      return;
+  }
 
   if (QucsSettings.DefaultSimulator!=spicecompat::simQucsator && !isDigital) {
       slotSimulateWithSpice();
@@ -3793,8 +3795,7 @@ void QucsApp::slotSimulateWithSpice()
     }
 }
 
-bool QucsApp::runPreSimulationChecks(QWidget *w, const QString &backend)
-{
+bool QucsApp::runPreSimulationChecks(QWidget *w, const QString &backend) {
   Schematic *sch = qobject_cast<Schematic*>(w);
   if (!sch)
     return false; // nothing to check on non-schematic documents

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -3845,10 +3845,11 @@ bool QucsApp::runPreSimulationChecks(QWidget *w, const QString &backend) {
     }
 
     // Build HTML text
-    html += QString("<p><b>%1 #%2 (<span style='color:%3'>%4</span>)</b>"
-                    "<br><i>%5</i><br><b>Suggested fix</b>: %6</p>")
+    html += QString("<p><b>%1 #%2 - %3 [<span style='color:%4'>%5</span>]</b>"
+                    "<br><i>%6</i><br><b>Suggested fix</b>: %7</p>")
                 .arg(tr("Issue"))
                 .arg(i + 1)
+                .arg(issue.title.toHtmlEscaped())
                 .arg(severityColor.name())
                 .arg(severity)
                 .arg(issue.message.toHtmlEscaped())

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -3799,7 +3799,9 @@ bool QucsApp::runPreSimulationChecks(QWidget *w, const QString &backend)
   if (!sch)
     return false; // nothing to check on non-schematic documents
 
-  QVector<ValidationIssue> issues = a_validator.validate(sch, backend);
+  a_validator.setSimulationBackend(backend);
+  a_validator.setSchematic(sch);
+  QVector<ValidationIssue> issues = a_validator.validate();
   if (issues.isEmpty())
     return false;
 

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -3806,12 +3806,12 @@ bool QucsApp::runPreSimulationChecks(QWidget *w, const QString &backend)
     return false;
 
   QDialog dlg(this);
-  dlg.setWindowTitle(tr("Cannot start simulation"));
+  dlg.setWindowTitle(tr("Issues found"));
 
   QVBoxLayout *layout = new QVBoxLayout(&dlg);
 
   QLabel *header = new QLabel(
-      tr("The schematic has %1 issue(s) that must be fixed before simulating:")
+      tr("The schematic has %1 issue(s) that should be fixed before simulating:")
           .arg(issues.size()), &dlg);
   header->setWordWrap(true);
   layout->addWidget(header);
@@ -3856,13 +3856,27 @@ bool QucsApp::runPreSimulationChecks(QWidget *w, const QString &backend)
   textArea->setHtml(html);
   layout->addWidget(textArea);
 
-  QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok, &dlg);
-  connect(buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+  QDialogButtonBox *buttons = new QDialogButtonBox(&dlg);
+
+  // Go back to the schematic and fix the issues
+  QPushButton *fixButton = buttons->addButton(tr("Fix Issues"), QDialogButtonBox::RejectRole);
+  fixButton->setToolTip(tr("Go back to the schematic and fix the issues"));
+  connect(fixButton, &QPushButton::clicked, &dlg, &QDialog::reject);
+
+  // Simulate anyway
+  QPushButton *proceedButton = buttons->addButton(tr("Simulate Anyway"), QDialogButtonBox::AcceptRole);
+  proceedButton->setToolTip(tr("Run the simulation"));
+  connect(proceedButton, &QPushButton::clicked, &dlg, &QDialog::accept);
   layout->addWidget(buttons);
 
   dlg.resize(480, 280);
-  dlg.exec();
-  return true;
+  int result = dlg.exec();
+
+  if (result == QDialog::Accepted) {
+    return false;
+  } else {
+    return true;
+  }
 }
 
 

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -3860,12 +3860,12 @@ bool QucsApp::runPreSimulationChecks(QWidget *w, const QString &backend) {
   QDialogButtonBox *buttons = new QDialogButtonBox(&dlg);
 
   // Go back to the schematic and fix the issues
-  QPushButton *fixButton = buttons->addButton(tr("Fix Issues"), QDialogButtonBox::RejectRole);
+  QPushButton *fixButton = buttons->addButton(tr("Fix Issues"), QDialogButtonBox::AcceptRole);
   fixButton->setToolTip(tr("Go back to the schematic and fix the issues"));
   connect(fixButton, &QPushButton::clicked, &dlg, &QDialog::reject);
 
   // Simulate anyway
-  QPushButton *proceedButton = buttons->addButton(tr("Simulate Anyway"), QDialogButtonBox::AcceptRole);
+  QPushButton *proceedButton = buttons->addButton(tr("Simulate Anyway"), QDialogButtonBox::RejectRole);
   proceedButton->setToolTip(tr("Run the simulation"));
   connect(proceedButton, &QPushButton::clicked, &dlg, &QDialog::accept);
   layout->addWidget(buttons);

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -27,6 +27,8 @@
 #include <QStack>
 #include <QString>
 
+#include "schematicvalidator.h"  // Schematic validation before simulation
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -128,6 +130,8 @@ public:
   ExternSimDialog *a_tunerExternSimDlg = nullptr;
   bool m_tunerAbortForRerun = false;
 
+  SchematicValidator a_validator; // Schematic validation
+
   // current mouse methods
   void (MouseActions::*MouseMoveAction)(Schematic *, QMouseEvent *);
   void (MouseActions::*MousePressAction)(Schematic *, QMouseEvent *, float,
@@ -203,6 +207,13 @@ public slots:
 
   void slotSimulate(QWidget *w = nullptr);
   void slotSimulateWithSpice();
+
+  /// @brief Validate the schematic before simulation.
+  /// @param w Schematic object
+  /// @param backend Backend simulator (ngspice, Xyce, qucsator-RF)
+  /// @return 'True' No issues detected.
+  ///         'False' There are issues to solve before simulation
+  bool runPreSimulationChecks(QWidget *w, const QString &backend);
   void slotAbortTuningSimulation();
   void slotTune(bool checked);
 

--- a/qucs/qucs.h
+++ b/qucs/qucs.h
@@ -210,10 +210,11 @@ public slots:
 
   /// @brief Validate the schematic before simulation.
   /// @param w Schematic object
-  /// @param backend Backend simulator (ngspice, Xyce, qucsator-RF)
+  /// @param isPresimulation Flag to indicate if the "Simulate anyway" button must be added
   /// @return 'True' No issues detected.
   ///         'False' There are issues to solve before simulation
-  bool runPreSimulationChecks(QWidget *w, const QString &backend);
+  bool runSchematicChecks(QWidget *w, bool isPreSimulation);
+
   void slotAbortTuningSimulation();
   void slotTune(bool checked);
 

--- a/qucs/schematicvalidator.cpp
+++ b/qucs/schematicvalidator.cpp
@@ -285,10 +285,22 @@ QVector<ValidationIssue> SchematicValidator::checkUnconnectedPorts() const
       Node *node = port->Connection;
       bool isFloating = !node || !netReachesOtherComponent(node, component);
       if (isFloating) {
+
+        // First get the name of the component.
+        QString componentLabel;
+        if (component->Name.isEmpty()){
+          // The component's name is empty (e.g. GND). Then take the model name.
+          componentLabel = QObject::tr("%1 component at (%2, %3)")
+                               .arg(component->Model).arg(component->cx).arg(component->cy);
+        } else {
+          // The component has a name (the vast majority of components)
+          componentLabel = component->Name;
+        }
+
         ValidationIssue issue;
         issue.title = QObject::tr("Disconnected port");
         issue.message = QObject::tr("Port of %1 is not connected to anything.")
-                                 .arg(component->Name);
+                                 .arg(componentLabel);
         issue.severity = 2; // Warning. Simulation may run (e.g. 1-port S-parameter ngspice require one dangling port), but the user must check this.
         issue.suggestedFix = QObject::tr(
             "Connect this pin to the intended net, or check for a typo in the net label.");

--- a/qucs/schematicvalidator.cpp
+++ b/qucs/schematicvalidator.cpp
@@ -15,6 +15,7 @@ QVector<ValidationIssue> SchematicValidator::validate() const
   issues += checkMinimumPortsInSPSimulation();
   issues += checkMissingSimulation();
   issues += checkDanglingWires();
+  issues += checkUnconnectedPorts();
 
   return issues;
 }
@@ -189,4 +190,63 @@ QVector<ValidationIssue> SchematicValidator::checkDanglingWires() const
     }
   }
   return issues;
+}
+
+QVector<ValidationIssue> SchematicValidator::checkUnconnectedPorts() const
+{
+  QVector<ValidationIssue> issues;
+  for (Component *component : sch->a_DocComps) {
+    // Iterate over each component in the schematic
+    if (!component->isActive) {
+      // Discard deactivated components
+      continue;
+    }
+    for (Port *port : std::as_const(component->Ports)) {
+      // For each port, check if the ports' net reaches something. Otherwise, report issue
+      Node *node = port->Connection;
+      bool isFloating = !node || !netReachesOtherComponent(node, component);
+      if (isFloating) {
+        ValidationIssue issue;
+        issue.message = QObject::tr("Port of %1 is not connected to anything.")
+                                 .arg(component->Name);
+        issue.severity = 2; // Warning. Simulation may run (e.g. 1-port S-parameter ngspice require one dangling port), but the user must check this.
+        issue.suggestedFix = QObject::tr(
+            "Connect this pin to the intended net, or check for a typo in the net label.");
+        issues.append(issue);
+      }
+    }
+  }
+  return issues;
+}
+
+bool SchematicValidator::netReachesOtherComponent(Node *node, Component *owner) const {
+  QSet<Node*> visited; // Nodes already visited during the traversal, to avoid revisiting again.
+  QVector<Node*> stack; // Nodes still to be explored
+  stack.push_back(node);
+
+  while (!stack.isEmpty()) {
+    Node *n = stack.takeLast();
+
+    if (!n || visited.contains(n)) {
+      // Skip null nodes and nodes visited
+      continue;
+    }
+    visited.insert(n);
+
+    for (Component *c : n->components()) {
+      // Check every component attached to this node.
+      if (c != owner)
+        return true;
+    }
+
+    // Follow every wire touching this node to the node on its other end, and queue it up for exploration,
+    for (Wire *w : n->wires()) {
+      Node *other = (w->Port1 == n) ? w->Port2 : w->Port1;
+      if (other && !visited.contains(other))
+        stack.push_back(other);
+    }
+  }
+
+  // Explored the entire net reachable from 'node' and found no component other than 'owner', so the net is effectively dangling.
+  return false;
 }

--- a/qucs/schematicvalidator.cpp
+++ b/qucs/schematicvalidator.cpp
@@ -79,7 +79,7 @@ QVector<ValidationIssue> SchematicValidator::checkSubcircuits(QSet<QString> &vis
     nestedValidator.setSimulationBackend(backend);
     QVector<ValidationIssue> SubCktIssues = nestedValidator.checkStructuralIssues(visitedFiles);
 
-    for (ValidationIssue issue : SubCktIssues) {
+    for (ValidationIssue issue : std::as_const(SubCktIssues)) {
       issue.message = QObject::tr("[in subcircuit '%1'] %2").arg(file, issue.message);
       issues.append(issue);
     }

--- a/qucs/schematicvalidator.cpp
+++ b/qucs/schematicvalidator.cpp
@@ -164,8 +164,8 @@ QVector<ValidationIssue> SchematicValidator::checkMinimumPortsInSPSimulation() c
     ValidationIssue issue;
     issue.title = QObject::tr("Wrong S-parameter simulation setup");
     issue.message = QObject::tr(
-                        "The schematic has %1 AC power source."
-                        "ngspice requires at least 2 for S-parameter analysis.").arg(acSourceCount);
+                        "The schematic has %1 AC power source. "
+                        "Ngspice requires at least 2 for S-parameter analysis.").arg(acSourceCount);
     issue.severity = 1; // Critical - simulation will fail
     issue.suggestedFix = QObject::tr(
         "If this is a 1-port SP simulation, add another AC Power souce component with the negative port connected to GND");

--- a/qucs/schematicvalidator.cpp
+++ b/qucs/schematicvalidator.cpp
@@ -6,16 +6,83 @@
 #include "schematicvalidator.h"
 #include "schematic.h"
 #include "components/component.h"
+#include "components/subcircuit.h"
 
-QVector<ValidationIssue> SchematicValidator::validate() const
-{
+QVector<ValidationIssue> SchematicValidator::validate() const {
+  QSet<QString> visitedFiles;
+  return runAllChecks(visitedFiles);
+}
+
+
+QVector<ValidationIssue> SchematicValidator::runAllChecks(QSet<QString> &visitedFiles) const {
   QVector<ValidationIssue> issues;
 
+  // Top-level schematic checks. Not applicable to subcircuits
   issues += checkFrequencySweepType();
   issues += checkMinimumPortsInSPSimulation();
   issues += checkMissingSimulation();
+
+  // Structural checks: run at top-level and recursively inside every subcircuit.
+  issues += checkStructuralIssues(visitedFiles);
+
+  return issues;
+}
+
+
+QVector<ValidationIssue> SchematicValidator::checkStructuralIssues(QSet<QString> &visitedFiles) const {
+  QVector<ValidationIssue> issues;
+
   issues += checkDanglingWires();
   issues += checkUnconnectedPorts();
+  issues += checkSubcircuits(visitedFiles);
+
+  return issues;
+}
+
+
+QVector<ValidationIssue> SchematicValidator::checkSubcircuits(QSet<QString> &visitedFiles) const{
+  QVector<ValidationIssue> issues;
+
+  for (Component *component : sch->a_DocComps) {
+    if (!component->isActive || component->Model != "Sub") {
+      // Discard all but subcircuits
+      continue;
+    }
+
+    Subcircuit *subcirc = static_cast<Subcircuit*>(component);
+    QString file = subcirc->getSubcircuitFile();
+
+    if (file.isEmpty() || visitedFiles.contains(file)) {
+      // Skip already inspected subcircuits
+      continue;
+    }
+    visitedFiles.insert(file);
+
+    Schematic *nested = new Schematic(nullptr, file);
+    if (!nested->loadDocument()) {
+      ValidationIssue issue;
+      issue.message = QObject::tr("Cannot load subcircuit file '%1'.").arg(file);
+      issue.severity = 1; // Critical: Simulation won't run if the subckt is missing
+      issue.suggestedFix = QObject::tr(
+          "Check that the subcircuit file exists and is a valid schematic.");
+      issues.append(issue);
+      delete nested;
+      continue;
+    }
+
+    // Check subcircuit
+    SchematicValidator nestedValidator;
+    nestedValidator.setSchematic(nested);
+    nestedValidator.setSimulationBackend(backend);
+    QVector<ValidationIssue> SubCktIssues = nestedValidator.checkStructuralIssues(visitedFiles);
+
+    for (ValidationIssue issue : SubCktIssues) {
+      issue.message = QObject::tr("[in subcircuit '%1'] %2").arg(file, issue.message);
+      issues.append(issue);
+    }
+
+    delete nested;
+  }
 
   return issues;
 }

--- a/qucs/schematicvalidator.cpp
+++ b/qucs/schematicvalidator.cpp
@@ -63,6 +63,7 @@ QVector<ValidationIssue> SchematicValidator::checkSubcircuits(QSet<QString> &vis
     Schematic *nested = new Schematic(nullptr, file);
     if (!nested->loadDocument()) {
       ValidationIssue issue;
+      issue.title = QObject::tr("Missing subcircuit");
       issue.message = QObject::tr("Cannot load subcircuit file '%1'.").arg(file);
       issue.severity = 1; // Critical: Simulation won't run if the subckt is missing
       issue.suggestedFix = QObject::tr(
@@ -108,6 +109,9 @@ QVector<ValidationIssue> SchematicValidator::checkFrequencySweepType() const
     bool usesListSweep = sweepType && sweepType->Value == "list";
     if (usesListSweep) {
       ValidationIssue issue;
+
+      // Issue title
+      issue.title = QObject::tr("Wrong sweep");
 
       // Error message
       issue.message = QObject::tr("%1 uses a 'list' frequency sweep, which %2 does not support.")
@@ -158,6 +162,7 @@ QVector<ValidationIssue> SchematicValidator::checkMinimumPortsInSPSimulation() c
 
   if (acSourceCount < 2) {
     ValidationIssue issue;
+    issue.title = QObject::tr("Wrong S-parameter simulation setup");
     issue.message = QObject::tr(
                         "The schematic has %1 AC power source."
                         "ngspice requires at least 2 for S-parameter analysis.").arg(acSourceCount);
@@ -186,6 +191,7 @@ QVector<ValidationIssue> SchematicValidator::checkMissingSimulation() const
   }
 
   ValidationIssue issue;
+  issue.title = QObject::tr("Missing simulation block");
   issue.message = QObject::tr(
       "The schematic does not contain any active simulation block.");
   issue.severity = 1; // Critical - nothing to simulate
@@ -213,6 +219,7 @@ QVector<ValidationIssue> SchematicValidator::checkDanglingWires() const
     if (endpoint1_isOpen && endpoint2_isOpen) {
       // Both ends open: the wire is entirely disconnected
       ValidationIssue issue;
+      issue.title = QObject::tr("Dangling wire");
       issue.message = QObject::tr(
                            "Wire is not connected to anything at either end (near (%1, %2) and (%3, %4)).")
                            .arg(endpoint1->cx).arg(endpoint1->cy)
@@ -234,6 +241,7 @@ QVector<ValidationIssue> SchematicValidator::checkDanglingWires() const
         message = QObject::tr("Wire has an unconnected end near (%1, %2).").arg(endpoint1->cx).arg(endpoint1->cy);
       }
 
+      issue.title = QObject::tr("Dangling wire");
       issue.message = message;
       issue.severity = 3;
       issue.suggestedFix = QObject::tr(
@@ -243,6 +251,8 @@ QVector<ValidationIssue> SchematicValidator::checkDanglingWires() const
     else if (endpoint2_isOpen) {
       // Second end open
       ValidationIssue issue;
+
+      issue.title = QObject::tr("Dangling wire");
 
       QString message;
       if (endpoint2->hasLabel()){
@@ -276,6 +286,7 @@ QVector<ValidationIssue> SchematicValidator::checkUnconnectedPorts() const
       bool isFloating = !node || !netReachesOtherComponent(node, component);
       if (isFloating) {
         ValidationIssue issue;
+        issue.title = QObject::tr("Disconnected port");
         issue.message = QObject::tr("Port of %1 is not connected to anything.")
                                  .arg(component->Name);
         issue.severity = 2; // Warning. Simulation may run (e.g. 1-port S-parameter ngspice require one dangling port), but the user must check this.

--- a/qucs/schematicvalidator.cpp
+++ b/qucs/schematicvalidator.cpp
@@ -12,7 +12,7 @@ QVector<ValidationIssue> SchematicValidator::validate(Schematic *sch, const QStr
   QVector<ValidationIssue> issues;
 
   issues += checkFrequencySweepType(sch, backend);
-  // issues += checkSomeOtherThing(sch, backend);
+  issues += checkMinimumPortsInSPSimulation(sch, backend);
 
   return issues;
 }
@@ -49,6 +49,52 @@ QVector<ValidationIssue> SchematicValidator::checkFrequencySweepType(
       issue.suggestedFix = QObject::tr("Use lin or log frequency sweep in %1").arg(component->Name);
       issues.append(issue);
     }
+  }
+
+  return issues;
+}
+
+
+QVector<ValidationIssue> SchematicValidator::checkMinimumPortsInSPSimulation(
+    Schematic *sch, const QString &backend) const {
+  QVector<ValidationIssue> issues;
+
+  if (backend.toLower() != "ngspice")
+    return issues; // only ngspice has this restriction
+
+
+  bool hasActiveSPBlock = false;
+  for (Component *component : sch->a_DocComps) {
+    if (component->isActive && component->Model == ".SP") {
+      hasActiveSPBlock = true;
+      break;
+    }
+  }
+  if (!hasActiveSPBlock)
+    return issues; // no S-parameter simulation, nothing to check
+
+  int acSourceCount = 0;
+  for (Component *component : sch->a_DocComps) {
+    if (!component->isActive) {
+      // Ignore deactivated components
+      continue;
+    }
+
+    if (component->Model.startsWith("VP")) {
+      // AC power source found. They start with VP for ngspice
+      acSourceCount++;
+    }
+  }
+
+  if (acSourceCount < 2) {
+    ValidationIssue issue;
+    issue.message = QObject::tr(
+                        "The schematic has %1 AC power source."
+                        "ngspice requires at least 2 for S-parameter analysis.").arg(acSourceCount);
+    issue.severity = 1; // Critical - simulation will fail
+    issue.suggestedFix = QObject::tr(
+        "If this is a 1-port SP simulation, add another AC Power souce component with the negative port connected to GND");
+    issues.append(issue);
   }
 
   return issues;

--- a/qucs/schematicvalidator.cpp
+++ b/qucs/schematicvalidator.cpp
@@ -1,0 +1,55 @@
+/// @file schematicvalidator.cpp
+/// @brief Schematic validation class (implementation)
+/// @author Andrés Martínez Mera
+/// @date July 12, 2026
+
+#include "schematicvalidator.h"
+#include "schematic.h"
+#include "components/component.h"
+
+QVector<ValidationIssue> SchematicValidator::validate(Schematic *sch, const QString &backend) const
+{
+  QVector<ValidationIssue> issues;
+
+  issues += checkFrequencySweepType(sch, backend);
+  // issues += checkSomeOtherThing(sch, backend);
+
+  return issues;
+}
+
+QVector<ValidationIssue> SchematicValidator::checkFrequencySweepType(
+    Schematic *sch, const QString &backend) const
+{
+  QVector<ValidationIssue> issues; // It may be several SP/AC blocks
+
+  if (backend.toLower() == "qucsator")
+    return issues; // qucsator handles list sweeps fine
+
+  for (Component *component : sch->a_DocComps) {
+    if (!component->isActive)
+      continue;
+
+    bool isFrequencySweepBlock = (component->Model == ".AC" || component->Model == ".SP");
+    if (!isFrequencySweepBlock)
+      continue;
+
+    Property *sweepType = component->getProperty("Type");
+    bool usesListSweep = sweepType && sweepType->Value == "list";
+    if (usesListSweep) {
+      ValidationIssue issue;
+
+      // Error message
+      issue.message = QObject::tr("%1 uses a 'list' frequency sweep, which %2 does not support.")
+                          .arg(component->Name, backend);
+
+      // Issue relevance
+      issue.severity = 1; // Critical - Simulation will fail
+
+      // Suggested solution
+      issue.suggestedFix = QObject::tr("Use lin or log frequency sweep in %1").arg(component->Name);
+      issues.append(issue);
+    }
+  }
+
+  return issues;
+}

--- a/qucs/schematicvalidator.cpp
+++ b/qucs/schematicvalidator.cpp
@@ -13,6 +13,7 @@ QVector<ValidationIssue> SchematicValidator::validate() const
 
   issues += checkFrequencySweepType();
   issues += checkMinimumPortsInSPSimulation();
+  issues += checkMissingSimulation();
 
   return issues;
 }
@@ -78,7 +79,7 @@ QVector<ValidationIssue> SchematicValidator::checkMinimumPortsInSPSimulation() c
       continue;
     }
 
-    if (component->Model.startsWith("VP")) {
+    if (component->Model.startsWith("Pac")) {
       // AC power source found. They start with VP for ngspice
       acSourceCount++;
     }
@@ -94,6 +95,33 @@ QVector<ValidationIssue> SchematicValidator::checkMinimumPortsInSPSimulation() c
         "If this is a 1-port SP simulation, add another AC Power souce component with the negative port connected to GND");
     issues.append(issue);
   }
+
+  return issues;
+}
+
+QVector<ValidationIssue> SchematicValidator::checkMissingSimulation() const
+{
+  QVector<ValidationIssue> issues;
+
+  // Model strings for all recognized simulation controller blocks.
+  static const QStringList kSimulationBlockModels = {
+      ".AC", ".SP", ".TR", ".DC", ".HB", ".SW", ".NOISE", ".TF"
+  };
+
+  for (Component *component : sch->a_DocComps) {
+    if (component->isActive && kSimulationBlockModels.contains(component->Model))
+      // Found one block. It's ok
+      return issues;
+  }
+
+  ValidationIssue issue;
+  issue.message = QObject::tr(
+      "The schematic does not contain any active simulation block.");
+  issue.severity = 1; // Critical - nothing to simulate
+  issue.suggestedFix = QObject::tr(
+      "Add a simulation block (e.g. .AC, .SP, .TR, .DC) to the schematic.");
+
+  issues.append(issue);
 
   return issues;
 }

--- a/qucs/schematicvalidator.cpp
+++ b/qucs/schematicvalidator.cpp
@@ -5,6 +5,8 @@
 
 #include "schematicvalidator.h"
 #include "schematic.h"
+#include "node.h"
+#include "wire.h"
 #include "components/component.h"
 #include "components/subcircuit.h"
 

--- a/qucs/schematicvalidator.cpp
+++ b/qucs/schematicvalidator.cpp
@@ -14,6 +14,7 @@ QVector<ValidationIssue> SchematicValidator::validate() const
   issues += checkFrequencySweepType();
   issues += checkMinimumPortsInSPSimulation();
   issues += checkMissingSimulation();
+  issues += checkDanglingWires();
 
   return issues;
 }
@@ -123,5 +124,69 @@ QVector<ValidationIssue> SchematicValidator::checkMissingSimulation() const
 
   issues.append(issue);
 
+  return issues;
+}
+
+QVector<ValidationIssue> SchematicValidator::checkDanglingWires() const
+{
+  QVector<ValidationIssue> issues;
+  // Inspect all wires
+  for (Wire *wire : sch->a_DocWires) {
+    Node *endpoint1 = wire->Port1;
+    Node *endpoint2 = wire->Port2;
+
+    bool endpoint1_isOpen = endpoint1->wires().size() <= 1
+                            && endpoint1->components().empty();
+    bool endpoint2_isOpen = endpoint2->wires().size() <= 1
+                            && endpoint2->components().empty();
+
+    if (endpoint1_isOpen && endpoint2_isOpen) {
+      // Both ends open: the wire is entirely disconnected
+      ValidationIssue issue;
+      issue.message = QObject::tr(
+                           "Wire is not connected to anything at either end (near (%1, %2) and (%3, %4)).")
+                           .arg(endpoint1->cx).arg(endpoint1->cy)
+                           .arg(endpoint2->cx).arg(endpoint2->cy);
+      issue.severity = 3; // Minor, but the user should review it. In many cases this will be something merely aesthetic, but
+      // it may happen that the user forgot to connect something
+      issue.suggestedFix = QObject::tr(
+          "Remove the wire.");
+      issues.append(issue);
+    }
+    else if (endpoint1_isOpen) {
+      // First end open
+      ValidationIssue issue;
+
+      QString message;
+      if (endpoint1->hasLabel()){
+        message = QObject::tr("Wire end at net '%1' is not connected to anything.").arg(endpoint1->Name);
+      } else {
+        message = QObject::tr("Wire has an unconnected end near (%1, %2).").arg(endpoint1->cx).arg(endpoint1->cy);
+      }
+
+      issue.message = message;
+      issue.severity = 3;
+      issue.suggestedFix = QObject::tr(
+          "Terminate the open end or remove the dangling wire.");
+      issues.append(issue);
+    }
+    else if (endpoint2_isOpen) {
+      // Second end open
+      ValidationIssue issue;
+
+      QString message;
+      if (endpoint2->hasLabel()){
+        message = QObject::tr("Wire end at net '%1' is not connected to anything.").arg(endpoint2->Name);
+      } else {
+        message = QObject::tr("Wire has an unconnected end near (%1, %2).").arg(endpoint2->cx).arg(endpoint2->cy);
+      }
+
+      issue.message = message;
+      issue.severity = 3;
+      issue.suggestedFix = QObject::tr(
+          "Terminate the open end or remove the dangling wire.");
+      issues.append(issue);
+    }
+  }
   return issues;
 }

--- a/qucs/schematicvalidator.cpp
+++ b/qucs/schematicvalidator.cpp
@@ -7,18 +7,17 @@
 #include "schematic.h"
 #include "components/component.h"
 
-QVector<ValidationIssue> SchematicValidator::validate(Schematic *sch, const QString &backend) const
+QVector<ValidationIssue> SchematicValidator::validate() const
 {
   QVector<ValidationIssue> issues;
 
-  issues += checkFrequencySweepType(sch, backend);
-  issues += checkMinimumPortsInSPSimulation(sch, backend);
+  issues += checkFrequencySweepType();
+  issues += checkMinimumPortsInSPSimulation();
 
   return issues;
 }
 
-QVector<ValidationIssue> SchematicValidator::checkFrequencySweepType(
-    Schematic *sch, const QString &backend) const
+QVector<ValidationIssue> SchematicValidator::checkFrequencySweepType() const
 {
   QVector<ValidationIssue> issues; // It may be several SP/AC blocks
 
@@ -55,8 +54,7 @@ QVector<ValidationIssue> SchematicValidator::checkFrequencySweepType(
 }
 
 
-QVector<ValidationIssue> SchematicValidator::checkMinimumPortsInSPSimulation(
-    Schematic *sch, const QString &backend) const {
+QVector<ValidationIssue> SchematicValidator::checkMinimumPortsInSPSimulation() const {
   QVector<ValidationIssue> issues;
 
   if (backend.toLower() != "ngspice")

--- a/qucs/schematicvalidator.h
+++ b/qucs/schematicvalidator.h
@@ -6,6 +6,9 @@
 #ifndef SCHEMATICVALIDATOR_H
 #define SCHEMATICVALIDATOR_H
 
+#include "wire.h"
+#include "node.h"
+
 #include <QString>
 #include <QVector>
 
@@ -61,6 +64,11 @@ private:
 
   /// @brief Simulation backends require a simulation block
   QVector<ValidationIssue> checkMissingSimulation() const;
+
+  /// @brief Check if the schematic contain wires with at least one endpoint open
+  /// @details Iterates over every wire in the schematic and inspects both of its endpoints (Port1 and Port2).
+  /// An endpoint is considered "open" when it is not shared with any other wire and no component pin is attached to it.
+  QVector<ValidationIssue> checkDanglingWires() const;
 
   /// @}
 };

--- a/qucs/schematicvalidator.h
+++ b/qucs/schematicvalidator.h
@@ -1,0 +1,49 @@
+/// @file schematicvalidator.h
+/// @brief Schematic validation class (definition)
+/// @author Andrés Martínez Mera
+/// @date July 12, 2026
+
+#ifndef SCHEMATICVALIDATOR_H
+#define SCHEMATICVALIDATOR_H
+
+#include <QString>
+#include <QVector>
+
+class Schematic;
+
+/// @brief A single problem found in a schematic
+/// @param message Human-readable description for the user
+/// @param severity Relevance of the issue
+///        1: Critical - The simulation backend will fail
+///        2: Warning  - Simulation may proceed, but care must be taken.
+///        3: Minor    - Not relevant
+/// @param suggestedFix Message containing with a suggestion about how to solve the problem
+struct ValidationIssue
+{
+  QString message;
+  QString suggestedFix;
+  int severity;
+};
+
+/// @class SchematicValidator
+/// @brief Identify issues in an schematic given a simulation backend.
+/// @details  Validation runs before the simulation is started, so the user
+/// is warned about potential incompatibilities
+class SchematicValidator
+{
+public:
+  /// @brief Run all checks against an schematic given a certain simulation backend,
+  /// e.g. qucsator-RF, ngspice, xyce
+  QVector<ValidationIssue> validate(Schematic *sch, const QString &backend) const;
+
+private:
+
+  /// Checks @{
+
+  /// @brief SP/AC frequency sweep must not be a list if the simulation backend is ngspice or xyce
+  QVector<ValidationIssue> checkFrequencySweepType(Schematic *sch, const QString &backend) const;
+
+  /// @}
+};
+
+#endif // SCHEMATICVALIDATOR_H

--- a/qucs/schematicvalidator.h
+++ b/qucs/schematicvalidator.h
@@ -16,6 +16,7 @@ class Wire;
 class Component;
 
 /// @brief A single problem found in a schematic
+/// @param title Type of issue
 /// @param message Human-readable description for the user
 /// @param severity Relevance of the issue
 ///        1: Critical - The simulation backend will fail
@@ -24,6 +25,7 @@ class Component;
 /// @param suggestedFix Message containing with a suggestion about how to solve the problem
 struct ValidationIssue
 {
+  QString title;
   QString message;
   QString suggestedFix;
   int severity;

--- a/qucs/schematicvalidator.h
+++ b/qucs/schematicvalidator.h
@@ -34,17 +34,30 @@ class SchematicValidator
 public:
   /// @brief Run all checks against an schematic given a certain simulation backend,
   /// e.g. qucsator-RF, ngspice, xyce
-  QVector<ValidationIssue> validate(Schematic *sch, const QString &backend) const;
+  QVector<ValidationIssue> validate() const;
+
+  /// @brief Set simulation backend
+  /// @param SimulationBackend Name of the backend simulator
+  /// @details Used by Qucs-S main app to set the simulation backend for the validation
+  void setSimulationBackend(QString SimulationBackend) {backend = SimulationBackend;}
+
+  /// @brief Set the schematic to validate
+  /// @param Schematic Schematic object
+  /// @details Used by Qucs-S main app to set the schematic under validation
+  void setSchematic(Schematic *Schematic){sch = Schematic;}
 
 private:
+
+  Schematic *sch;
+  QString backend; /// Simulation backend
 
   /// Checks @{
 
   /// @brief SP/AC frequency sweep must not be a list if the simulation backend is ngspice or xyce
-  QVector<ValidationIssue> checkFrequencySweepType(Schematic *sch, const QString &backend) const;
+  QVector<ValidationIssue> checkFrequencySweepType() const;
 
   /// @brief ngspice needs at least two AC power sources in SP simulation
-  QVector<ValidationIssue> checkMinimumPortsInSPSimulation(Schematic *sch, const QString &backend) const;
+  QVector<ValidationIssue> checkMinimumPortsInSPSimulation() const;
 
 
   /// @}

--- a/qucs/schematicvalidator.h
+++ b/qucs/schematicvalidator.h
@@ -59,6 +59,8 @@ private:
   /// @brief ngspice needs at least two AC power sources in SP simulation
   QVector<ValidationIssue> checkMinimumPortsInSPSimulation() const;
 
+  /// @brief Simulation backends require a simulation block
+  QVector<ValidationIssue> checkMissingSimulation() const;
 
   /// @}
 };

--- a/qucs/schematicvalidator.h
+++ b/qucs/schematicvalidator.h
@@ -6,14 +6,14 @@
 #ifndef SCHEMATICVALIDATOR_H
 #define SCHEMATICVALIDATOR_H
 
-#include "wire.h"
-#include "node.h"
-
 #include <QString>
 #include <QVector>
 #include <QSet>
 
 class Schematic;
+class Node;
+class Wire;
+class Component;
 
 /// @brief A single problem found in a schematic
 /// @param message Human-readable description for the user

--- a/qucs/schematicvalidator.h
+++ b/qucs/schematicvalidator.h
@@ -11,6 +11,7 @@
 
 #include <QString>
 #include <QVector>
+#include <QSet>
 
 class Schematic;
 
@@ -53,6 +54,28 @@ private:
 
   Schematic *sch;
   QString backend; /// Simulation backend
+
+
+  /// @brief Runs the full ruleset (simulation-control + structural checks)
+  /// against the top-level schematic. Simulation-control checks are not
+  /// re-run for nested subcircuits
+  /// @see checkStructuralIssues().
+  QVector<ValidationIssue> runAllChecks(QSet<QString> &visitedFiles) const;
+
+  /// @brief Runs only the checks that are meaningful regardless of nesting
+  /// depth (wiring/connectivity), plus recursion into subcircuits.
+  /// @param visitedFiles Shared cache of subcircuit files already processed.
+  QVector<ValidationIssue> checkStructuralIssues(QSet<QString> &visitedFiles) const;
+
+  /// @brief Recursively validates every subcircuit instance in the schematic.
+  /// @details For each unique, not-yet-visited subcircuit file, loads it
+  /// headlessly (mirroring Schematic::throughAllComps: null QucsApp*,
+  /// loadDocument() rather than load(), to avoid GUI side effects) and
+  /// re-runs the full ruleset against it. Resulting issues are prefixed
+  /// with the subcircuit file name so the user knows where the problem is.
+  /// @param visitedFiles Shared cache of subcircuit files already processed.
+  /// @return A list of ValidationIssue entries found inside subcircuits.
+  QVector<ValidationIssue> checkSubcircuits(QSet<QString> &visitedFiles) const;
 
   /// Checks @{
 

--- a/qucs/schematicvalidator.h
+++ b/qucs/schematicvalidator.h
@@ -43,6 +43,10 @@ private:
   /// @brief SP/AC frequency sweep must not be a list if the simulation backend is ngspice or xyce
   QVector<ValidationIssue> checkFrequencySweepType(Schematic *sch, const QString &backend) const;
 
+  /// @brief ngspice needs at least two AC power sources in SP simulation
+  QVector<ValidationIssue> checkMinimumPortsInSPSimulation(Schematic *sch, const QString &backend) const;
+
+
   /// @}
 };
 

--- a/qucs/schematicvalidator.h
+++ b/qucs/schematicvalidator.h
@@ -57,18 +57,36 @@ private:
   /// Checks @{
 
   /// @brief SP/AC frequency sweep must not be a list if the simulation backend is ngspice or xyce
+  /// @return A list of ValidationIssue entries..
   QVector<ValidationIssue> checkFrequencySweepType() const;
 
   /// @brief ngspice needs at least two AC power sources in SP simulation
+  /// @return A list of ValidationIssue entries.
   QVector<ValidationIssue> checkMinimumPortsInSPSimulation() const;
 
   /// @brief Simulation backends require a simulation block
+  /// @return A list of ValidationIssue entries.
   QVector<ValidationIssue> checkMissingSimulation() const;
 
   /// @brief Check if the schematic contain wires with at least one endpoint open
   /// @details Iterates over every wire in the schematic and inspects both of its endpoints (Port1 and Port2).
   /// An endpoint is considered "open" when it is not shared with any other wire and no component pin is attached to it.
+  /// @return A list of ValidationIssue entries, one per unconnected port found.
   QVector<ValidationIssue> checkDanglingWires() const;
+
+  /// @brief Checks whether a net reaches any component other than a given owner.
+  /// @param node  The starting node of the net to traverse. May be null, in which case the function returns false.
+  /// @param owner The component that should be excluded from the search.
+  /// @return true if at least one component other than @a owner is reachable from @a node via wires; false if the net is empty,
+  /// dangling, or only reaches @a owner itself.
+  /// @details Starting from @a node, performs a hops from node to node across every wire segment. At each node visited, all attached components are
+  /// inspected. This is used to detect ports that only appear connected because they touch a single wire, when in fact that wire (or chain of wires) leads
+  /// nowhere
+  bool netReachesOtherComponent(Node *node, Component *owner) const;
+
+  /// @brief Detect subcircuit/component ports that have no wire or net attached
+  /// @return A list of ValidationIssue entries, one per unconnected port found.
+  QVector<ValidationIssue> checkUnconnectedPorts() const;
 
   /// @}
 };

--- a/qucs/settings.cpp
+++ b/qucs/settings.cpp
@@ -84,6 +84,7 @@ void settingsManager::initDefaults()
     m_Defaults["AllowFlexibleWires"] = false;
     m_Defaults["AllowLayingWiresAnew"] = false;
     m_Defaults["EnableSchematicValidation"] = true; // Pre-simulation schematic validation.
+    m_Defaults["ValidateOnSave"] = false;           // Check schematic when saving
 }
 
 void settingsManager::initAliases()

--- a/qucs/settings.cpp
+++ b/qucs/settings.cpp
@@ -83,6 +83,7 @@ void settingsManager::initDefaults()
     m_Defaults["NgspiceCompatMode"] = spicecompat::NgspDefault;
     m_Defaults["AllowFlexibleWires"] = false;
     m_Defaults["AllowLayingWiresAnew"] = false;
+    m_Defaults["EnableSchematicValidation"] = true; // Pre-simulation schematic validation.
 }
 
 void settingsManager::initAliases()


### PR DESCRIPTION
**Motivation**
Sometimes simulations fail because small mistakes that may be hard to read in the simulator error log.
 
This PR introduces a pre-simulation schematic check for common issues. The goal is to catch common configuration issues early, before the simulator crashes.

Features:

- Checks are propagated to the subcircuits.
- It runs only in the single-run simulation mode. It doesn't make sense to run the checks in tuning mode and, it would also be a mess.
- The user can still run the simulation even if the checks found errors.
- Three categories: "Critical" (the simulation can't run, major errors), "Warning" (something is odd, but it may run), "Minor" (dangling wires, etc.)
- This feature can be disabled in the Qucs-S Settings panel.

<img width="565" height="487" alt="image" src="https://github.com/user-attachments/assets/e9b7f73d-1645-4bfc-b8fe-fc8461ef41cf" />


The errors/warnings (if any) are listed in a pop-up window.

<img width="484" height="301" alt="image" src="https://github.com/user-attachments/assets/9ea1fc13-feb8-44bd-bcf7-6e43d4207b3a" />


**Checks**

1. List-based frequency sweep
Validates that the SP/AC frequency sweep is not defined as a list when the simulation backend is ngspice or xyce. 
qucsator supports list-based frequency sweeps, but ngspice and xyce do not. Previously, switching backends from qucsator to ngspice/xyce on a schematic with a list-based sweep would cause the simulation to fail with an unhelpful error.

2. Minimum port count for ngspice SP simulation
ngspice requires at least two ports to run an SP simulation. Added a check to catch schematics with fewer than two ports before simulation is attempted.

3. Missing simulation block
All backends require at least one simulation block to be present. xyce in particular fails silently when none is defined.

4. Propagate checks to subcircuits. This is useful to fix this: https://github.com/ra3xdh/qucs_s/issues/1697

6. Dangling wires and nets connected to nothing
This is marked as minor, as it shouldn't break the simulation

8. Check for unconnected ports


This is the workspace I used for checking this feature
[SchematicValidation_prj.tar.gz](https://github.com/user-attachments/files/30575032/SchematicValidation_prj.tar.gz)


@tskaar I added a test to catch dangling wires and unconnected ports. Please check if this fixes https://github.com/ra3xdh/qucs_s/issues/1697

