### PR TITLE
Fix issue #1703: "Reset to default" feature not working in Qucs-S Settings dialog

### DIFF
--- a/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/dialogs/qucssettingsdialog.cpp
@@ -988,14 +988,45 @@ void QucsSettingsDialog::slotDefaultValues()
 
     undoNumEdit->setText("20");
     editorEdit->setText(QucsSettings.BinDir + "qucs");
-    checkWiring->setChecked(false);
-    allowFlexibleWires->setChecked(_settings::Get().itemDefault<bool>("AllowFlexibleWires"));
-    enableSchematicValidation->setChecked(_settings::Get().itemDefault<bool>("EnableSchematicValidation"));
-    validateOnSave->setChecked(_settings::Get().itemDefault<bool>("ValidateOnSave"));
-    checkLoadFromFutureVersions->setChecked(false);
-    checkAntiAliasing->setChecked(false);
-    checkTextAntiAliasing->setChecked(true);
-    checkFullTraceNames->setChecked(false);
+
+    // Checkboxes
+    // 1) Settings tab
+    // Start wiring when clicking open node
+    checkWiring->setChecked(
+        _settings::Get().itemDefault<bool>("NodeWiring"));
+
+    // Try to load also documents created with newer versions of Qucs
+    checkLoadFromFutureVersions->setChecked(
+        _settings::Get().itemDefault<bool>("LoadFutureVersion"));
+
+    // Show prefixes for trace names on diagrams like "ngspice"
+    checkFullTraceNames->setChecked(
+        _settings::Get().itemDefault<bool>("fullTraceName"));
+
+    // Always use the prefix for dataset, i.e. \"tr1.v(out)\" rather than \"v(out)\"
+    alwaysPrefixDataset->setChecked(
+        _settings::Get().itemDefault<bool>("alwaysPrefixDataset"));  // was missing entirely
+
+    // Allow flexible wires
+    allowFlexibleWires->setChecked(
+        _settings::Get().itemDefault<bool>("AllowFlexibleWires"));
+
+    // Check the schematic for common issues before running the simulation
+    enableSchematicValidation->setChecked(
+        _settings::Get().itemDefault<bool>("EnableSchematicValidation"));
+
+    // Check the schematic for common issues after saving
+    validateOnSave->setChecked(
+        _settings::Get().itemDefault<bool>("ValidateOnSave"));
+
+    // 2) Appearance tab
+    // Use anti-aliasing for graphs for a smoother appearance
+    checkAntiAliasing->setChecked(
+        _settings::Get().itemDefault<bool>("GraphAntiAliasing"));
+
+    // Use anti-aliasing for text for a smoother appearance
+    checkTextAntiAliasing->setChecked(
+        _settings::Get().itemDefault<bool>("TextAntiAliasing"));
 }
 
 // -----------------------------------------------------------

--- a/qucs/settings.cpp
+++ b/qucs/settings.cpp
@@ -77,14 +77,26 @@ void settingsManager::initDefaults()
     m_Defaults["Nprocs"] = 4;
     m_Defaults["SpiceOpusExecutable"] = "spiceopus";
     m_Defaults["SimParameters"] = "";
-    m_Defaults["GraphAntiAliasing"] = false;
-    m_Defaults["TextAntiAliasing"] = false;
-    m_Defaults["fullTraceName"] = false;
-    m_Defaults["NgspiceCompatMode"] = spicecompat::NgspDefault;
-    m_Defaults["AllowFlexibleWires"] = false;
+
+    // Qucs-S Settings Dialog - Checkboxes
+    // 1) Settings tab
+    m_Defaults["NodeWiring"] = false;                // Start wiring when clicking open node
+    m_Defaults["LoadFutureVersion"] = false;         // Try to load also documents created with newer versions of Qucs
+    m_Defaults["fullTraceName"] = false;             // Show prefixes for trace names on diagrams like "ngspice"
+    m_Defaults["alwaysPrefixDataset"] = false;       // Always use the prefix for dataset, i.e. \"tr1.v(out)\" rather than \"v(out)\"
+    m_Defaults["AllowFlexibleWires"] = false;        // Allow flexible wires
+    m_Defaults["EnableSchematicValidation"] = false; // Check the schematic for common issues before running the simulation
+    m_Defaults["ValidateOnSave"] = false;            // Check the schematic for common issues after saving
+
+    // 2) Appearance tab
+    m_Defaults["GraphAntiAliasing"] = false;        // Use anti-aliasing for graphs for a smoother appearance
+    m_Defaults["TextAntiAliasing"] = true;          // Use anti-aliasing for text for a smoother appearance
+
+    // Not used - Keeping for now
     m_Defaults["AllowLayingWiresAnew"] = false;
-    m_Defaults["EnableSchematicValidation"] = false; // Pre-simulation schematic validation.
-    m_Defaults["ValidateOnSave"] = false;            // Check schematic when saving
+
+    // Simulation settings dialog
+    m_Defaults["NgspiceCompatMode"] = spicecompat::NgspDefault;
 }
 
 void settingsManager::initAliases()

--- a/qucs/settings.h
+++ b/qucs/settings.h
@@ -22,7 +22,7 @@ public:
   template<class T>
   T itemDefault(const QString& key)
   {
-    return value(key).value<T>();
+    return m_Defaults[key].value<T>();
   }
 
   /** \brief Store a setting.


### PR DESCRIPTION
This PR fixes issue #1703

1) It was found that the settingsManager::itemDefault [1] did not retrieve the default value, but the current value. This prevented some settings from being reset to their default value.

2) It was also found that the reset action for some settings was hardcoded, whereas others actually looked at its value in the m_Default map. The lines were also rearranged to match the same order in which the settings are presented in the dialog. The tooltips of the checkboxes were copied as comments in QucsSettingsDialog::slotDefaultValues() and settingsManager::initDefaults() for convenience. This helps to see the correspondance between values.

[1] https://github.com/ra3xdh/qucs_s/blob/current/qucs/settings.h#L23