### PR TITLE
Fix CI for Windows builds: Pin NO_OLDNAMES to fix MinGW header macro collision

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -423,7 +423,8 @@ jobs:
         cmake.exe -B build/ -G 'Ninja' \
                   -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
                   -DCMAKE_INSTALL_PREFIX=build/qucs-suite  \
-                  -DCI_VERSION="${{env.VERSION}}"
+                  -DCI_VERSION="${{env.VERSION}}" \
+                  -DCMAKE_CXX_FLAGS="-DNO_OLDNAMES"
         cmake.exe --build build/ --parallel --config ${{env.BUILD_TYPE}}
 
     - name: Make install


### PR DESCRIPTION
It seems that MSYS2's mingw changed something about the legacy macros. This broke the build when packaging qucsator_rf.

Define NO_OLDNAMES for the MinGW build to suppress these legacy POSIX macros.

Old break log:

 [248/1132] Building CXX object qucsator_rf/src/CMakeFiles/libqucsator.dir/spsolver.cpp.obj
FAILED: [code=1] qucsator_rf/src/CMakeFiles/libqucsator.dir/spsolver.cpp.obj D:\a\_temp\msys64\ucrt64\bin\c++.exe -DDEBUG -DHAVE_CONFIG_H -DQT_NO_DEBUG_OUTPUT -ID:/a/qucs_s/qucs_s/qucsator_rf/src/math -ID:/a/qucs_s/qucs_s/qucsator_rf/src -ID:/a/qucs_s/qucs_s/qucsator_rf/src/components -ID:/a/qucs_s/qucs_s/qucsator_rf/src/interface -ID:/a/qucs_s/qucs_s/build/qucsator_rf -ID:/a/qucs_s/qucs_s/build/qucsator_rf/src -ID:/a/qucs_s/qucs_s/build/qucsator_rf/src/components -O3 -DNDEBUG -std=gnu++11 -w -MD -MT qucsator_rf/src/CMakeFiles/libqucsator.dir/spsolver.cpp.obj -MF qucsator_rf\src\CMakeFiles\libqucsator.dir\spsolver.cpp.obj.d -o qucsator_rf/src/CMakeFiles/libqucsator.dir/spsolver.cpp.obj -c D:/a/qucs_s/qucs_s/qucsator_rf/src/spsolver.cpp D:/a/qucs_s/qucs_s/qucsator_rf/src/spsolver.cpp: In member function 'void qucs::spsolver::insertOpen(qucs::node*)': D:/a/qucs_s/qucs_s/qucsator_rf/src/spsolver.cpp:773:28: error: expected type-specifier before 'open'
  773 |     circuit * result = new open ();
      |                            ^~~~
