### PR TITLE
Graph white background

### DIFF
--- a/qucs/diagrams/diagram.cpp
+++ b/qucs/diagrams/diagram.cpp
@@ -115,13 +115,17 @@ void Diagram::paintDiagram(QPainter *painter) {
     painter->translate(cx, cy);
 
     if (whiteBackground) {
+      int bx1, by1, bx2, by2;
+      Bounding(bx1, by1, bx2, by2);
+
+      QRectF bgRect(bx1 - cx,
+                    by1 - cy - DIAGRAM_MARGIN_TOP,
+                    (bx2 - bx1) + DIAGRAM_MARGIN_RIGHT,
+                    (by2 - by1) + DIAGRAM_MARGIN_TOP);
+
       painter->save();
       painter->setPen(Qt::NoPen);
       painter->setBrush(Qt::white);
-      QRectF bgRect(-Bounding_x1,
-                    -y2 - Bounding_y2,
-                    x2 + Bounding_x1 + Bounding_x2,
-                    y2 + Bounding_y2 - Bounding_y1);
       painter->drawRect(bgRect);
       painter->restore();
     }
@@ -2020,21 +2024,23 @@ QRect Diagram::boundingRect() const noexcept
 }
 
 QImage Diagram::toImage() const {
+  // Bonding returns the diagram full coordinates, including the margin
+  // for the axis ticks
   int bx1, by1, bx2, by2;
   const_cast<Diagram*>(this)->Bounding(bx1, by1, bx2, by2);
 
-  const int marginTop   = 15;
-  const int marginRight = 15;
-
-  QImage img(bx2 - bx1 + marginRight, by2 - by1 + marginTop,
+  // Size of the diagram + some room margin (static value)
+  QImage img(bx2 - bx1 + DIAGRAM_MARGIN_RIGHT,
+             by2 - by1 + DIAGRAM_MARGIN_TOP,
              QImage::Format_ARGB32);
   img.fill(Qt::white);
 
+  // Temporarily disable selection during render
   bool wasSelected = isSelected;
   const_cast<Diagram*>(this)->isSelected = false;
 
   QPainter painter(&img);
-  painter.translate(-bx1, -by1 + marginTop);
+  painter.translate(-bx1, -by1 + DIAGRAM_MARGIN_TOP);
   const_cast<Diagram*>(this)->paint(&painter);
 
   const_cast<Diagram*>(this)->isSelected = wasSelected;

--- a/qucs/diagrams/diagram.cpp
+++ b/qucs/diagrams/diagram.cpp
@@ -2019,7 +2019,25 @@ QRect Diagram::boundingRect() const noexcept
     return QRect{QPoint{x1_, y1_}, QPoint{x2_, y2_}}.normalized();
 }
 
-//void Diagram::SetLimitsBySelectionRect(QRectF) {}
+QImage Diagram::toImage() const {
+  int bx1, by1, bx2, by2;
+  const_cast<Diagram*>(this)->Bounding(bx1, by1, bx2, by2);
 
+  const int marginTop   = 15;
+  const int marginRight = 15;
 
-// vim:ts=8:sw=2:noet
+  QImage img(bx2 - bx1 + marginRight, by2 - by1 + marginTop,
+             QImage::Format_ARGB32);
+  img.fill(Qt::white);
+
+  bool wasSelected = isSelected;
+  const_cast<Diagram*>(this)->isSelected = false;
+
+  QPainter painter(&img);
+  painter.translate(-bx1, -by1 + marginTop);
+  const_cast<Diagram*>(this)->paint(&painter);
+
+  const_cast<Diagram*>(this)->isSelected = wasSelected;
+
+  return img;
+}

--- a/qucs/diagrams/diagram.cpp
+++ b/qucs/diagrams/diagram.cpp
@@ -91,6 +91,7 @@ Diagram::Diagram(int _cx, int _cy) {
     Type = isDiagram;
     isSelected = false;
     GridPen = QPen(Qt::lightGray, 0);
+    whiteBackground = false; // Transparent background
 }
 
 Diagram::~Diagram() {
@@ -112,6 +113,19 @@ void Diagram::paintDiagram(QPainter *painter) {
     painter->save();
 
     painter->translate(cx, cy);
+
+    if (whiteBackground) {
+      painter->save();
+      painter->setPen(Qt::NoPen);
+      painter->setBrush(Qt::white);
+      QRectF bgRect(-Bounding_x1,
+                    -y2 - Bounding_y2,
+                    x2 + Bounding_x1 + Bounding_x2,
+                    y2 + Bounding_y2 - Bounding_y1);
+      painter->drawRect(bgRect);
+      painter->restore();
+    }
+
     painter->save();
 
     for (qucs::Line* line : std::as_const(Lines)) {
@@ -1232,6 +1246,7 @@ QString Diagram::save() {
     char c = '0';
     if (xAxis.GridOn) c |= 1;
     if (hideLines) c |= 2;
+    if (whiteBackground) c |= 4;
     s += c;
     s += " " + GridPen.color().name() + " " + QString::number(GridPen.style());
 
@@ -1303,10 +1318,11 @@ bool Diagram::load(const QString &Line, QTextStream *stream) {
     if (!ok) return false;
 
     char c;
-    n = s.section(' ', 5, 5);    // GridOn
+    n = s.section(' ', 5, 5);    // GridOn / hideLines / whiteBackground
     c = n.at(0).toLatin1() - '0';
     xAxis.GridOn = yAxis.GridOn = (c & 1) != 0;
     hideLines = (c & 2) != 0;
+    whiteBackground = (c & 4) != 0;
 
     n = s.section(' ', 6, 6);    // color for GridPen
     QColor co = misc::ColorFromString(n);

--- a/qucs/diagrams/diagram.h
+++ b/qucs/diagrams/diagram.h
@@ -185,6 +185,9 @@ protected:
 
 private:
   int Bounding_x1, Bounding_x2, Bounding_y1, Bounding_y2;
+
+  static const int DIAGRAM_MARGIN_TOP   = 15;
+  static const int DIAGRAM_MARGIN_RIGHT = 15;
 };
 
 #endif

--- a/qucs/diagrams/diagram.h
+++ b/qucs/diagrams/diagram.h
@@ -144,6 +144,7 @@ public:
 
   QString Name; // identity of diagram type (e.g. Polar), used for saving etc.
   QPen    GridPen;
+  bool whiteBackground; // True: White background. False: Transparent background
 
   QList<Graph *>  Graphs;
   QList<qucs::Arc *>    Arcs;

--- a/qucs/diagrams/diagram.h
+++ b/qucs/diagrams/diagram.h
@@ -138,6 +138,10 @@ public:
   bool sameDependencies(Graph const*, Graph const*) const;
   int  checkColumnWidth(const QString&, const QFontMetrics&, int, int, int);
 
+  /// @brief Convert a diagram to image
+  /// @return QImage object
+  QImage toImage() const;
+
   virtual bool insideDiagram(float, float) const;
   bool insideDiagramP(Graph::iterator const& ) const;
   Marker* setMarker(int x, int y);

--- a/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/diagrams/diagramdialog.cpp
@@ -517,6 +517,12 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
       NotationBox = 0;
     }
 
+    // Enable white background
+    WhiteBackground = new QCheckBox(tr("white background"), Tab2);
+    gp->addWidget(WhiteBackground, Row, 0);
+    Row++;
+    WhiteBackground->setChecked(Diag->whiteBackground);
+
     NotationLabel = new QLabel(tr("Number notation: "), Tab2);
     gp->addWidget(NotationLabel, Row, 0);
     NotationBox = new QComboBox(Tab2);
@@ -1523,6 +1529,12 @@ void DiagramDialog::slotApply() {
         Diag->yAxis.GridOn = GridOn->isChecked();
         changed = true;
       }
+    if (WhiteBackground) {
+      if (Diag->whiteBackground != WhiteBackground->isChecked()) {
+        Diag->whiteBackground = WhiteBackground->isChecked();
+        changed = true;
+      }
+    }
     if (GridColorButt)
       if (Diag->GridPen.color() !=
           misc::getWidgetBackgroundColor(GridColorButt)) {

--- a/qucs/diagrams/diagramdialog.h
+++ b/qucs/diagrams/diagramdialog.h
@@ -165,6 +165,7 @@ private:
   QSpinBox    *thicknessSpin, *precisionSpin;
   QCheckBox   *GridOn, *GridLogX, *GridLogY, *GridLogZ;
   QCheckBox   *manualX, *manualY, *manualZ, *hideInvisible;
+  QCheckBox   *WhiteBackground;
   QLineEdit   *startX, *stepX, *stopX;
   QLineEdit   *startY, *stepY, *stopY;
   QLineEdit   *startZ, *stepZ, *stopZ;

--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -739,6 +739,12 @@ void MouseActions::rightPressMenu(Schematic *Doc, QMouseEvent *Event, float fX, 
                                  QucsMain,
                                  SLOT(slotSaveDiagramToGraphicsFile()));
                 ComponentMenu->addAction(actExport);
+
+                QAction *actCopyImage = new QAction(QObject::tr("Copy as Image"), QucsMain);
+                QObject::connect(actCopyImage, &QAction::triggered, [diagram]() {
+                  QApplication::clipboard()->setImage(diagram->toImage());
+                });
+                ComponentMenu->addAction(actCopyImage);
             }
         }
         break;


### PR DESCRIPTION
**Motivation**
Sometimes it looks better to have a white solid background in the diagrams.

**Changes**
1) An optional setting is added to the Diagram class to set the background color of the diagram to white. It was file persistance.

2) Once there, it was added an option in the context menu to copy the diagram as a png image into the system clipboard. This is useful to copy the graphs to another document without the need of taking an screenshot.
<img width="1137" height="845" alt="image" src="https://github.com/user-attachments/assets/ecc60e55-c55f-44a8-a0a0-5ebb6ca97ba2" />

A checkbox is added to the diagram properties. The white background is disabled by default.
<img width="825" height="712" alt="image" src="https://github.com/user-attachments/assets/290cece5-a24d-4928-bad2-9f082819bdac" />

Here's the schematic I've used for testing this feature
[test_whiteBG.sch.tar.gz](https://github.com/user-attachments/files/31102948/test_whiteBG.sch.tar.gz)
