### PR TITLE
schematicValidation: reduce on-save checks to structural validation only

### DIFF
--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -3807,6 +3807,11 @@ bool QucsApp::runSchematicChecks(QWidget *w, bool isPreSimulation)
     return false;
   }
 
+  if (sch->getSymbolMode()) {
+    // There is no symbol checks; skip
+    return false;
+  }
+
   // Get the backend simulator
   QString backend = simulatorsCombobox->currentText().toLower();
 

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -3826,7 +3826,14 @@ bool QucsApp::runSchematicChecks(QWidget *w, bool isPreSimulation)
 
   a_validator.setSimulationBackend(backend);
   a_validator.setSchematic(sch);
-  QVector<ValidationIssue> issues = a_validator.validate();
+  QVector<ValidationIssue> issues;
+  if (isPreSimulation) {
+    // run every check
+    issues = a_validator.validate();
+  } else {
+    // run schematic checks only
+    issues = a_validator.saveValidate();
+  }
   if (issues.isEmpty())
     return false;
 

--- a/qucs/schematicvalidator.cpp
+++ b/qucs/schematicvalidator.cpp
@@ -15,6 +15,16 @@ QVector<ValidationIssue> SchematicValidator::validate() const {
   return runAllChecks(visitedFiles);
 }
 
+QVector<ValidationIssue> SchematicValidator::saveValidate() const {
+  QSet<QString> visitedFiles;
+  QVector<ValidationIssue> issues;
+
+  // Structural checks: run at top-level and recursively inside every subcircuit.
+  issues += checkStructuralIssues(visitedFiles);
+
+  return issues;
+}
+
 
 QVector<ValidationIssue> SchematicValidator::runAllChecks(QSet<QString> &visitedFiles) const {
   QVector<ValidationIssue> issues;

--- a/qucs/schematicvalidator.h
+++ b/qucs/schematicvalidator.h
@@ -42,6 +42,9 @@ public:
   /// e.g. qucsator-RF, ngspice, xyce
   QVector<ValidationIssue> validate() const;
 
+  /// @brief Validate schematic structure on save, excluding simulation checks.
+  QVector<ValidationIssue> saveValidate() const;
+
   /// @brief Set simulation backend
   /// @param SimulationBackend Name of the backend simulator
   /// @details Used by Qucs-S main app to set the simulation backend for the validation


### PR DESCRIPTION
## What

This removes checks for when saving symbols (currently there are no explicit symbol checks anyways).

Additionally, on-save validation now runs only structural checks, skipping simulation-specific checks. 
Pre-simulation validation continues to run all checks as before.

## Why

The amount of "nagging" got distracting when modifying symbols, but also when modifying subcircuits (circuits that are not to be simulated standalone), where the "no simulation blocks found" error would pop-up every time one saved.

## Notes

Ideally, the simulation block check should be skipped on subcircuits, however I don't think there is an easy qualifier (at this moment anyway) to see the difference between a subcircuit block and a general schematic that is missing a simulation block

A couple of qualifiers I was considering was:

1. If there is no sources in the schematic, assume it's a subcircuit
2. If there are ports (Pins) in the schematics, assume it's a subcircuit

However, both of these have edge-cases, which then would end up being a false-negative trigger for schematic validation... So I thought just reducing the scope of `ValidationOnSave` was the safest in-between solution here.

CC: @andresmmera, since you are the implementer of the SchematicValidator, do you mind taking a look (especially on 5ea551591772f4bb901d9f458ea5bf422b5caf03)?

Thanks!