### PR TITLE
Fix cancellation of keyboard moves

### DIFF
--- a/qucs/mouseactions.cpp
+++ b/qucs/mouseactions.cpp
@@ -1493,6 +1493,7 @@ void MouseActions::MReleaseMoving(Schematic *Doc, QMouseEvent* event)
     if ( Doc->healAfterMousyMutation() || MAx3 != 0 || MAy3 != 0 ) {
         Doc->setChanged(true, true);
     }
+    Doc->endCancellableMove();
 
     Doc->viewport()->update();
     Doc->releaseKeyboard(); // allow keyboard inputs again
@@ -1533,6 +1534,7 @@ void MouseActions::MReleaseMoveFree(Schematic *Doc, QMouseEvent *Event)
     if (Doc->healAfterMousyMutation() || MAx3 != 0 || MAy3 != 0) {
         Doc->setChanged(true, true);
     }
+    Doc->endCancellableMove();
     Doc->viewport()->update();
 
     // Reset everything and go back to select mode

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -238,6 +238,21 @@ void QucsApp::slotEditDelete(bool on) {
 }
 
 // ------------------------------------------------------------------------
+// Resolves a pending cancellable keyboard move on Doc - restores the
+// pre-move snapshot and clears MouseActions' transient pointers - if one is
+// genuinely still active. No-op otherwise.
+static void resolvePendingKeyboardMove(Schematic* Doc, MouseActions* view) {
+  if (!Doc || !Doc->cancellableMovePending()) {
+    return;
+  }
+  view->focusElement = nullptr;
+  view->movingElements.clear();
+  view->movingState = MovingState{};
+  Doc->cancelCancellableMove();
+  Doc->viewport()->update();
+}
+
+// ------------------------------------------------------------------------
 // Is called if "Strech (move w/wiring)"-Button is pressed.
 void QucsApp::slotEditStretch(bool on) {
   Schematic *Doc = dynamic_cast<Schematic *>(DocumentTab->currentWidget());
@@ -251,8 +266,16 @@ void QucsApp::slotEditStretch(bool on) {
     return;
   }
 
+  if (!on) {
+    resolvePendingKeyboardMove(Doc, view);
+  }
+
   performToggleAction(on, editStretch, nullptr, &MouseActions::MMoveMoving,
                       nullptr);
+
+  if (on) {
+    Doc->beginCancellableMove();
+  }
 }
 
 // ------------------------------------------------------------------------
@@ -269,7 +292,15 @@ void QucsApp::slotEditMove(bool on) {
     return;
   }
 
+  if (!on) {
+    resolvePendingKeyboardMove(Doc, view);
+  }
+
   performToggleAction(on, editMove, nullptr, &MouseActions::MMoveFree, nullptr);
+
+  if (on) {
+    Doc->beginCancellableMove();
+  }
 }
 
 // -----------------------------------------------------------------------
@@ -353,6 +384,11 @@ void QucsApp::slotZoomIn(bool on) {
 }
 
 void QucsApp::slotEscape() {
+  if (activeAction == editStretch || activeAction == editMove) {
+    auto* Doc = dynamic_cast<Schematic*>(DocumentTab->currentWidget());
+    resolvePendingKeyboardMove(Doc, view);
+  }
+
   select->setChecked(true);
   slotSearchClear();
 }

--- a/qucs/schematic.cpp
+++ b/qucs/schematic.cpp
@@ -1791,6 +1791,38 @@ bool Schematic::redo()
 }
 
 // ---------------------------------------------------
+// Captures the current document state so a keyboard move can be cancelled
+// later. Overwrites any previous (by now inactive) snapshot.
+void Schematic::beginCancellableMove() {
+  a_moveSnapshotSymbolMode = a_symbolMode;
+  a_moveSnapshotIdx        = a_symbolMode ? a_undoSymbolIdx : a_undoActionIdx;
+  a_moveSnapshot =
+      a_symbolMode ? createSymbolUndoString('*') : createUndoString('*');
+}
+
+// ---------------------------------------------------
+// Tells whether a_moveSnapshot still belongs to a keyboard move that is
+// genuinely still in progress, i.e. no undo entry has been committed since
+// beginCancellableMove() was called.
+bool Schematic::cancellableMovePending() const {
+  if (!a_moveSnapshot.has_value()) {
+    return false;
+  }
+  if (a_symbolMode != a_moveSnapshotSymbolMode) {
+    return false;
+  }
+  int currentIdx = a_symbolMode ? a_undoSymbolIdx : a_undoActionIdx;
+  return currentIdx == a_moveSnapshotIdx;
+}
+
+// ---------------------------------------------------
+// Discards the pending move snapshot without touching the schematic or the
+// undo stack. Called once a keyboard move has been committed normally.
+void Schematic::endCancellableMove() {
+  a_moveSnapshot.reset();
+}
+
+// ---------------------------------------------------
 void Schematic::switchPaintMode()
 {
     a_symbolMode = !a_symbolMode; // change mode

--- a/qucs/schematic.h
+++ b/qucs/schematic.h
@@ -34,6 +34,7 @@
 #include "qt3_compat/q3scrollview.h"
 #include <QVector>
 #include <QStringList>
+#include <optional>
 
 class QTextStream;
 class QTextEdit;
@@ -228,6 +229,13 @@ public:
   bool    undo();
   bool    redo();
 
+  // Transient snapshot for cancelling an in-progress keyboard move (M /
+  // Shift+M). Kept outside the normal undo history; see schematic_file.cpp.
+  void beginCancellableMove();
+  bool cancellableMovePending() const;
+  void cancelCancellableMove();
+  void endCancellableMove();
+
   void scrollUp(int);
   void scrollDown(int);
   void scrollLeft(int);
@@ -321,6 +329,12 @@ private:
   QVector<QString *> a_undoAction;
   int a_undoSymbolIdx;
   QVector<QString *> a_undoSymbol;    // undo stack for circuit symbol
+
+  // a_undoActionIdx/a_undoSymbolIdx and a_symbolMode when a_moveSnapshot was
+  // taken, so cancellableMovePending() can detect an intervening commit.
+  std::optional<QString> a_moveSnapshot;
+  int a_moveSnapshotIdx         = 0;
+  bool a_moveSnapshotSymbolMode = false;
 
   bool isImageFilePath(const QString& path); // Detect if a file is an image
 

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -1718,8 +1718,8 @@ bool Schematic::elementsOnGrid(Selection selection, bool doHeal)
 
     if (doHeal) {
         heal(&noninteractiveMutationParams);
+        setChanged(true, true);
     }
-    setChanged(true, true);
     return true;
 }
 
@@ -1789,15 +1789,17 @@ bool Schematic::rotateElements(Selection selection, bool doHeal)
 
     if (a_symbolMode || a_isSymbolOnly) {
         internal::symbolElementsOnGrid(this, selection.paintings);
-        setChanged(true, true);
+        if (doHeal) {
+            setChanged(true, true);
+        }
     } else {
-        // elementsOnGrid heals and adds undo-entry by its own
-        // if it changes something
+        // elementsOnGrid() heals and commits via setChanged() itself,
+        // but only when doHeal is true and it actually changed something.
         if (!elementsOnGrid(selection, doHeal)) {
             if (doHeal) {
                 heal(&noninteractiveMutationParams);
+                setChanged(true, true);
             }
-            setChanged(true, true);
         }
     }
 
@@ -1842,15 +1844,17 @@ bool Schematic::mirrorXComponents(Selection selection, bool doHeal)
 
     if (a_symbolMode || a_isSymbolOnly) {
         internal::symbolElementsOnGrid(this, selection.paintings);
-        setChanged(true, true);
+        if (doHeal) {
+            setChanged(true, true);
+        }
     } else {
-        // elementsOnGrid heals and adds undo-entry by its own
-        // if it changes something
+        // elementsOnGrid() heals and commits via setChanged() itself,
+        // but only when doHeal is true and it actually changed something.
         if (!elementsOnGrid(selection, doHeal)) {
             if (doHeal) {
                 heal(&noninteractiveMutationParams);
+                setChanged(true, true);
             }
-            setChanged(true, true);
         }
     }
 
@@ -1894,15 +1898,17 @@ bool Schematic::mirrorYComponents(Selection selection, bool doHeal)
 
     if (a_symbolMode || a_isSymbolOnly) {
         internal::symbolElementsOnGrid(this, selection.paintings);
-        setChanged(true, true);
+        if (doHeal) {
+            setChanged(true, true);
+        }
     } else {
-        // elementsOnGrid heals and adds undo-entry by its own
-        // if it changes something
+        // elementsOnGrid() heals and commits via setChanged() itself,
+        // but only when doHeal is true and it actually changed something.
         if (!elementsOnGrid(selection, doHeal)) {
             if (doHeal) {
                 heal(&noninteractiveMutationParams);
+                setChanged(true, true);
             }
-            setChanged(true, true);
         }
     }
 

--- a/qucs/schematic_file.cpp
+++ b/qucs/schematic_file.cpp
@@ -1371,6 +1371,24 @@ bool Schematic::rebuildSymbol(QString *s)
   return true;
 }
 
+// -------------------------------------------------------------
+// Restores the schematic from the pending cancellable-move snapshot and
+// discards it. Does nothing if no keyboard move is genuinely still pending
+// (see cancellableMovePending()).
+void Schematic::cancelCancellableMove() {
+  if (!cancellableMovePending()) {
+    return;
+  }
+
+  if (a_symbolMode) {
+    rebuildSymbol(&*a_moveSnapshot);
+  } else {
+    rebuild(&*a_moveSnapshot);
+    reloadGraphs(); // load recent simulation data
+  }
+
+  a_moveSnapshot.reset();
+}
 
 // ***************************************************************
 // *****                                                     *****


### PR DESCRIPTION
Fixes #1525.

When cancelling a keyboard move with Esc or by pressing the same move
shortcut again, restore the schematic to its state before the move started.

The transient move snapshot is kept outside the normal undo history and is
discarded when the move is completed normally.

Also avoid creating intermediate undo entries when rotating or mirroring
elements during an in-progress keyboard move.

Validated with:
- M -> move -> Esc
- M -> move -> M
- Shift+M -> move -> Esc
- Shift+M -> move -> Shift+M
- rotate/mirror during Shift+M followed by cancel
- successful moves followed by a single undo
- paste with rotate followed by a single undo
- connected and multiple selected components
- GeometryTest